### PR TITLE
Working on improving sumgenweights and subsamples handling

### DIFF
--- a/notebooks/SumGenWeights.ipynb
+++ b/notebooks/SumGenWeights.ipynb
@@ -1,0 +1,890 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "513d0cb3-9c99-4d38-a136-a0f7b88fcb67",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from coffea.util import load\n",
+    "import numpy as np\n",
+    "from hist import Hist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "74051f9b-a689-4d4a-9dad-015c2bdec9e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df = load(\"/work/dvalsecc/ttHbb/AnalysisConfigs/configs/tests/output_tests_subsamples_v1/output_all.coffea\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "060748f3-0355-455b-ad8b-85f7ae9a9dfe",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'baseline': {'TTToSemiLeptonic': {'2017': 1474591054073537.8,\n",
+       "   '2018': 2314196834472307.5},\n",
+       "  'TTToSemiLeptonic__=1b': {'2017': 508774068364007.5,\n",
+       "   '2018': 772664401598814.8},\n",
+       "  'TTToSemiLeptonic__=2b': {'2017': 705592978256304.0,\n",
+       "   '2018': 1126592343516059.5},\n",
+       "  'TTToSemiLeptonic__>2b': {'2017': 162464457001657.6,\n",
+       "   '2018': 279895256971586.5}},\n",
+       " '1b': {'TTToSemiLeptonic': {'2017': 611386390863777.5,\n",
+       "   '2018': 941622792940661.2},\n",
+       "  'TTToSemiLeptonic__=1b': {'2017': 463341328363505.4,\n",
+       "   '2018': 703246377455417.9},\n",
+       "  'TTToSemiLeptonic__=2b': {'2017': 135336464167370.19,\n",
+       "   '2018': 216948342806848.03},\n",
+       "  'TTToSemiLeptonic__>2b': {'2017': 12708598332902.004,\n",
+       "   '2018': 21428072678395.203}},\n",
+       " '2b': {'TTToSemiLeptonic': {'2017': 633926531327971.2,\n",
+       "   '2018': 1021251071083066.4},\n",
+       "  'TTToSemiLeptonic__=1b': {'2017': 0.0, '2018': 0.0},\n",
+       "  'TTToSemiLeptonic__=2b': {'2017': 562627443843573.2,\n",
+       "   '2018': 898438125433768.5},\n",
+       "  'TTToSemiLeptonic__>2b': {'2017': 71299087484397.98,\n",
+       "   '2018': 122812945649297.77}},\n",
+       " '3b': {'TTToSemiLeptonic': {'2017': 73933827124137.58,\n",
+       "   '2018': 127093213652954.67},\n",
+       "  'TTToSemiLeptonic__=1b': {'2017': 0.0, '2018': 0.0},\n",
+       "  'TTToSemiLeptonic__=2b': {'2017': 0.0, '2018': 0.0},\n",
+       "  'TTToSemiLeptonic__>2b': {'2017': 73933827124137.58,\n",
+       "   '2018': 127093213652954.67}},\n",
+       " '4b': {'TTToSemiLeptonic': {'2017': 3781470409615.63,\n",
+       "   '2018': 7251014476547.143},\n",
+       "  'TTToSemiLeptonic__=1b': {'2017': 0.0, '2018': 0.0},\n",
+       "  'TTToSemiLeptonic__=2b': {'2017': 0.0, '2018': 0.0},\n",
+       "  'TTToSemiLeptonic__>2b': {'2017': 3781470409615.63,\n",
+       "   '2018': 7251014476547.143}}}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[\"sumw\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "50e49929-fe97-4a57-85b8-5e6bf7f1ece7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ElectronGood_eta_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\\\eta_{e}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.71541e+15, variance=6.7616e+25) (WeightedSum(value=1.47948e+16, variance=5.24538e+26) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\\\eta_{e}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=1.32372e+16, variance=8.63248e+25) (WeightedSum(value=2.19016e+16, variance=4.45985e+26) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\\\eta_{e}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.23652e+15, variance=2.24542e+25) (WeightedSum(value=5.18741e+15, variance=9.2496e+25) with flow)},\n",
+       " 'ElectronGood_pt_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 500, name='ElectronGood.pt', label='$p_{T}^{e}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.71516e+15, variance=6.76138e+25) (WeightedSum(value=1.47948e+16, variance=5.24538e+26) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 500, name='ElectronGood.pt', label='$p_{T}^{e}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=1.32358e+16, variance=8.63146e+25) (WeightedSum(value=2.19016e+16, variance=4.45985e+26) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 500, name='ElectronGood.pt', label='$p_{T}^{e}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.23538e+15, variance=2.24464e+25) (WeightedSum(value=5.18741e+15, variance=9.2496e+25) with flow)},\n",
+       " 'ElectronGood_phi_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='ElectronGood.phi', label='$\\\\phi_{e}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.71487e+15, variance=6.76125e+25) (WeightedSum(value=1.47948e+16, variance=5.24538e+26) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='ElectronGood.phi', label='$\\\\phi_{e}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=1.32367e+16, variance=8.63217e+25) (WeightedSum(value=2.19016e+16, variance=4.45985e+26) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='ElectronGood.phi', label='$\\\\phi_{e}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.23634e+15, variance=2.24531e+25) (WeightedSum(value=5.18741e+15, variance=9.2496e+25) with flow)},\n",
+       " 'ElectronGood_etaSC_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Variable(array([-2.5   , -2.3   , -2.1   , -1.9   , -1.7   , -1.566 , -1.4442,\n",
+       "         -1.2   , -1.    , -0.8   , -0.6   , -0.4   , -0.2   ,  0.    ,\n",
+       "          0.2   ,  0.4   ,  0.6   ,  0.8   ,  1.    ,  1.2   ,  1.4442,\n",
+       "          1.566 ,  1.7   ,  1.9   ,  2.1   ,  2.3   ,  2.5   ]), name='ElectronGood.etaSC', label='Electron Supercluster $\\\\eta$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.71541e+15, variance=6.7616e+25) (WeightedSum(value=1.47948e+16, variance=5.24538e+26) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Variable(array([-2.5   , -2.3   , -2.1   , -1.9   , -1.7   , -1.566 , -1.4442,\n",
+       "         -1.2   , -1.    , -0.8   , -0.6   , -0.4   , -0.2   ,  0.    ,\n",
+       "          0.2   ,  0.4   ,  0.6   ,  0.8   ,  1.    ,  1.2   ,  1.4442,\n",
+       "          1.566 ,  1.7   ,  1.9   ,  2.1   ,  2.3   ,  2.5   ]), name='ElectronGood.etaSC', label='Electron Supercluster $\\\\eta$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=1.32372e+16, variance=8.63248e+25) (WeightedSum(value=2.19016e+16, variance=4.45985e+26) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Variable(array([-2.5   , -2.3   , -2.1   , -1.9   , -1.7   , -1.566 , -1.4442,\n",
+       "         -1.2   , -1.    , -0.8   , -0.6   , -0.4   , -0.2   ,  0.    ,\n",
+       "          0.2   ,  0.4   ,  0.6   ,  0.8   ,  1.    ,  1.2   ,  1.4442,\n",
+       "          1.566 ,  1.7   ,  1.9   ,  2.1   ,  2.3   ,  2.5   ]), name='ElectronGood.etaSC', label='Electron Supercluster $\\\\eta$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.23652e+15, variance=2.24542e+25) (WeightedSum(value=5.18741e+15, variance=9.2496e+25) with flow)},\n",
+       " 'MuonGood_eta_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='MuonGood.eta', label='$\\\\eta_{\\\\mu}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=1.34695e+16, variance=1.09344e+26) (WeightedSum(value=2.21373e+16, variance=7.67754e+26) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='MuonGood.eta', label='$\\\\eta_{\\\\mu}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.04557e+16, variance=1.39631e+26) (WeightedSum(value=3.30414e+16, variance=6.12163e+26) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='MuonGood.eta', label='$\\\\eta_{\\\\mu}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=5.15826e+15, variance=3.72467e+25) (WeightedSum(value=8.12138e+15, variance=2.11236e+26) with flow)},\n",
+       " 'MuonGood_pt_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 500, name='MuonGood.pt', label='$p_{T}^{\\\\mu}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=1.34697e+16, variance=1.0934e+26) (WeightedSum(value=2.21373e+16, variance=7.67754e+26) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 500, name='MuonGood.pt', label='$p_{T}^{\\\\mu}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.04536e+16, variance=1.39613e+26) (WeightedSum(value=3.30414e+16, variance=6.12163e+26) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 500, name='MuonGood.pt', label='$p_{T}^{\\\\mu}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=5.15811e+15, variance=3.7246e+25) (WeightedSum(value=8.12138e+15, variance=2.11236e+26) with flow)},\n",
+       " 'MuonGood_phi_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='MuonGood.phi', label='$\\\\phi_{\\\\mu}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=1.34693e+16, variance=1.09343e+26) (WeightedSum(value=2.21373e+16, variance=7.67754e+26) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='MuonGood.phi', label='$\\\\phi_{\\\\mu}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.04544e+16, variance=1.39624e+26) (WeightedSum(value=3.30414e+16, variance=6.12163e+26) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='MuonGood.phi', label='$\\\\phi_{\\\\mu}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=5.15744e+15, variance=3.72408e+25) (WeightedSum(value=8.12138e+15, variance=2.11236e+26) with flow)},\n",
+       " 'nElectronGood': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(3, 0, 3, name='events.nElectronGood', label='$N_{ElectronGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(3, 0, 3, name='events.nElectronGood', label='$N_{ElectronGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(3, 0, 3, name='events.nElectronGood', label='$N_{ElectronGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'nMuonGood': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(3, 0, 3, name='events.nMuonGood', label='$N_{MuonGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(3, 0, 3, name='events.nMuonGood', label='$N_{MuonGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(3, 0, 3, name='events.nMuonGood', label='$N_{MuonGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'nJets': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(10, 4, 14, name='events.nJetGood', label='$N_{JetGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(10, 4, 14, name='events.nJetGood', label='$N_{JetGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36927e+16, variance=2.25955e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(10, 4, 14, name='events.nJetGood', label='$N_{JetGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39464e+15, variance=5.97003e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'nBJets': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(12, 2, 14, name='events.nBJetGood', label='$N_{BJetGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=0, variance=0) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(12, 2, 14, name='events.nBJetGood', label='$N_{BJetGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.70033e+16, variance=1.7662e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(12, 2, 14, name='events.nBJetGood', label='$N_{BJetGood}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=7.73645e+15, variance=5.47418e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_eta_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_pt_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21792e+16, variance=1.76901e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36865e+16, variance=2.25875e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39104e+15, variance=5.96563e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_phi_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21831e+16, variance=1.76947e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36889e+16, variance=2.25931e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39419e+15, variance=5.96971e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_btagDeepFlavB_1': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_eta_2': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_pt_2': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21843e+16, variance=1.76955e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36918e+16, variance=2.25941e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_phi_2': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21831e+16, variance=1.76947e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36914e+16, variance=2.25946e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39383e+15, variance=5.96947e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_btagDeepFlavB_2': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_eta_3': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_pt_3': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(100, 0, 1000, name='JetGood.pt', label='$p_{T}^{j}$ [GeV]'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_phi_3': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21847e+16, variance=1.76959e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36909e+16, variance=2.25943e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(64, -3.14159, 3.14159, name='JetGood.phi', label='$\\\\phi_{j}$'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39397e+15, variance=5.96936e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)},\n",
+       " 'JetGood_btagDeepFlavB_3': {'TTToSemiLeptonic__=1b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26) (WeightedSum(value=3.69321e+16, variance=1.29229e+27) with flow),\n",
+       "  'TTToSemiLeptonic__=2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=3.36929e+16, variance=2.25956e+26) (WeightedSum(value=5.4943e+16, variance=1.05815e+27) with flow),\n",
+       "  'TTToSemiLeptonic__>2b': Hist(\n",
+       "    StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "    StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "    StrCategory(['2018'], name='year', label='Year'),\n",
+       "    Regular(50, 0, 1, name='JetGood.btagDeepFlavB', label='AK4 DeepJet b-tag score'),\n",
+       "    storage=Weight()) # Sum: WeightedSum(value=8.39478e+15, variance=5.97009e+25) (WeightedSum(value=1.33088e+16, variance=3.03732e+26) with flow)}}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[\"variables\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3a00eea0-ac19-4ec7-9cf7-3b87249d05b3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "H = df[\"variables\"][\"JetGood_eta_1\"][\"TTToSemiLeptonic__=1b\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c2c64f00-feee-4bb2-a523-6ec2e3fbb058",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Hist(\n",
+       "  StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "  StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "  Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "  storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "H[{\"year\":'2018'}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "af5b5096-279e-4d83-baa1-2b296b64b1a1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Not supported yet",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mH\u001b[49m\u001b[43m[\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43myear\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m2018\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m]\u001b[49m \u001b[38;5;241m=\u001b[39m H[{\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124myear\u001b[39m\u001b[38;5;124m\"\u001b[39m:\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m2018\u001b[39m\u001b[38;5;124m'\u001b[39m}]\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m2\u001b[39m\n",
+      "File \u001b[0;32m~/micromamba/envs/pocket-coffea/lib/python3.9/site-packages/hist/basehist.py:333\u001b[0m, in \u001b[0;36mBaseHist.__setitem__\u001b[0;34m(self, index, value)\u001b[0m\n\u001b[1;32m    326\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__setitem__\u001b[39m(  \u001b[38;5;66;03m# type: ignore[override]\u001b[39;00m\n\u001b[1;32m    327\u001b[0m     \u001b[38;5;28mself\u001b[39m, index: IndexingExpr, value: ArrayLike \u001b[38;5;241m|\u001b[39m bh\u001b[38;5;241m.\u001b[39maccumulators\u001b[38;5;241m.\u001b[39mAccumulator\n\u001b[1;32m    328\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    329\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    330\u001b[0m \u001b[38;5;124;03m    Set histogram item.\u001b[39;00m\n\u001b[1;32m    331\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 333\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__setitem__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_index_transform\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/micromamba/envs/pocket-coffea/lib/python3.9/site-packages/boost_histogram/_internal/hist.py:1002\u001b[0m, in \u001b[0;36mHistogram.__setitem__\u001b[0;34m(self, index, value)\u001b[0m\n\u001b[1;32m    999\u001b[0m indexes \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_compute_commonindex(index)\n\u001b[1;32m   1001\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(value, Histogram):\n\u001b[0;32m-> 1002\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNot supported yet\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m   1004\u001b[0m value \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39masarray(value)\n\u001b[1;32m   1005\u001b[0m view \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mview(flow\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n",
+      "\u001b[0;31mTypeError\u001b[0m: Not supported yet"
+     ]
+    }
+   ],
+   "source": [
+    "H[{\"year\":'2018'}] = H[{\"year\":'2018'}]*2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "0323cdcb-2cb2-46a0-b45e-166f4ade9b3b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       " StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       " StrCategory(['2018'], name='year', label='Year'),\n",
+       " Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'))"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "H.axes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "599a768b-1d48-44f8-bb12-300998ea53dd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sumgenw = df[\"sum_genweights\"][\"TTToSemiLeptonic__=1b\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "2865a114-05e7-4900-a50d-442a96bf5041",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "794553340.0"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sumgenw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "c280e84c-5aa6-4883-af4a-6a9a1e8666b3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "rescale_tensor  = np.zeros(H.values().shape[-2:])\n",
+    "rescale_tensor[0,:] = 794553340.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "cc9d2b8c-0fb6-4dbd-be47-b092dc1c796e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08, 7.9455334e+08, 7.9455334e+08,\n",
+       "        7.9455334e+08, 7.9455334e+08]])"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rescale_tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "ec54d7b0-bab9-4fa0-af15-d3b69b2a0c08",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5, 15, 1, 50)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "H.values().shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "2ae52c75-da42-4885-a818-efb1a8ea3b67",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "new_W = H.view() / rescale_tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "32f5d531-8629-4607-912c-6a5e934cece8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "new_h  = H.values() / rescale_tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "e6a84245-aae6-4c73-9096-1a999f9c489d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "new_hist = H.copy().reset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "3fd16d5a-ae89-47c5-b877-9e9289d1d3d3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Hist(\n",
+       "  StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "  StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "  StrCategory(['2018'], name='year', label='Year'),\n",
+       "  Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "  storage=Weight()) # Sum: WeightedSum(value=0, variance=0)"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_hist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "cb6639ec-178d-4209-95f9-14886e2fb16d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "new_hist[{}] = new_W"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "fca5361d-1c7a-4a09-b876-b54f3add3da9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Hist(\n",
+       "  StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "  StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "  StrCategory(['2018'], name='year', label='Year'),\n",
+       "  Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "  storage=Weight()) # Sum: WeightedSum(value=2.79212e+07, variance=2.80304e+08)"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_hist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "682fa569-b756-4ac7-a211-4d0d34f6be4f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Hist(\n",
+       "  StrCategory(['1b', '2b', '3b', '4b', 'baseline'], name='cat', label='Category'),\n",
+       "  StrCategory(['nominal', 'pileupDown', 'pileupUp', 'sf_btagDown', 'sf_btagUp', 'sf_ele_idDown', 'sf_ele_idUp', 'sf_ele_recoDown', 'sf_ele_recoUp', 'sf_jet_puIdDown', 'sf_jet_puIdUp', 'sf_mu_idDown', 'sf_mu_idUp', 'sf_mu_isoDown', 'sf_mu_isoUp'], name='variation', label='Variation'),\n",
+       "  StrCategory(['2018'], name='year', label='Year'),\n",
+       "  Regular(50, -2.5, 2.5, name='JetGood.eta', label='$\\\\eta_{j}$'),\n",
+       "  storage=Weight()) # Sum: WeightedSum(value=2.21849e+16, variance=1.7696e+26)"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "H"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eac69386-deab-4626-8d14-e2e581e1a9b0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pocket_coffea/lib/columns_manager.py
+++ b/pocket_coffea/lib/columns_manager.py
@@ -17,7 +17,7 @@ class ColOut:
 
 
 class ColumnsManager:
