### PR TITLE
Weights caching and column to_numpy to speedup histogram filling

### DIFF
--- a/pocket_coffea/lib/weights_manager.py
+++ b/pocket_coffea/lib/weights_manager.py
@@ -310,7 +310,7 @@ class WeightsManager:
                     variations=[shape_variation],
                     njets=events.nJetGood,
                 )
-                
+
             else:
                 # Only the nominal if there is a shape variation
                 # TODO Implement the varied btag for the JES variations

--- a/pocket_coffea/workflows/tthbb_base_processor.py
+++ b/pocket_coffea/workflows/tthbb_base_processor.py
@@ -79,6 +79,8 @@ class ttHbbBaseProcessor(BaseProcessorABC):
     # Function that defines common variables employed in analyses and save them as attributes of `events`
     def define_common_variables_before_presel(self, variation):
         self.events["JetGood_Ht"] = ak.sum(abs(self.events.JetGood.pt), axis=1)
+        self.events["nJetGoodCFlavour"] = ak.sum(self.events.JetGood.hadronFlavour==4, axis=1)
+        self.events["nJetGoodBFlavour"] = ak.sum(self.events.JetGood.hadronFlavour==5, axis=1)
 
     def fill_histograms_extra(self, variation):
         '''


### PR DESCRIPTION
The histogram filling has been speed up by caching the broadcasted weights, when the weights are event-level and the data_structure is 1-D. 

Moreover profiling the filling I observed that the `hist.fill()` method is much faster then we pass numpy arrays instead of awkward arrays. I have included a `to_numpy` while caching the variables to fill. 

This PR brings a ~30% speedup in the histogram filling phase, which with >10 categories can save quite a lot of time.