### PR TITLE
Implementation of muon id and iso scale factors

### DIFF
--- a/PocketCoffea/parameters/lepton_scale_factors.py
+++ b/PocketCoffea/parameters/lepton_scale_factors.py
@@ -24,3 +24,23 @@ electronJSONfiles = {
         'name' : "UL-Electron-ID-SF"
     }
 }
+
+muonSF = {
+    'id'  : "NUM_TightID_DEN_TrackerMuons",
+    'iso' : "NUM_LooseRelIso_DEN_TightIDandIPCut",
+}
+
+muonJSONfiles = {
+    '2016preVFP' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2017postVFP_UL/muon_Z.json.gz",
+    },
+    '2016postVFP' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2017preVFP_UL/muon_Z.json.gz",
+    },
+    '2017' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2017_UL/muon_Z.json.gz",
+    },
+    '2018' : {
+        'file' : "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2018_UL/muon_Z.json.gz",
+    }
+}

--- a/PocketCoffea/workflows/base.py
+++ b/PocketCoffea/workflows/base.py
@@ -14,7 +14,7 @@ import correctionlib
 
 from ..lib.objects import jet_correction, lepton_selection, jet_selection, btagging, get_dilepton
 from ..lib.pileup import sf_pileup_reweight
-from ..lib.scale_factors import sf_ele_reco, sf_ele_id
+from ..lib.scale_factors import sf_ele_reco, sf_ele_id, sf_mu
 from ..lib.fill import fill_histograms_object
 from ..parameters.triggers import triggers
 from ..parameters.btag import btag
@@ -203,6 +203,9 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
             # Electron reco and id SF with nominal, up and down variations
             self.weights.add('sf_ele_reco', *sf_ele_reco(self.events, self._year))
             self.weights.add('sf_ele_id',   *sf_ele_id(self.events, self._year))
+            # Muon id and iso SF with nominal, up and down variations
+            self.weights.add('sf_mu_id',  *sf_mu(self.events, self._year, 'id'))
+            self.weights.add('sf_mu_iso', *sf_mu(self.events, self._year, 'iso'))
 
     def fill_histograms(self):
         for (obj, obj_hists) in zip([None], [self.nobj_hists]):


### PR DESCRIPTION
The computation of the weights associated with the muon identification and isolation cut are included in the framework, and applied to Monte Carlo. The scale factors are computed for each muon and two per-event scale factors (`sf_mu_id` and `sf_mu_iso`) are derived by multiplying the scale factors of all the muons in the event.
As in the electron case, two dedicated weights are included in the `Weights()` object and therefore the muon weights are properly taken into account when histograms are filled.
Together with the "nominal" scale factors, also the "up" and "down" variations are stored, allowing future studies on the variation of the corresponding systematic uncertainties.