-    def __init__(self, cfg, sample, categories_config):
+    def __init__(self, cfg, categories_config):
         self.cfg = cfg
         self.categories_config = categories_config
 

--- a/pocket_coffea/lib/cut_functions.py
+++ b/pocket_coffea/lib/cut_functions.py
@@ -21,7 +21,7 @@ def _get_trigger_mask_proxy(events, params, processor_params, year, isMC, **kwar
     )
 
 
-def get_HLTsel(key, primaryDatasets=None, invert=False):
+def get_HLTsel(primaryDatasets=None, invert=False):
     '''Create the HLT trigger mask
 
     The Cut function reads the triggers configuration and create the mask.
@@ -32,14 +32,13 @@ def get_HLTsel(key, primaryDatasets=None, invert=False):
 
     This is useful to remove the overlap of primary datasets in data.
 
-    :param key: Key in the trigger configuration for the list of triggers to apply
     :param primaryDatasets: (optional) list of primaryDatasets to use. Overwrites any other config
                                       both for Data and MC
     :param invert: invert the mask, if True the function returns events failing the HLT selection
 
     :returns: events mask
     '''
-    name = f"HLT_{key}"
+    name = "HLT_trigger"
     if primaryDatasets:
         name += "_" + "_".join(primaryDatasets)
     if invert:

