### PR TITLE
Cleaning up the subsample implementation

### DIFF
--- a/config/test_subsamples.py
+++ b/config/test_subsamples.py
@@ -2,6 +2,7 @@ from pocket_coffea.parameters.cuts.preselection_cuts import *
 from pocket_coffea.workflows.tthbb_base_processor import ttHbbBaseProcessor
 from pocket_coffea.lib.cut_functions import get_nObj_min, get_nObj_eq, get_nBtag, get_HLTsel, get_nObj_less
 from pocket_coffea.parameters.histograms import *
+from pocket_coffea.lib.columns_manager import ColOut
 from pocket_coffea.parameters.btag import btag_variations
 from pocket_coffea.lib.weights_manager import WeightCustom
 import numpy as np
@@ -18,8 +19,9 @@ cfg =  {
             "samples": [
                 # "TTToSemiLeptonic",
                 "TTbbSemiLeptonic",
-                # "ttHTobb",
-                # "DATA_SingleMu", "DATA_SingleEle"
+                "ttHTobb",
+                "DATA_SingleMu",
+                # "DATA_SingleEle"
             ],
             "samples_exclude" : [],
             "year": ['2018']
@@ -31,6 +33,10 @@ cfg =  {
                 "tt+3b": [get_nObj_eq(3, coll="BJetGood")],
                 "tt+4b": [get_nObj_eq(4, coll="BJetGood")],
                 "tt>4b": [get_nObj_min(5, coll="BJetGood")],
+            },
+            "ttHTobb":{
+                "ttH<4b": [get_nObj_less(4, coll="BJetGood")],
+                "ttH+4b": [get_nObj_min(4, coll="BJetGood")],
             }
         }
     },
@@ -108,59 +114,20 @@ cfg =  {
 
         **ele_hists(coll="ElectronGood", pos=0),
         **muon_hists(coll="MuonGood", pos=0),
-        # **count_hist(name="nElectronGood", coll="ElectronGood",bins=3, start=0, stop=3),
-        # **count_hist(name="nMuonGood", coll="MuonGood",bins=3, start=0, stop=3),
-        # **count_hist(name="nJets", coll="JetGood",bins=10, start=4, stop=14),
-        # **count_hist(name="nBJets", coll="BJetGood",bins=12, start=2, stop=14),
-        # **jet_hists(coll="JetGood", pos=0),
-        # **jet_hists(coll="JetGood", pos=1),
-        # **jet_hists(coll="JetGood", pos=2),
-        # **jet_hists(coll="JetGood", pos=3),
-        # **jet_hists(coll="JetGood", pos=4),
-        # **jet_hists(name="bjet",coll="BJetGood", pos=0),
-        # **jet_hists(name="bjet",coll="BJetGood", pos=1),
-        # **jet_hists(name="bjet",coll="BJetGood", pos=2),
+    },
 
