### PR TITLE
Migration of semileptonic trigger SF library to hist

### DIFF
--- a/PocketCoffea/lib/HistManager.py
+++ b/PocketCoffea/lib/HistManager.py
@@ -166,7 +166,7 @@ class HistManager():
                  all_axes = [cat_ax, var_ax]
              else:
                  # no variation axis for data
-                 all_axies = [cat_ax]
+                 all_axes = [cat_ax]
              # the custom axis get included in the hcfg for future use
              hcfg.axes = custom_axes + hcfg.axes
              for ax in hcfg.axes:
@@ -209,14 +209,14 @@ class HistManager():
             # The weights will be flattened if needed for each histo
             # map of weights in this category, with mask APPLIED
             if self.isMC:
-                 weights = {}
+                weights = {}
                 for variation in self.available_variations_bycat[category]:
-                     if variation == "nominal":
-                         weights["nominal"]  = weights_manager.get_weight(category)[mask]
-                     else:
-                         # Check if the variation is available in this category
-                         weights[variation] = weights_manager.get_weight(category, modifier=variation)[mask]
-                     #print(f"\t\t= Weights [{variation}] = {weights[variation]} ")
+                    if variation == "nominal":
+                        weights["nominal"]  = weights_manager.get_weight(category)[mask]
+                    else:
+                        # Check if the variation is available in this category
+                        weights[variation] = weights_manager.get_weight(category, modifier=variation)[mask]
+                        #print(f"\t\t= Weights [{variation}] = {weights[variation]} ")
                 # #print(weights["nominal"])
                 # #print(weights_manager._weightsByCat["btagSF"].partial_weight(include=["sf_btag_central"]))
             

--- a/PocketCoffea/parameters/histograms.py
+++ b/PocketCoffea/parameters/histograms.py
@@ -34,7 +34,7 @@ collection_fields = {
     'parton':  ["eta","pt","phi", "dRMatchedJet","pdgId"],
     'electron': ["eta","pt","phi", "etaSC"],
     'muon':  ["eta","pt","phi"]
-} 
+}
 
 
 def _get_default_hist(name, type, coll, pos=None, fields=None):
@@ -84,7 +84,8 @@ def count_hist(coll, bins=10, start=0, stop=9, label=None, name=None):
         f"{name}": HistConf(axes=[
         Axis(coll="events", field=f"n{coll}",
              label=f"$N_{{{coll}}}$",
-             bins=bins, start=start, stop=stop)
+             bins=bins, start=start, stop=stop,
+             lim=(start,stop))
         ])
     }
 

--- a/PocketCoffea/utils/Configurator.py
+++ b/PocketCoffea/utils/Configurator.py
@@ -25,6 +25,7 @@ class Configurator():
         self.fileset = {}
         self.samples = []
         self.years = []
+        self.eras = []
         self.load_dataset()
 
         # Check if output file exists, and in case add a `_v01` label, make directory
@@ -130,9 +131,12 @@ class Configurator():
             raise Exception("Wrong fileset configuration")
         else:
             for name, d in self.fileset.items():
-                if (m:=d["metadata"]) not in self.samples:
+                m = d["metadata"]
+                if (m["sample"]) not in self.samples:
                     self.samples.append(m["sample"])
                     self.years.append(m["year"])
+                    if 'era' in m.keys():
+                        self.eras.append(m["era"])
 
     def filter_dataset(self, nfiles):
         filtered_dataset = {}

--- a/PocketCoffea/workflows/base.py
+++ b/PocketCoffea/workflows/base.py
@@ -71,14 +71,7 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
             "variables": { v: {} for v, vcfg in self.cfg.variables.items() if not vcfg.metadata_hist},
             "columns" :  {cat: {} for cat in self._categories},
             "processing_metadata": { v: {} for v, vcfg in self.cfg.variables.items() if vcfg.metadata_hist}