--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -40,11 +40,11 @@ class HistConf:
     no_weights: bool = False  # Do not fill the weights
     metadata_hist: bool = False  # Non-event variables, for processing metadata
     hist_obj = None
-    collapse_2D_masks = False # if 2D masks are applied on the events
-                              # and the data_ndim=1, when collapse_2D_mask=True the OR
-                              # of the masks on the axis=2 is performed to get the mask
-                              # on axis=1, otherwise an exception is raised
-    collapse_2D_masks_mode = "OR" # Use OR or AND to collapse 2D masks for data_ndim=1 if collapse_2D_masks == True
+    collapse_2D_masks = False  # if 2D masks are applied on the events
+    # and the data_ndim=1, when collapse_2D_mask=True the OR
+    # of the masks on the axis=2 is performed to get the mask
+    # on axis=1, otherwise an exception is raised
+    collapse_2D_masks_mode = "OR"  # Use OR or AND to collapse 2D masks for data_ndim=1 if collapse_2D_masks == True
 
     def serialize(self):
         out = {**self.__dict__}
@@ -434,7 +434,7 @@ class HistManager:
                     # In this case the mask is reduced to per-event mask
                     # doing a logical OR only if explicitely allowed by the user
                     # WARNING!! POTENTIAL PROBLEMATIC BEHAVIOUR
