### PR TITLE
Electron id and reco SF

### DIFF
--- a/lib/scale_factors.py
+++ b/lib/scale_factors.py
@@ -1,0 +1,68 @@
+import awkward as ak
+
+import correctionlib
+
+from parameters.lepton_scale_factors import electronSF, electronJSONfiles
+
+def get_sf(year, pt, eta, counts, type='', pt_region=None):
+    '''
+    This function computes the per-electron reco or id SF.
+    If 'reco', the appropriate corrections are chosen by using the argument `pt_region`.
+    '''
+    electronJSON = correctionlib.CorrectionSet.from_file(electronJSONfiles[year]['file'])
+    map_name = electronJSONfiles[year]['name']
+    if type == 'reco':
+        sfName = electronSF[type][pt_region]
+    elif type == 'id':
+        sfName = electronSF[type]
+
+    sf     = electronJSON[map_name].evaluate(year, "sf",     sfName, eta.to_numpy(), pt.to_numpy())
+    sfup   = electronJSON[map_name].evaluate(year, "sfup",   sfName, eta.to_numpy(), pt.to_numpy())
+    sfdown = electronJSON[map_name].evaluate(year, "sfdown", sfName, eta.to_numpy(), pt.to_numpy())
+
+    # The unflattened arrays are returned in order to have one row per event.
+    return ak.unflatten(sf, counts), ak.unflatten(sfup, counts), ak.unflatten(sfdown, counts)
+
+def sf_ele_reco(events, year):
+    '''
+    This function computes the per-electron reco SF and returns the corresponding per-event SF, obtained by multiplying the per-electron SF in each event.
+    Additionally, also the up and down variations of the SF are returned.
+    Electrons are split into two categories based on a pt cut at 20 GeV, so that the proper SF is applied.
+    '''
+
+    ele_pt  = events.ElectronGood.pt
+    ele_eta = events.ElectronGood.eta
+
+    Above20 = ele_pt >= 20
+    Below20 = ele_pt < 20
+
+    # Since `correctionlib` does not support jagged arrays as an input, the pt and eta arrays are flattened.
+    ele_pt_Above20,  ele_counts_Above20 = ak.flatten(ele_pt[Above20]), ak.num(ele_pt[Above20])
+    ele_eta_Above20 = ak.flatten(ele_eta[Above20])
+
+    ele_pt_Below20,  ele_counts_Below20 = ak.flatten(ele_pt[Below20]), ak.num(ele_pt[Below20])
+    ele_eta_Below20 = ak.flatten(ele_eta[Below20])
+
+    sf_reco_Above20, sfup_reco_Above20, sfdown_reco_Above20 = get_sf(year, ele_pt_Above20, ele_eta_Above20, ele_counts_Above20, 'reco', 'pt>20')
+    sf_reco_Below20, sfup_reco_Below20, sfdown_reco_Below20 = get_sf(year, ele_pt_Below20, ele_eta_Below20, ele_counts_Below20, 'reco', 'pt<20')
+
+    # The SF arrays corresponding to the electrons with pt above and below 20 GeV are concatenated and multiplied along the electron axis in order to obtain a per-event scale factor.
+    sf_reco     = ak.prod( ak.concatenate( (sf_reco_Above20,     sf_reco_Below20),     axis=1 ), axis=1 )
+    sfup_reco   = ak.prod( ak.concatenate( (sfup_reco_Above20,   sfup_reco_Below20),   axis=1 ), axis=1 )
+    sfdown_reco = ak.prod( ak.concatenate( (sfdown_reco_Above20, sfdown_reco_Below20), axis=1 ), axis=1 )
+
+    return sf_reco, sfup_reco, sfdown_reco
+
+def sf_ele_id(events, year):
+    '''
+    This function computes the per-electron id SF and returns the corresponding per-event SF, obtained by multiplying the per-electron SF in each event.
+    Additionally, also the up and down variations of the SF are returned.
+    '''
+    ele_pt  = events.ElectronGood.pt
+    ele_eta = events.ElectronGood.eta
+
+    ele_pt_flat, ele_eta_flat, ele_counts = ak.flatten(ele_pt), ak.flatten(ele_eta), ak.num(ele_pt)
+    sf_id, sfup_id, sfdown_id = get_sf(year, ele_pt_flat, ele_eta_flat, ele_counts, 'id')
+
+    # The SF arrays corresponding to the electrons are multiplied along the electron axis in order to obtain a per-event scale factor.
+    return ak.prod(sf_id, axis=1), ak.prod(sfup_id, axis=1), ak.prod(sfdown_id, axis=1)

--- a/parameters/lepton_scale_factors.py
+++ b/parameters/lepton_scale_factors.py
@@ -1,0 +1,26 @@
+electronSF = {
+    'reco' : {
+        'pt>20' : "RecoAbove20",
+        'pt<20' : "RecoBelow20"
+    },
+    'id' : "wp80iso"
+}
+
+electronJSONfiles = {
+    '2016preVFP' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2016preVFP_UL/electron.json.gz",
+        'name' : "UL-Electron-ID-SF"
+    },
+    '2016postVFP' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2016postVFP_UL/electron.json.gz",
+        'name' : "UL-Electron-ID-SF"
+    },
+    '2017' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2017_UL/electron.json.gz",
+        'name' : "UL-Electron-ID-SF"
+    },
+    '2018' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2018_UL/electron.json.gz",
+        'name' : "UL-Electron-ID-SF"
+    }
+}