-    #     # 2D plots
-    #     "jet_eta_pt_leading": HistConf(
-    #         [
-    #             Axis(coll="JetGood", field="pt", pos=0, bins=40, start=0, stop=1000,
-    #                  label="Leading jet $p_T$"),
-    #             Axis(coll="JetGood", field="eta", pos=0, bins=40, start=-2.4, stop=2.4,
-    #                  label="Leading jet $\eta$"),
-    #         ]
-    #     ),
-    #     "jet_eta_pt_all": HistConf(
-    #         [
-    #             Axis(coll="JetGood", field="pt", bins=40, start=0, stop=1000,
-    #                  label="Leading jet $p_T$"),
-    #             Axis(coll="JetGood", field="eta", bins=40, start=-2.4, stop=2.4,
-    #                  label="Leading jet $\eta$")
-    #         ]
-    #     ),
-
-    #     # Metadata of the processing
-    #     "events_per_chunk" : HistConf(
-    #            axes=[
-    #                Axis(name='nEvents_initial', field=None,
-    #                     bins=100, start=0, stop=500000,                       
-    #                     label="Number of events in the chunk",
-    #                     ), 
-    #                Axis(name='nEvents_after_skim', field=None,
-    #                     bins=100, start=0, stop=500000,                       
-    #                     label="Number of events after skim per chunk",
-    #                     ), 
-    #                Axis(name='nEvents_after_presel',field=None,
-    #                     bins=100, start=0, stop=500000,
-    #                     label="Number of events after preselection per chunk",
-    #                     )
-    #            ],
-    #         storage="int64",
-    #         autofill=False,
-    #         metadata_hist = True,
-    #         no_weights=True,
-    #         only_categories=["baseline"],
-    #         variations=False,),
-    # }
+    "columns": {
+        "common": {
+            "inclusive": [ ColOut("JetGood", ["pt", "eta","phi"]),
+                           ColOut("ElectronGood", ["pt","eta","phi"])]
+        },
+        "bysample":{
+            "ttHTobb": {
+                "inclusive": [ColOut("MuonGood", ["pt", "eta", "phi"])]
+            },
+            "ttH+4b":{
+                "inclusive": [ColOut("BJetGood", ["pt", "eta", "phi"])]
+            }
         }
+    }
 }

--- a/pocket_coffea/lib/columns_manager.py
+++ b/pocket_coffea/lib/columns_manager.py
@@ -17,7 +17,7 @@ class ColOut:
 
 class ColumnsManager:
     def __init__(self, cfg, sample, categories_config):
-        self.cfg = cfg.get(sample, {})
+        self.cfg = cfg
         self.categories_config = categories_config
 
     def add_column(self, cfg: ColOut, categories=None):

--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -145,14 +145,14 @@ class HistManager:
         # The variation config is organized as the weights one, by sample and by category
 
         for name, hcfg in deepcopy(hist_config).items():
-            # TODO THIS IS BROKEN
             # Check if the histogram is active for the current sample
-            # if hcfg.only_samples != None:
-            #     if cfg.only_samples not in self.subsamples:
-            #         continue
-            # elif hcfg.exclude_samples != None:
-            #     if hcfg.exclude_samples not in self.subsamples:
-            #         continue
+            # We only check for the parent sample, not for subsamples
+            if hcfg.only_samples != None:
+                if self.sample not in cfg.only_samples:
+                    continue
+            elif hcfg.exclude_samples != None:
+                if self.sample in hcfg.exclude_samples:
+                    continue
             # Now we handle the selection of the categories
             cats = []
             for c in self.available_categories:
@@ -209,7 +209,7 @@ class HistManager:
             # Then we add those axes to the full list
             for ax in hcfg.axes:
                 all_axes.append(get_hist_axis_from_config(ax))
-
+            # Creating an histogram object for each subsample
             for subsample in self.subsamples:
                 hcfg_subs = deepcopy(hcfg)
                 # Build the histogram object with the additional axes

--- a/pocket_coffea/parameters/xsec.py
+++ b/pocket_coffea/parameters/xsec.py
@@ -2,6 +2,7 @@
 
 xsec = {
     "ttHTobb": 0.2953,
+    "TTbbSemiLeptonic": 365.4574,  # to be checked
     "TTToSemiLeptonic": 365.4574,
     "TTTo2L2Nu": 88.3419,
     "TTToHadronic": 377.9607,

--- a/pocket_coffea/utils/dataset.py
+++ b/pocket_coffea/utils/dataset.py
@@ -103,7 +103,7 @@ class Dataset:
             if not scfg["metadata"]["isMC"]:
                 sname += f"_Era{scfg['metadata']['era']}"
             if "dbs_instance" in scfg.keys():
-                kwargs = {"dbs_instance" : scfg['dbs_instance']}
+                kwargs = {"dbs_instance": scfg['dbs_instance']}
             else:
                 kwards = {}
             sample = Sample(
@@ -111,7 +111,7 @@ class Dataset:
                 das_names=scfg["das_names"],
                 sample=self.sample,
                 metadata=scfg["metadata"],
-                **kwargs
+                **kwargs,
             )
             self.samples_obj.append(sample)
             # Get the default prefix and the the one

--- a/pocket_coffea/workflows/tthbb_base_processor.py
+++ b/pocket_coffea/workflows/tthbb_base_processor.py
@@ -29,36 +29,6 @@ class ttHbbBaseProcessor(BaseProcessorABC):
             )
         )
 