-                    # The user must be aware of the behavior. 
+                    # The user must be aware of the behavior.
 
                     if data_ndim == 1 and mask.ndim > 1:
                         if histo.collapse_2D_masks:
@@ -443,24 +443,26 @@ class HistManager:
                             elif histo.collapse_2D_masks_mode == "AND":
                                 mask = ak.all(mask, axis=1)
                             else:
-                                raise Exception("You want to collapse the 2D masks on 1D data but the `collapse_2D_masks_mode` is not 'AND/OR'")
-                            
+                                raise Exception(
+                                    "You want to collapse the 2D masks on 1D data but the `collapse_2D_masks_mode` is not 'AND/OR'"
+                                )
+
                         else:
-                            raise Exception("+++++ BE AWARE! This is a possible mis-behavior! +++++\n"+
-                                            f"You are trying to fill the histogram {name} with data of dimention 1 (variable by event)"+
-                                            "and masking it with a mask with more than 1 dimension (e.g. mask on Jets)\n"+
-                                            "This means that you are either performing a cut on a collections (e.g Jets),"+
-                                            " or you are using subsamples with cuts on collections.\n"+
-                                            "\n As an example of a bad behaviour would be saving the pos=1 of a collection e.g. `JetGood.pt[1]`\n"+
-                                            "while also having a 2D cut on the `JetGood` collection --> this is not giving you the second jet passing the cut!\n"+
-                                            "In that case the 2nd JetGood.pt will be always plotted even if masked by the 2D cut: in fact "+
-                                            "the 2D masks would be collapsed to the event dimension. \n\n"
-                                            "If you really wish to save the histogram with a single value for event (data dim=1)
-                                            you can do so by configuring the histogram with `collapse_2D_masks=True\n"+
-                                            "The 2D masks will be collapsed on the event dimension (axis=1) doing an OR (default) or an AND\n"+
-                                            "You can configure this behaviour with `collapse_2D_masks_mode='OR'/'AND'` in the histo configuration."
-                                            )
-                    
+                            raise Exception(
+                                "+++++ BE AWARE! This is a possible mis-behavior! +++++\n"
+                                + f"You are trying to fill the histogram {name} with data of dimention 1 (variable by event)"
+                                + "and masking it with a mask with more than 1 dimension (e.g. mask on Jets)\n"
+                                + "This means that you are either performing a cut on a collections (e.g Jets),"
+                                + " or you are using subsamples with cuts on collections.\n"
+                                + "\n As an example of a bad behaviour would be saving the pos=1 of a collection e.g. `JetGood.pt[1]`\n"
+                                + "while also having a 2D cut on the `JetGood` collection --> this is not giving you the second jet passing the cut!\n"
+                                + "In that case the 2nd JetGood.pt will be always plotted even if masked by the 2D cut: in fact "
+                                + "the 2D masks would be collapsed to the event dimension. \n\n"
+                                + "If you really wish to save the histogram with a single value for event (data dim=1)"
+                                + "you can do so by configuring the histogram with `collapse_2D_masks=True\n"
+                                + "The 2D masks will be collapsed on the event dimension (axis=1) doing an OR (default) or an AND\n"
+                                + "You can configure this behaviour with `collapse_2D_masks_mode='OR'/'AND'` in the histo configuration."
+                            )
 
                     # Mask the variables and flatten them
                     # save the isnotnone and datastructure

