### PR TITLE
Created new json and pickled configuration output

### DIFF
--- a/lib/cut_definition.py
+++ b/lib/cut_definition.py
@@ -24,13 +24,16 @@ class Cut:
     def __str__(self):
         return f"Cut: {self.name}, f:{self.function.__name__}"
 
-    def serialize(self):
-        return {
+    def serialize(self, src_code=False):
+        out = {
             "name" : self.name,
             "params": self.params,
             "function": {
                 "name": self.function.__name__,
                 "module": self.function.__module__,
-                "src_file": inspect.getsourcefile(self.function)
+                "src_file": inspect.getsourcefile(self.function),
             }
         }
+        if src_code:
+            out["function"]["src_code"] = inspect.getsource(self.function)
+        return out

--- a/lib/cut_definition.py
+++ b/lib/cut_definition.py
@@ -22,3 +22,10 @@ class Cut:
 
     def __str__(self):
         return f"Cut: {self.name}, f:{self.function.__name__}"
+
+    def serialize(self):
+        return {
+            "name" : self.name,
+            "params": self.params,
+            "function": repr(self.function)
+        }

--- a/lib/cut_definition.py
+++ b/lib/cut_definition.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from collections.abc import Callable
 import awkward as ak
 import json
+import inspect
 
 @dataclass
 class Cut:
@@ -27,5 +28,9 @@ class Cut:
         return {
             "name" : self.name,
             "params": self.params,
-            "function": repr(self.function)
+            "function": {
+                "name": self.function.__name__,
+                "module": self.function.__module__,
+                "src_file": inspect.getsourcefile(self.function)
+            }
         }

--- a/lib/cut_functions.py
+++ b/lib/cut_functions.py
@@ -13,9 +13,20 @@ def dilepton(events, params, year, sample):
     #SFOS = SF & OS
     not_SF = ( (events.nmuon == 1) & (events.nelectron == 1) )
 
-    mask = ( (events.nlep == 2) & (ak.firsts(events.LeptonGood.pt) > params["pt_leading_lepton"]) & OS &
-             (events.njet >= params["njet"]) & (events.nbjet >= params["nbjet"]) & (MET.pt > params["met"]) &
-             (events.ll.mass > params["mll"]) & ( ( SF & ( (events.ll.mass < params["mll_SFOS"]["low"]) | (events.ll.mass > params["mll_SFOS"]["high"]) ) ) | not_SF) )
+    mask = ( (events.nlep == 2) &
+             (ak.firsts(events.LeptonGood.pt) > params["pt_leading_lepton"]) &
+             (events.njet >= params["njet"]) &
+             (events.nbjet >= params["nbjet"]) &
+             (MET.pt > params["met"]) &
+             OS & # Opposite sign 
+             (events.ll.mass > params["mll"]) &
+             # If same-flavour we exclude a mll mass interval 
+             ( ( SF & ( (events.ll.mass < params["mll_SFOS"]["low"]) | (events.ll.mass > params["mll_SFOS"]["high"]) ) )
+               | not_SF) )
 
     # Pad None values with False
     return ak.where(ak.is_none(mask), ~ak.is_none(mask), mask)
+
+
+def count_objects(events,params,year,sample):
+    mask = ak.count(events[params["object"]], axis=1) > params

--- a/parameters/cuts/baseline_cuts.py
+++ b/parameters/cuts/baseline_cuts.py
@@ -26,5 +26,3 @@ dilepton_presel = Cut(
 	},
     function = cuts_f.dilepton
  )
-
-

--- a/runner.py
+++ b/runner.py
@@ -17,10 +17,13 @@ from utils.Configurator import Configurator
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run analysis on baconbits files using processor coffea files')
     # Inputs
-    parser.add_argument('--cfg', default=os.getcwd() + "/config/test.py", help='Config file with parameters specific to the current run', required=True)
+    parser.add_argument('--cfg', default=os.getcwd() + "/config/test.py", required=True, type=str,
+                        help='Config file with parameters specific to the current run')
+    parser.add_argument("-o", "--output-dir", required=False, type=str,
+                        help="Overwrite the output folder in the configuration")
 
     args = parser.parse_args()
-    config = Configurator(args.cfg)
+    config = Configurator(args.cfg, overwrite_output_dir=args.output_dir)
 
     if config.run_options['executor'] not in ['futures', 'iterative']:
         # dask/parsl needs to export x509 to read over xrootd
@@ -190,7 +193,9 @@ if __name__ == '__main__':
                                         },
                                         chunksize=config.run_options['chunk'], maxchunks=config.run_options['max']
                             )
-
+    else:
+        print(f"Executor {config.run_options['executor']} not defined!")
+        exit(1)
     save(output, config.outfile)
     print(output)
     print(f"Saving output to {config.outfile}")

--- a/runner.py
+++ b/runner.py
@@ -3,7 +3,7 @@ import sys
 import json
 import argparse
 import time
-
+import pickle
 import numpy as np
 
 import uproot
@@ -23,7 +23,13 @@ if __name__ == '__main__':
                         help="Overwrite the output folder in the configuration")
 
     args = parser.parse_args()
-    config = Configurator(args.cfg, overwrite_output_dir=args.output_dir)
+
+    if args.cfg[:-3] == ".py":
+        config = Configurator(args.cfg, overwrite_output_dir=args.output_dir)
+    elif args.cfg[:-4] == ".pkl":
+        config = pickle.load(open(args.cfg,"rb"))
+    else:
+        raise NotImplemented("Please provide a .py/.pkl configuration file")
 
     if config.run_options['executor'] not in ['futures', 'iterative']:
         # dask/parsl needs to export x509 to read over xrootd

--- a/utils/Configurator.py
+++ b/utils/Configurator.py
@@ -34,9 +34,15 @@ class Configurator():
         # Load histogram settings
         self.load_histogram_settings()
 
-        # Load cuts and categories
-        self.categories = {}
+        ## Load cuts and categories
+        # Cuts: set of Cut objects
+        # Categories: dict with a set of Cut names for each category
         self.cuts = []
+        self.categories = {}
+        # Saving also a dict of Cut objects to map their names
+        self.cuts_dict = {}
+        ## Call the function which transforms the dictionary in the cfg
+        # in the objects needed in the processors
         self.load_cuts_and_categories()
 
         # Load workflow
@@ -88,10 +94,13 @@ class Configurator():
             exit(1)
 
     def load_cuts_and_categories(self):
+        for presel in self.cfg["preselections"]:
+            self.cuts_dict[presel.name] = presel
         for cat, cuts in self.cfg["categories"].items():
             self.categories[cat] = []                
             for cut in cuts:
                 self.cuts.append(cut)
+                self.cuts_dict[cut.name] = cut
                 self.categories[cat].append(cut.name)
 
         # Unique set of cuts


### PR DESCRIPTION
The configuration is dumped in the output folder in two formats. 

- json: Only the cut function name and parameters are retained, not the full object. 
- pickle: the full Configurator object is dumped and it may be directly used to run again. 

Now the outputdir can be overwritten by the runner.py options.