### PR TITLE
Bugfix: Decorrelate JERC between AK4 and AK8 jets

### DIFF
--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -657,20 +657,24 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
 
                 
             elif ("JES" in variation) | ("JER" in variation):
-                # We recover the variation name from the string by stripping the jet type string
-                variation_name = '_'.join(variation.split("_")[:-1])
                 # JES_jes is the total. JES_[type] is for different variations
+                # We recover the variation name and the jet type by splitting the variation name
+                variation_name = '_'.join(variation.split("_")[:-1])
+                jet_type = variation.split("_")[-1]
                 self.events = nominal_events
-                for jet_coll_name, jet_coll in jets_calibrated.items():
-                    self.events[jet_coll_name] = jet_coll[variation_name].up
+
+                # We vary ONLY the jet collection corresponding to the jet type in the variation name
+                # This way, we vary independently the different jet types
+                # e.g. `JES_Total_AK4PFchs` will vary only the `AK4PFchs` jets,
+                # while `JES_Total_AK8PFPuppi` will vary only the `AK8PFPuppi` jets
+                jet_coll_name = jet_calib_params.collection[jet_type]
+                self.events[jet_coll_name] = jets_calibrated[jet_coll_name][variation_name].up
 
                 yield variation + "Up"
 
-                # then go down
-                # restore nominal before going to down
+                # restore nominal before saving the down-variated collection
                 self.events = nominal_events
-                for jet_coll_name, jet_coll in jets_calibrated.items():
-                    self.events[jet_coll_name] = jet_coll[variation_name].down
+                self.events[jet_coll_name] = jets_calibrated[jet_coll_name][variation_name].down
                 
                 yield variation + "Down"
 


### PR DESCRIPTION
In the previous implementation, the JES and JER variations were applied simultaneously to the AK4 and AK8 jets. For instance, this means that the histograms corresponding to `JES_TotalUp` and `JES_TotalDown` were produced by varying the AK4 and AK8 JES in the same direction at the same time.

In the new implementation, we decorrelate the jet variations for the AK4 and AK8 jets by adding an additional suffix `_AK4PFchs` or `_AK8PFPuppi` to the JES/JER variation in order to specify which collection has to be varied.
In this way, only the collection that is specified in the suffix of the variation is varied. If both collections need to be varied, then one has to specify the two independent variations in the variations config. As an example, the following snippet of code uses the newest scheme for the jet variations:

```
variations = {
        "weights": {
            "common": {
                "inclusive": [  "pileup", ],
                "bycategory" : {
                }
            },
            "bysample": {
            }
        },
        "shape": {
            "common":{
                "inclusive": [ "JES_Total_AK4PFchs", "JER_AK8PFPuppi" ]
            }
        }
    },
```

The two variations `JES_Total_AK4PFchs` and `JER_AK8PFPuppi` are applied in this case:
- `JES_Total_AK4PFchs` will vary the total JES of  the AK4 jets
- `JER_AK8PFPuppi` will vary the JER of the AK8 jets

In this example, the output histograms for MC will have the following variations:
```
StrCategory(['nominal', 'JER_AK8PFPuppiDown', 'JER_AK8PFPuppiUp', 'JES_Total_AK4PFchsDown', 'JES_Total_AK4PFchsUp', 'pileupDown', 'pileupUp'], name='variation', label='Variation')
```

The available variations are defined in the `available_variations()` class method of the `BaseProcessorABC` in `pocket_coffea/workflows/base.py`, where the available jet types are also reported. Since these jet types are specific for the datasets of the Run 2 CMS UL campaign, a change might be needed in the future if the jet collections will change and a better parametrization of the available jet types will be needed.

The syntax `JES_Total` and `JER` will no longer work as the jet type always needs to be specified as a suffix.

Example output histogram with the semileptonic ttHbb preselection:
```
nominal
Hist(Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\eta_{e}$'), storage=Weight()) # Sum: WeightedSum(value=68078.3, variance=1.15073e+06)

JER_AK8PFPuppiDown
Hist(Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\eta_{e}$'), storage=Weight()) # Sum: WeightedSum(value=68078.3, variance=1.15073e+06)

JER_AK8PFPuppiUp
Hist(Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\eta_{e}$'), storage=Weight()) # Sum: WeightedSum(value=68078.3, variance=1.15073e+06)

JES_Total_AK4PFchsDown
Hist(Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\eta_{e}$'), storage=Weight()) # Sum: WeightedSum(value=63696.3, variance=1.07685e+06)

JES_Total_AK4PFchsUp
Hist(Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\eta_{e}$'), storage=Weight()) # Sum: WeightedSum(value=71698.2, variance=1.2119e+06)

pileupDown
Hist(Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\eta_{e}$'), storage=Weight()) # Sum: WeightedSum(value=67825.6, variance=1.15836e+06)

pileupUp
Hist(Regular(50, -2.5, 2.5, name='ElectronGood.eta', label='$\\eta_{e}$'), storage=Weight()) # Sum: WeightedSum(value=68419.4, variance=1.24121e+06)
```

We can check that the total event yield is changing for the `JES_Total_AK4PFchsUp` and `JES_Total_AK4PFchsDown` variations, while it's not changing for the `JER_AK8PFPuppiUp` and `JER_AK8PFPuppiDown` variations. This is due to the fact that the event preselection depends on the AK4 jets, but does not depend on the AK8 jets, therefore these latter variations are equal to the nominal.