--- a/pocket_coffea/lib/weights_manager.py
+++ b/pocket_coffea/lib/weights_manager.py
@@ -131,7 +131,6 @@ class WeightsManager:
         self._sample = metadata["sample"]
         self._year = metadata["year"]
         self._xsec = metadata["xsec"]
-        self._sum_genweights = float(metadata["sum_genweights"])
         self._shape_variation = shape_variation
         self.weightsConf = weightsConf
         self.storeIndividual = storeIndividual
@@ -222,7 +221,7 @@ class WeightsManager:
         in the constructor.
         '''
         if weight_name == "genWeight":
-            return [('genWeight', events.genWeight / self._sum_genweights)]
+            return [('genWeight', events.genWeight)]
         elif weight_name == 'lumi':
             return [
                 (

--- a/pocket_coffea/utils/configurator.py
+++ b/pocket_coffea/utils/configurator.py
@@ -563,7 +563,7 @@ class Configurator:
             f"  - Preselection: {[c.name for c in self.preselections]}",
             f"  - Categories: {self.categories}",
             f"  - Variables:  {list(self.variables.keys())}",
-            f"  - Columns: {self.columns}",
+            # f"  - Columns: {self.columns}",
             f"  - available weights variations: {self.available_weights_variations} ",
             f"  - available shape variations: {self.available_shape_variations}",            
         ]

--- a/pocket_coffea/utils/configurator.py
+++ b/pocket_coffea/utils/configurator.py
@@ -56,7 +56,7 @@ class Configurator:
         # Load dataset
         self.datasets_cfg = datasets
         # The following attributes are loaded by load_datasets
-        self.fileset = {}
+        self.filesets = {}
         self.datasets = []
         self.samples = []
 
@@ -157,30 +157,27 @@ class Configurator:
                         if ds["metadata"]["year"] not in ds_filter["year"]:
                             pass_filter = False
                     if pass_filter:
-                        self.fileset[key] = ds
+                        self.filesets[key] = ds
             else:
-                self.fileset.update(ds_dict)
+                self.filesets.update(ds_dict)
 
-        # Now loading and storing the metadata of the filtered fileset
-        if len(self.fileset) == 0:
+        # Now loading and storing the metadata of the filtered filesets
+        if len(self.filesets) == 0:
             print("File set is empty: please check you dataset definition...")
-            raise Exception("Wrong fileset configuration")
+            raise Exception("Wrong filesets configuration")
         else:
-            for name, d in self.fileset.items():
+            for name, d in self.filesets.items():
                 m = d["metadata"]
                 if name not in self.datasets:
                     self.datasets.append(name)
-                if (m["sample"]) not in self.samples:
+                if m["sample"] not in self.samples:
                     self.samples.append(m["sample"])
+                if m["year"] not in self.years:
                     self.years.append(m["year"])
                 if 'era' in m.keys():
                     if (m["era"]) not in self.eras:
                         self.eras.append(m["era"])
                         
-        # Check for overlap
-        data_list = {}
-        mc_list = {}
-        
 
     def load_subsamples(self):
         # subsamples configuration
@@ -457,11 +454,14 @@ class Configurator:
                                 self.columns[sample][cat].append(w)
 
     def filter_dataset(self, nfiles):
-        filtered_dataset = {}
-        for sample, ds in self.fileset.items():
+        filtered_filesets = {}
+        filtered_datasets = []
+        for dataset_name, ds in self.filesets.items():
             ds["files"] = ds["files"][0:nfiles]
-            filtered_dataset[sample] = ds
-        self.fileset = filtered_dataset
+            filtered_filesets[dataset_name] = ds
+            filtered_datasets.append(dataset_name)
+        self.filesets = filtered_filesets
+        self.datasets = filtered_datasets
 
     def load_workflow(self):
         self.processor_instance = self.workflow(cfg=self)
@@ -471,7 +471,7 @@ class Configurator:
         ocfg["datasets"] = {
             "names": self.datasets,
             "samples": self.samples,
-            "fileset": self.fileset,
+            "filesets": self.filesets,
         }
 
         subsamples_cuts = self.subsamples
@@ -547,15 +547,15 @@ class Configurator:
         s = [
             'Configurator instance:',
             f"  - Workflow: {self.workflow}",
-            f"  - N. samples: {len(self.samples)} "]
+            f"  - N. datasets: {len(self.datasets)} "]
 
-        for dataset, meta in self.fileset.items():
+        for dataset, meta in self.filesets.items():
             metadata = meta["metadata"]
             s.append(f"   -- Dataset: {dataset},  Sample: {metadata['sample']}, N. files: {len(meta['files'])}, N. events: {metadata['nevents']}")
 
         s.append( f"  - Subsamples:")
         for subsample, cuts in self.subsamples.items():
-            s.append(f"   -- Subsample {subsample}: {cuts}")
+            s.append(f"   -- Sample {subsample}: {cuts}")
 
         s += [
            

--- a/pocket_coffea/utils/dataset.py
+++ b/pocket_coffea/utils/dataset.py
@@ -157,7 +157,10 @@ class Dataset:
     # Function to build the dataset dictionary
     def get_samples(self, files):
         for scfg in files:
-            sname = f"{self.name}_{scfg['metadata']['year']}"
+            if 'part' in scfg['metadata']:
+                sname = f"{self.name}_{scfg['metadata']['part']}_{scfg['metadata']['year']}"
+            else:
+                sname = f"{self.name}_{scfg['metadata']['year']}"
             if not scfg["metadata"]["isMC"]:
                 sname += f"_Era{scfg['metadata']['era']}"
             if "dbs_instance" in scfg.keys():

--- a/pocket_coffea/workflows/tthbb_base_processor.py
+++ b/pocket_coffea/workflows/tthbb_base_processor.py
@@ -14,20 +14,6 @@ from ..lib.objects import (
 
 
 class ttHbbBaseProcessor(BaseProcessorABC):
-    def __init__(self, cfg: Configurator):
-        super().__init__(cfg)
-        # Additional axis for the year
-        self.custom_axes.append(
-            Axis(
-                coll="metadata",
-                field="year",
-                name="year",
-                bins=set(sorted(self.cfg.years)),
-                type="strcat",
-                growth=False,
-                label="Year",
-            )
-        )
 
     def apply_object_preselection(self, variation):
         '''

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
             _exec = processor.iterative_executor
         else:
             _exec = processor.futures_executor