--- a/parameters/pileup.py
+++ b/parameters/pileup.py
@@ -1,18 +1,18 @@
 pileupJSONfiles = {
-	'2016_PreVFP'  : {
-		'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2016preVFP_UL/puWeights.json.gz",
-		'name' : "Collisions16_UltraLegacy_goldenJSON"
-	},
-	'2016_PostVFP' : {
-		'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2016postVFP_UL/puWeights.json.gz",
-		'name' : "Collisions16_UltraLegacy_goldenJSON"
-	},
-	'2017'		   : {
-		'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2017_UL/puWeights.json.gz",
-		'name' : "Collisions17_UltraLegacy_goldenJSON"
-	},
-	'2018' 		   : {
-		'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2018_UL/puWeights.json.gz",
-		'name' : "Collisions18_UltraLegacy_goldenJSON"
-	}
+    '2016preVFP'  : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2016preVFP_UL/puWeights.json.gz",
+        'name' : "Collisions16_UltraLegacy_goldenJSON"
+    },
+    '2016postVFP' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2016postVFP_UL/puWeights.json.gz",
+        'name' : "Collisions16_UltraLegacy_goldenJSON"
+    },
+    '2017'         : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2017_UL/puWeights.json.gz",
+        'name' : "Collisions17_UltraLegacy_goldenJSON"
+    },
+    '2018'         : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2018_UL/puWeights.json.gz",
+        'name' : "Collisions18_UltraLegacy_goldenJSON"
+    }
 }

--- a/workflows/base.py
+++ b/workflows/base.py
@@ -13,6 +13,7 @@ from coffea.analysis_tools import PackedSelection, Weights
 import correctionlib
 
 from lib.objects import jet_correction, lepton_selection, jet_selection, get_dilepton
+from lib.scale_factors import sf_ele_reco, sf_ele_id
 from lib.fill import fill_histograms_object
 from parameters.triggers import triggers
 from parameters.btag import btag
@@ -154,7 +155,7 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
         #self.events["FatJetGood"]   = self.events.FatJet[self.good_fatjets]
 
         if self.cfg.finalstate == 'dilepton':
-            self.events["ll"]           = get_dilepton(self.events.ElectronGood, self.events.MuonGood)
+            self.events["ll"] = get_dilepton(self.events.ElectronGood, self.events.MuonGood)
 
     # Function that counts the preselected objects and save the counts as attributes of `events`
     def count_objects(self):
@@ -203,6 +204,9 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
             self.weights.add('pileup', puWeightsJSON[self._puName].evaluate(self.events.Pileup.nPU.to_numpy(), 'nominal'),
                               weightUp=puWeightsJSON[self._puName].evaluate(self.events.Pileup.nPU.to_numpy(), 'up'),
                             weightDown=puWeightsJSON[self._puName].evaluate(self.events.Pileup.nPU.to_numpy(), 'down') )
+            # Electron reco and id SF with nominal, up and down variations
+            self.weights.add('sf_ele_reco', *sf_ele_reco(self.events, self._year))
+            self.weights.add('sf_ele_id',   *sf_ele_id(self.events, self._year))
 
     def fill_histograms(self):
         for (obj, obj_hists) in zip([None], [self.nobj_hists]):


### PR DESCRIPTION
The electron scale factors are read from the json files as recommended by [EGamma](https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaSFJSON), the reconstruction and ID scale factors are computed per-electron and a final per-event weight is computed as the product of the single electron weights and included in the set of applied per-event weights.
Together with the nominal weights, also the weights corresponding to the up and down variations are returned, obtained by varying up and down the electron SF by 1 sigma:
```
sf_reco [1, 0.972, 0.994, 0.985, 0.996, 0.996, ... 0.979, 0.986, 1, 0.992, 0.999, 0.989]
sfup_reco [1, 1.01, 1.01, 1.01, 1.01, 1.01, 1, 1, ... 1.01, 1.01, 1, 1.01, 1, 1.01, 1.02, 1]
sfdown_reco [1, 0.993, 0.987, 0.988, 0.995, 0.995, ... 0.997, 0.994, 1, 0.988, 0.977, 0.996]
sf_id [1, 0.891, 0.922, 0.872, 0.98, 0.971, ... 0.938, 0.952, 1, 0.956, 0.962, 0.957]
sfup_id [1, 1.03, 1.02, 1.02, 1.01, 1.01, 1.01, 1, ... 1.01, 1.01, 1.01, 1, 1.02, 1.03, 1.01]
sfdown_id [1, 0.975, 0.984, 0.979, 0.989, 0.991, ... 0.989, 0.987, 1, 0.983, 0.972, 0.993]
```