### PR TITLE
Dedicated library for pileup reweighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,11 @@
-lib/__pycache__
-parameters/__pycache__
-workflows/__pycache__
+PocketCoffea/lib/__pycache__
+PocketCoffea/parameters/__pycache__
+PocketCoffea/workflows/__pycache__
 notebooks/.ipynb_checkpoints
 .ipynb_checkpoints/
 plots/
 histograms/
 output/
 logs/
-parameters/corrections/JEC/tmp/
 *~
 *.pyc

--- a/PocketCoffea/lib/pileup.py
+++ b/PocketCoffea/lib/pileup.py
@@ -1,0 +1,15 @@
+import correctionlib
+
+from ..parameters.pileup import pileupJSONfiles
+
+def sf_pileup_reweight(events, year):
+    puFile = pileupJSONfiles[year]['file']
+    puName = pileupJSONfiles[year]['name']
+
+    puWeightsJSON = correctionlib.CorrectionSet.from_file(puFile)
+
+    sf     = puWeightsJSON[puName].evaluate(events.Pileup.nPU.to_numpy(), 'nominal')
+    sfup   = puWeightsJSON[puName].evaluate(events.Pileup.nPU.to_numpy(), 'up')
+    sfdown = puWeightsJSON[puName].evaluate(events.Pileup.nPU.to_numpy(), 'down')
+
+    return sf, sfup, sfdown

--- a/config/example.py
+++ b/config/example.py
@@ -1,4 +1,5 @@
-from lib.cuts import dilepton, SR, CR_top
+from PocketCoffea.lib.cuts import dilepton, SR, CR_top
+from PocketCoffea.workflows.base import ttHbbBaseProcessor
 
 cfg =  {
 
@@ -12,7 +13,7 @@ cfg =  {
     },
 
     # Input and output files
-    "workflow" : "base",
+    "workflow" : ttHbbBaseProcessor,
     "output"   : "output/example",
 
     # Executor parameters

--- a/config/test_pileup.py
+++ b/config/test_pileup.py
@@ -1,4 +1,5 @@
-from parameters.cuts.baseline_cuts import dilepton_presel, passthrough
+from PocketCoffea.parameters.cuts.baseline_cuts import dilepton_presel, passthrough
+from PocketCoffea.workflows.base import ttHbbBaseProcessor
 
 cfg =  {
 
@@ -12,12 +13,12 @@ cfg =  {
     },
 
     # Input and output files
-    "workflow" : "base",
+    "workflow" : ttHbbBaseProcessor,
     "output"   : "output/test_pileup",
 
     # Executor parameters
     "run_options" : {
-        "executor"       : "futures",
+        "executor"       : "iterative",
         "workers"        : 12,
         "scaleout"       : 10,
         "partition"      : "standard",

--- a/config/test_pileup_variations.py
+++ b/config/test_pileup_variations.py
@@ -1,4 +1,5 @@
-from parameters.cuts.baseline_cuts import dilepton_presel, passthrough
+from PocketCoffea.parameters.cuts.baseline_cuts import dilepton_presel, passthrough
+from PocketCoffea.workflows.pileup_variations import pileupVariationsProcessor
 
 cfg =  {
 
@@ -12,12 +13,12 @@ cfg =  {
     },
 
     # Input and output files
-    "workflow" : "pileup_variations",
+    "workflow" : pileupVariationsProcessor,
     "output"   : "output/test_pileup_variations",
 
     # Executor parameters
     "run_options" : {
-        "executor"       : "futures",
+        "executor"       : "parsl/slurm",
         "workers"        : 12,
         "scaleout"       : 10,
         "partition"      : "standard",
@@ -28,7 +29,7 @@ cfg =  {
         "max"            : None,
         "skipbadfiles"   : None,
         "voms"           : None,
-        "limit"          : 2,
+        "limit"          : None,
     },
 
     # Cuts and plots settings


### PR DESCRIPTION
The computation of pileup weights is now defined in a dedicated library, in order to keep the base processor clean.
Additionally, the config files are updated to adapt to the new implementation of the `Configurator`.