-    # def load_metadata_extra(self):
-    #     self._JECversion = JECversions[self._year]['MC' if self._isMC else 'Data']
-    #     self._JERversion = JERversions[self._year]['MC' if self._isMC else 'Data']
-
-    # def apply_JERC(self, JER=True, verbose=False):
-    #     if not self._isMC:
-    #         return
-    #     if int(self._year) > 2018:
-    #         sys.exit("Warning: Run 3 JEC are not implemented yet.")
-    #     if JER:
-    #         self.events.Jet, seed_dict = jet_correction(
-    #             self.events,
-    #             "Jet",
-    #             "AK4PFchs",
-    #             self._year,
-    #             self._JECversion,
-    #             self._JERversion,
-    #             verbose=verbose,
-    #         )
-    #         self.output['seed_chunk'].update(seed_dict)
-    #     else:
-    #         self.events.Jet = jet_correction(
-    #             self.events,
-    #             "Jet",
-    #             "AK4PFchs",
-    #             self._year,
-    #             self._JECversion,
-    #             verbose=verbose,
-    #         )
-
     def apply_object_preselection(self, variation):
         '''
         The ttHbb processor cleans
@@ -86,8 +56,6 @@ class ttHbbBaseProcessor(BaseProcessorABC):
         )
         self.events["LeptonGood"] = leptons[ak.argsort(leptons.pt, ascending=False)]
 
-        # Apply JEC + JER
-        # self.apply_JERC()
         self.events["JetGood"], self.jetGoodMask = jet_selection(
             self.events, "Jet", self.cfg.finalstate
         )

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -132,8 +132,9 @@ if __name__ == '__main__':
                                     chunksize=config.run_options['chunk'],
                                     maxchunks=config.run_options['max']
                                     )
-        save(output, config.outfile)
-        print(f"Saving output to {config.outfile}")
+        outfile = config.outfile.replace("{dataset}","all")
+        save(output, outfile )
+        print(f"Saving output to {outfile}")
 
 
     elif 'parsl' in config.run_options['executor']:
@@ -181,8 +182,10 @@ if __name__ == '__main__':
                                         },
                                         chunksize=config.run_options['chunk'], maxchunks=config.run_options['max']
                                         )
-            save(output, config.outfile)
-            print(f"Saving output to {config.outfile}")
+
+            outfile = config.outfile.replace("{dataset}","all")
+            save(output, outfile )
+            print(f"Saving output to {outfile}")
     
         elif 'condor' in config.run_options['executor']:
             #xfer_files = [process_worker_pool, _x509_path]
@@ -322,8 +325,9 @@ if __name__ == '__main__':
                                         chunksize=config.run_options['chunk'],
                                         maxchunks=config.run_options['max']
                             )
-                print(f"Saving output to {config.outfile}")
-                save(output,config.outfile.replace("{dataset}","all"))
+                outfile = config.outfile.replace("{dataset}","all")
+                save(output, outfile )
+                print(f"Saving output to {outfile}")
             else:
                 # Running separately on each dataset
                 for sample, files in config.fileset.items():


### PR DESCRIPTION
Cleaned up the subsample implementation in the configurator and base processor. 

Histograms selection is done by **parent** sample for the moment. Instead, the column accumulator code is able to differentiate between subsamples in the configuration.  See `test_subsamples.py` configuration file. 