-        output = processor.run_uproot_job(config.fileset,
+        output = processor.run_uproot_job(config.filesets,
                                     treename='Events',
                                     processor_instance=config.processor_instance,
                                     executor=_exec,
@@ -196,7 +196,7 @@ if __name__ == '__main__':
             )
             dfk = parsl.load(slurm_htex)
 
-            output = processor.run_uproot_job(config.fileset,
+            output = processor.run_uproot_job(config.filesets,
                                         treename='Events',
                                         processor_instance=config.processor_instance,
                                         executor=processor.parsl_executor,
@@ -259,7 +259,7 @@ if __name__ == '__main__':
                 )
             dfk = parsl.load(condor_htex)
 
-            output = processor.run_uproot_job(config.fileset,
+            output = processor.run_uproot_job(config.filesets,
                                         treename='Events',
                                         processor_instance=config.processor_instance,
                                         executor=processor.parsl_executor,
@@ -353,7 +353,7 @@ if __name__ == '__main__':
 
             if args.full:
                 # Running separately on each dataset
-                fileset = config.fileset
+                fileset = config.filesets
                 logging.info(f"Working on samples: {list(fileset.keys())}")
                 
                 output = processor.run_uproot_job(fileset,
@@ -374,7 +374,7 @@ if __name__ == '__main__':
                 save(output, outfile.format("all") )
             else:
                 # Running separately on each dataset
-                for sample, files in config.fileset.items():
+                for sample, files in config.filesets.items():
                     logging.info(f"Working on sample: {sample}")
                     fileset = {sample:files}
                     

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -54,6 +54,7 @@ if __name__ == '__main__':
         print("Failed to setup logging, aborting.")
         exit(1) 
 
+    print("Loading the configuration file...")
     if args.cfg[-3:] == ".py":
         # Load the script
         config_module =  utils.path_import(args.cfg)

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -41,6 +41,12 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
 
+    # Setting up the output dir
+    os.makedirs(args.outputdir, exist_ok=True)
+    outfile = os.path.join(
+        args.outputdir, "output_{}.coffea"
+    )
+    
     # Prepare logging
     if (not setup_logging(console_log_output="stdout", console_log_level=args.loglevel, console_log_color=True,
                         logfile_file="last_run.log", logfile_log_level="info", logfile_log_color=False,
@@ -88,14 +94,9 @@ if __name__ == '__main__':
     if args.executor !=None:
         run_options["executor"] = args.executor
 
-    # Setting up the output dir
-    os.makedirs(args.outputdir, exist_ok=True)
-    outfile = os.path.join(
-        args.outputdir, "output_{}.coffea"
-    )
     #### Fixing the environment (assuming this is run in singularity)
     # dask/parsl needs to export x509 to read over xrootd
-    if run_options['voms'] is not None:
+    if run_options.get('voms', None) is not None:
         _x509_path = run_options['voms']
     else:
         _x509_localpath = get_proxy_path()
@@ -149,12 +150,12 @@ if __name__ == '__main__':
                                     processor_instance=config.processor_instance,
                                     executor=_exec,
                                     executor_args={
-                                        'skipbadfiles':run_options['skipbadfiles'],
+                                        'skipbadfiles':run_options.get('skipbadfiles'),
                                         'schema': processor.NanoAODSchema,
                                         'xrootdtimeout': run_options.get('xrootdtimeout', 600),
                                         'workers': run_options['scaleout']},
                                     chunksize=run_options['chunk'],
-                                    maxchunks=run_options['max']
+                                    maxchunks=run_options.get('max', None)
                                     )
         
         save(output, outfile.format("all"))
@@ -204,7 +205,7 @@ if __name__ == '__main__':
                                             'schema': processor.NanoAODSchema,
                                             'config': None,
                                         },
-                                        chunksize=run_options['chunk'], maxchunks=run_options['max']
+                                        chunksize=run_options['chunk'], maxchunks=run_options.get('max', None)
                                         )
 
             save(output, outfile.format("all") )
@@ -267,7 +268,7 @@ if __name__ == '__main__':
                                             'schema': processor.NanoAODSchema,
                                             'config': None,
                                         },
-                                        chunksize=run_options['chunk'], maxchunks=run_options['max']
+                                        chunksize=run_options['chunk'], maxchunks=run_options.get('max', None)
                                         )
             save(output, outfile.format("all"))
             print(f"Saving output to {outfile.format('all')}")
@@ -361,13 +362,13 @@ if __name__ == '__main__':
                                         executor=processor.dask_executor,
                                         executor_args={
                                             'client': client,
-                                            'skipbadfiles':run_options['skipbadfiles'],
+                                            'skipbadfiles': run_options.get('skipbadfiles',False),
                                             'schema': processor.NanoAODSchema,
                                             'retries' : run_options['retries'],
                                             'treereduction' : run_options.get('treereduction', 20)
                                         },
                                         chunksize=run_options['chunk'],
-                                        maxchunks=run_options['max']
+                                        maxchunks=run_options.get('max', None)
                             )
                 print(f"Saving output to {outfile.format('all')}")
                 save(output, outfile.format("all") )
@@ -383,13 +384,13 @@ if __name__ == '__main__':
                                             executor=processor.dask_executor,
                                             executor_args={
                                                 'client': client,
-                                                'skipbadfiles':run_options['skipbadfiles'],
+                                                'skipbadfiles': run_options.get('skipbadfiles',False),
                                                 'schema': processor.NanoAODSchema,
                                                 'retries' : run_options['retries'],
                                                 'treereduction' : run_options.get('treereduction', 20)
                                             },
                                             chunksize=run_options['chunk'],
-                                            maxchunks=run_options['max']
+                                            maxchunks=run_options.get('max', None)
                                 )
                     print(f"Saving output to {outfile.format(sample)}")
                     save(output, outfile.format(sample))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pocket_coffea
-version=0.1.0
+version=0.2.0
 description = Configurable analysis framework based on Coffea for CMS NanoAOD events analysis
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
In order to be able to rescale automatically the histograms without precomputing the sum of the genweights, we had restructured the output of the processor to save histograms by `dataset` instead of already regrouping by sample in the processor. 

The datasets and samples (subsamples) handling has been improved. 

A `datasets_metadata` dictionary has been added in the output to make easier the regrouping of the histograms at plotting/handling level. 

N.B: **The year is no more an axis in the histograms**. Since each dataset is already split by year, there is no need to create a year axis. The year metadata for each dataset is saved in `datasets_metadata`, but it is not manipulated otherwise.