-        }
-
-        # Custom axes to add to histograms in this processor
-        self.custom_axes = [Axis(coll="metadata", field="year",name="year",
-                                 bins=set(sorted(self.cfg.years)),
-                                  type="strcat", growth=False,
-                                  label="Year", )]
-        
+        }        
 
     def add_column_accumulator(self, name, categories=None, store_size=True):
         '''
@@ -116,7 +109,7 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
         self._year = self.events.metadata["year"]
         self._triggers = triggers[self.cfg.finalstate][self._year]
         self._btag = btag[self._year]
-        self._isMC = self.events.metadata["isMC"]
+        self._isMC = self.events.metadata["isMC"] == "True"
         if self._isMC:
             self._era = "MC"
         else:
@@ -246,6 +239,16 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
                                               })
     def compute_weights_extra(self):
         pass
+
+    def define_custom_axes(self):
+        # Custom axes to add to histograms in this processor
+        self.custom_axes = [Axis(coll="metadata", field="year",name="year",
+                                 bins=set(sorted(self.cfg.years)),
+                                 type="strcat", growth=False,
+                                 label="Year", )]
+
+    def define_custom_axes_extra(self):
+        pass
         
     def count_events(self):
         # Fill the output with the number of events and the sum
@@ -362,6 +365,8 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
         self.compute_weights_extra()
 
         # Create the HistManager
+        self.define_custom_axes()
+        self.define_custom_axes_extra()
         self.hists_manager = HistManager(self.cfg.variables,
                                          self._sample,
                                          self._categories,

--- a/PocketCoffea/workflows/base.py
+++ b/PocketCoffea/workflows/base.py
@@ -188,7 +188,7 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
     def count_objects(self):
         self.events["nMuonGood"]     = ak.num(self.events.MuonGood)
         self.events["nElectronGood"] = ak.num(self.events.ElectronGood)
-        self.events["nLepGood"]      = self.events["nMuonGood"] + self.events["nElectronGood"]
+        self.events["nLeptonGood"]   = self.events["nMuonGood"] + self.events["nElectronGood"]
         self.events["nJetGood"]      = ak.num(self.events.JetGood)
         self.events["nBJetGood"]     = ak.num(self.events.BJetGood)
         #self.events["nfatjet"]   = ak.num(self.events.FatJetGood)
@@ -226,7 +226,9 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
         return WeightsManager.available_variations()
     
     def compute_weights(self):
-        if not self._isMC: return
+        if not self._isMC:
+            self.weights_manager = None
+            return
         # Creating the WeightsManager with all the configured weights
         self.weights_manager = WeightsManager(self.weights_config_allsamples[self._sample],
                                               self.nEvents_after_presel,
@@ -372,7 +374,7 @@ class ttHbbBaseProcessor(processor.ProcessorABC):
                                          self._categories,
                                          self.cfg.variations_config[self._sample],
                                          custom_axes=self.custom_axes,
-                                         isMC=self.isMC)
+                                         isMC=self._isMC)
 
         # Fill histograms
         self.fill_histograms()

--- a/PocketCoffea/workflows/semileptonic_triggerSF.py
+++ b/PocketCoffea/workflows/semileptonic_triggerSF.py
@@ -6,55 +6,21 @@ from coffea.processor import dict_accumulator, defaultdict_accumulator
 from coffea.analysis_tools import Weights
 
 from ..workflows.base import ttHbbBaseProcessor
-from ..lib.pileup import sf_pileup_reweight
-from ..lib.scale_factors import sf_ele_reco, sf_ele_id, sf_mu
-from ..lib.fill import fill_histograms_object_with_variations
-from ..parameters.lumi import lumi
-from ..parameters.samples import samples_info
+from ..lib.HistManager import Axis
 
 class semileptonicTriggerProcessor(ttHbbBaseProcessor):
     def __init__(self,cfg) -> None:
         super().__init__(cfg=cfg)
-        variations_axis   = hist.Cat("var", "Variations")
-        for histname, h in self._hist_dict.items():
-            self._hist_dict[histname] = hist.Hist("$N_{events}$", *h.sparse_axes(), variations_axis, *h.dense_axes())
-        for histname, h in self._hist2d_dict.items():
-            self._hist2d_dict[histname] = hist.Hist("$N_{events}$", *h.sparse_axes(), variations_axis, *h.dense_axes())
-        # Accumulator with sum of weights of the events passing each category for each sample
-        self._eff_dict = {cat: defaultdict_accumulator(float) for cat in self._categories}
-        self._accum_dict["trigger_efficiency"] = dict_accumulator(self._eff_dict)
-        # Add 2D histogram for trigger efficiency computation
-        self.efficiency_maps = ["hist2d_electron_etaSC_vs_electron_pt", "hist2d_electron_phi_vs_electron_pt", "hist2d_electron_etaSC_vs_electron_phi"]
-        self.electron_hists = self.electron_hists + self.efficiency_maps
-        self._accum_dict.update(self._hist_dict)
-        self._accum_dict.update(self._hist2d_dict)
-        self._accumulator = processor.dict_accumulator(self._accum_dict)
-        if self.cfg.triggerSF != None:
-            self._apply_triggerSF = True
-        else:
-            self._apply_triggerSF = False
-        self.define_triggerSF_maps()
 
-    # Define trigger SF map to apply
-    def define_triggerSF_maps(self):
-        if self._apply_triggerSF:
-            self._triggerSF_map = {}
-            for category in self._categories.keys():
-                if 'Ele32_EleHT_pass' in category:
-                    self._triggerSF_map[category] = 'sf_nominal'
-                elif category in ['Ele32_EleHT_fail', 'inclusive']:
-                    self._triggerSF_map[category] = 'identity'
-                else:
-                    sys.exit(f"The association of the category '{category}' to a trigger SF key is ambiguous")
-        else:
-            return
+        self.output_format["trigger_efficiency"] = {cat: {} for cat in self._categories}
 
-    def fill_histograms(self):
-        systematics = ['pileup', 'sf_ele_reco', 'sf_ele_id']
-        for (obj, obj_hists) in zip([None], [self.perevent_hists]):
-            fill_histograms_object_with_variations(self, obj, obj_hists, systematics, event_var=True, split_eras=self.cfg.split_eras, triggerSF=self._apply_triggerSF)
-        for (obj, obj_hists) in zip([self.events.MuonGood, self.events.ElectronGood, self.events.JetGood], [self.muon_hists, self.electron_hists, self.jet_hists]):
-            fill_histograms_object_with_variations(self, obj, obj_hists, systematics, split_eras=self.cfg.split_eras, triggerSF=self._apply_triggerSF)
+    def define_custom_axes_extra(self):
+        # Add 'era' axis for data samples
+        if not self._isMC:
+            self.custom_axes += [Axis(coll="metadata", field="era",name="era",
+                                     bins=set(sorted(self.cfg.eras)),
+                                     type="strcat", growth=False,
+                                     label="Era", )]
 
     def postprocess(self, accumulator):
         super().postprocess(accumulator=accumulator)

--- a/config/semileptonic_triggerSF/functions.py
+++ b/config/semileptonic_triggerSF/functions.py
@@ -26,11 +26,11 @@ def trigger_mask_2017(events, params, **kwargs):
     return mask
 
 def ht_above(events, params, **kwargs):
-    mask = events["ht"] > params["minht"]
+    mask = events["JetGood_Ht"] > params["minht"]
     return mask
 
 def ht_below(events, params, **kwargs):
-    mask = (events["ht"] >= 0) & (events["ht"] < params["maxht"])
+    mask = (events["JetGood_Ht"] >= 0) & (events["JetGood_Ht"] < params["maxht"])
     return mask
 
 def get_trigger_passfail(triggers, category):

--- a/config/semileptonic_triggerSF/semileptonic_triggerSF_2018.py
+++ b/config/semileptonic_triggerSF/semileptonic_triggerSF_2018.py
@@ -26,8 +26,8 @@ cfg =  {
 
     # Executor parameters
     "run_options" : {
-        "executor"       : "dask/slurm",
-        "workers"        : 1,
+        "executor"       : "futures",
+        "workers"        : 16,
         "scaleout"       : 16,
         "partition"      : "short",
         "walltime"       : "1:00:00",
@@ -39,7 +39,7 @@ cfg =  {
         "max"            : None,
         "skipbadfiles"   : None,
         "voms"           : None,
-        "limit"          : 2,
+        "limit"          : None,
     },
 
     # Cuts and plots settings
@@ -84,34 +84,81 @@ cfg =  {
     "variables" : {
         **muon_hists(coll="MuonGood"),
         **muon_hists(coll="MuonGood", pos=0),
-        **ele_hists(coll="ElectronGood"),
-        **ele_hists(coll="ElectronGood", pos=0),
+        "ElectronGood_pt" : HistConf(
+            [
+                Axis(coll="ElectronGood", field="pt", type="variable",
+                     bins=[30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500],
+                     label="Electron $p_{T}$ [GeV]",
+                     lim=(0,500))
+            ]
+        ),
+        "ElectronGood_etaSC" : HistConf(
+            [
+                Axis(coll="ElectronGood", field="etaSC", type="variable",
+                     bins=[-2.5, -2.0, -1.5660, -1.4442, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4442, 1.5660, 2.0, 2.5],
+                     label="Electron Supercluster $\eta$",
+                     lim=(-2.5,2.5))
+            ]
+        ),
+        "ElectronGood_phi" : HistConf(
+            [
+                Axis(coll="ElectronGood", field="phi",
+                     bins=12, start=-pi, stop=pi,
+                     label="Electron $\phi$"),
+            ]
+        ),
+        "ElectronGood_pt_1" : HistConf(
+            [
+                Axis(coll="ElectronGood", field="pt", pos=0, type="variable",
+                     bins=[30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500],
+                     label="Electron $p_{T}$ [GeV]",
+                     lim=(0,500))
+            ]
+        ),
+        "ElectronGood_etaSC_1" : HistConf(
+            [
+                Axis(coll="ElectronGood", field="etaSC", pos=0, type="variable",
+                     bins=[-2.5, -2.0, -1.5660, -1.4442, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4442, 1.5660, 2.0, 2.5],
+                     label="Electron Supercluster $\eta$",
+                     lim=(-2.5,2.5))
+            ]
+        ),
+        "ElectronGood_phi_1" : HistConf(
+            [
+                Axis(coll="ElectronGood", field="phi", pos=0,
+                     bins=12, start=-pi, stop=pi,
+                     label="Electron $\phi$"),
+            ]
+        ),
         **jet_hists(coll="JetGood"),
-        **count_hist(name="nMuons", coll="MuonGood",bins=10, start=0, stop=10),
-        **count_hist(name="nElectrons", coll="ElectronGood",bins=10, start=0, stop=10),
-        **count_hist(name="nLeptons", coll="LeptonGood",bins=10, start=0, stop=10),
-        **count_hist(name="nJets", coll="JetGood",bins=10, start=0, stop=10),
-        **count_hist(name="nBJets", coll="BJetGood",bins=10, start=0, stop=10),
+        **count_hist(name="nMuons", coll="MuonGood",bins=10, start=0, stop=2),
+        **count_hist(name="nElectrons", coll="ElectronGood",bins=10, start=0, stop=2),
+        **count_hist(name="nLeptons", coll="LeptonGood",bins=10, start=0, stop=2),
+        **count_hist(name="nJets", coll="JetGood",bins=10, start=4, stop=10),
+        **count_hist(name="nBJets", coll="BJetGood",bins=10, start=4, stop=10),
         "ht" : HistConf(
             [
-                Axis(coll="events", field="JetGood_Ht", bins=400, start=0, stop=4000, label="$H_T$")
+                Axis(coll="events", field="JetGood_Ht", bins=400, start=0, stop=4000, label="$H_T$", lim=(0,1000))
             ]
         ),
         "electron_etaSC_pt_leading" : HistConf(
             [
                 Axis(coll="ElectronGood", field="pt", pos=0, type="variable",
-                     bins=[0, 30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500, 2000],
-                     label="Electron $p_{T}$ [GeV]"),
+                     bins=[30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500],
+                     label="Electron $p_{T}$ [GeV]",
+                     lim=(0,500)),
                 Axis(coll="ElectronGood", field="etaSC", pos=0, type="variable",
                      bins=[-2.5, -2.0, -1.5660, -1.4442, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4442, 1.5660, 2.0, 2.5],
-                     label="Electron Supercluster $\eta$"),
+                     label="Electron Supercluster $\eta$",
+                     lim=(-2.5,2.5)),
             ]
         ),
         "electron_phi_pt_leading" : HistConf(
             [
                 Axis(coll="ElectronGood", field="pt", pos=0, type="variable",
-                     bins=[0, 30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500, 2000],
-                     label="Electron $p_{T}$ [GeV]"),
+                     bins=[30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500],
+                     label="Electron $p_{T}$ [GeV]",
+                     lim=(0,500)),
                 Axis(coll="ElectronGood", field="phi", pos=0,
                      bins=12, start=-pi, stop=pi,
                      label="Electron $\phi$"),
@@ -124,24 +171,28 @@ cfg =  {
                      label="Electron $\phi$"),
                 Axis(coll="ElectronGood", field="etaSC", pos=0, type="variable",
                      bins=[-2.5, -2.0, -1.5660, -1.4442, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4442, 1.5660, 2.0, 2.5],
-                     label="Electron Supercluster $\eta$"),
+                     label="Electron Supercluster $\eta$",
+                     lim=(-2.5,2.5)),
             ]
         ),
         "electron_etaSC_pt_all" : HistConf(
             [
                 Axis(coll="ElectronGood", field="pt", type="variable",
-                     bins=[0, 30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500, 2000],
-                     label="Electron $p_{T}$ [GeV]"),
+                     bins=[30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500],
+                     label="Electron $p_{T}$ [GeV]",
+                     lim=(0,500)),
                 Axis(coll="ElectronGood", field="etaSC", type="variable",
                      bins=[-2.5, -2.0, -1.5660, -1.4442, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4442, 1.5660, 2.0, 2.5],
-                     label="Electron Supercluster $\eta$"),
+                     label="Electron Supercluster $\eta$",
+                     lim=(-2.5,2.5)),
             ]
         ),
         "electron_phi_pt_all" : HistConf(
             [
                 Axis(coll="ElectronGood", field="pt", type="variable",
-                     bins=[0, 30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500, 2000],
-                     label="Electron $p_{T}$ [GeV]"),
+                     bins=[30, 35, 40, 50, 60, 70, 80, 90, 100, 200, 500],
+                     label="Electron $p_{T}$ [GeV]",
+                     lim=(0,500)),
                 Axis(coll="ElectronGood", field="phi",
                      bins=12, start=-pi, stop=pi,
                      label="Electron $\phi$"),
@@ -154,7 +205,8 @@ cfg =  {
                      label="Electron $\phi$"),
                 Axis(coll="ElectronGood", field="etaSC", type="variable",
                      bins=[-2.5, -2.0, -1.5660, -1.4442, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4442, 1.5660, 2.0, 2.5],
-                     label="Electron Supercluster $\eta$"),
+                     label="Electron Supercluster $\eta$",
+                     lim=(-2.5,2.5)),
             ]
         ),
     },

--- a/runner.py
+++ b/runner.py
@@ -203,7 +203,7 @@ if __name__ == '__main__':
 
         if 'slurm' in config.run_options['executor']:
             cluster = SLURMCluster(
-                queue='standard',
+                queue=config.run_options['partition'],
                 cores=config.run_options['workers'],
                 processes=config.run_options['workers'],
                 memory=config.run_options['mem_per_worker'],


### PR DESCRIPTION
The present PR re-implements the semileptonic trigger SF library in order to migrate from `Coffea` histograms to `hist` histograms.