### PR TITLE
Define new metrics for matching

### DIFF
--- a/pocket_coffea/lib/deltaR_matching.py
+++ b/pocket_coffea/lib/deltaR_matching.py
@@ -69,6 +69,12 @@ def get_matching_objects_indices_padnone(
 def metric_pt(obj, obj2):
     return abs(obj.pt - obj2.pt)
 
+def metric_eta(obj, obj2):
+    return abs(obj.eta - obj2.eta)
+
+def metric_phi(obj, obj2):
+    return abs(obj.phi - obj2.phi)
+
 
 def object_matching(obj, obj2, dr_min, dpt_max=None, return_indices=False):
     # Compute deltaR(quark, jet) and save the nearest jet (deltaR matching)


### PR DESCRIPTION
Two extra metric functions are included in order to compute the $\Delta\eta$ and $\Delta\phi$ distance between objects.