### PR TITLE
Adding jet C-tagging, improving Parsl runner, logger, and minor bugfixes

### DIFF
--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -234,6 +234,8 @@ def btagging(Jet, btag):
     return Jet[Jet[btag["btagging_algorithm"]] > btag["btagging_WP"]]
 
 
+def CvsLsorted(jets, ctag):
+    return jets[ak.argsort(jets[ctag["tagger"]], axis=1, ascending=False)]
 
 
 def get_dijet(jets):

--- a/pocket_coffea/parameters/histograms.py
+++ b/pocket_coffea/parameters/histograms.py
@@ -150,6 +150,22 @@ default_axis_settings = {
         "lim": (0, 1),
         'label': "AK4 DeepJet b-tag score",
     },
+    'jet_btagDeepFlavCvL': {
+        "field": "btagDeepFlavCvL",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 DeepJet CvsL score",
+    },
+    'jet_btagDeepFlavCvB': {
+        "field": "btagDeepFlavCvB",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 DeepJet CvsB score",
+    },
     'fatjet_pt': {
         "field": "pt",
         "bins": 100,
@@ -417,7 +433,7 @@ default_axis_settings = {
 }
 
 collection_fields = {
-    'jet': ["eta", "pt", "phi", "btagDeepFlavB"],
+    'jet': ["eta", "pt", "phi", "btagDeepFlavB", "btagDeepFlavCvL", "btagDeepFlavCvB"],
     'fatjet': [
         "eta",
         "pt",
@@ -465,7 +481,8 @@ def _get_default_hist(name, type, coll, pos=None, fields=None, **kwargs):
                 setting["pos"] = pos
                 # Avoid 0-indexing for the name of the histogram
                 hist_name += f"_{pos+1}"
-
+                setting["label"] = setting["label"] + " for Obj. #%i"%(pos+1)
+                
             out[hist_name] = HistConf(
                 axes=[
                     Axis(**setting),

--- a/pocket_coffea/utils/dataset.py
+++ b/pocket_coffea/utils/dataset.py
@@ -118,8 +118,12 @@ class Sample:
             )
             filesjson = r.json()
             for fj in filesjson:
-                if fj["is_file_valid"] == 0:
-                    print(f"ERROR: File not valid on DAS: {f['name']}")
+                if 'is_file_valid' not in fj.keys():
+                    # print("fj=", fj)
+                    raise Exception(f"(probably) an Invalid dataset name provided for entry: {self}!")
+                elif  fj["is_file_valid"] == 0:
+                    print(f"ERROR: File not valid on DAS: {fj['name']}")
+                    raise Exception(f"Invalid files in sample {self}!")
                 else:
                     self.fileslist_redirector.append(fj['logical_file_name'])
                     self.metadata["nevents"] += fj['event_count']

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -401,8 +401,25 @@ class Shape:
             return
         h_dict_grouped = {}
         samples_in_map = []
+
+        cleaned_samples_list = self.style.samples_groups.copy()
         for sample_new, samples_list in self.style.samples_groups.items():
-            # print(sample_new, samples_list)
+            #print(sample_new, samples_list)
+            for s_to_group in samples_list:
+                if s_to_group not in self.h_dict.keys():
+                    if self.verbose>=0:
+                        print("WARNING. Sample ",s_to_group," is not in the list of samples: ", list(self.h_dict.keys()), "Skipping it.")
+                    cleaned_samples_list[sample_new].remove(s_to_group)
+                    continue
+                if self.verbose>=1:
+                    print("\t Sample ",s_to_group," will be grouped into sample", sample_new)
+
+        for sample_new, samples_list in cleaned_samples_list.items():
+            if len(samples_list)==0:
+                if self.verbose>=1:
+                    print("WARNING. The list of samples to group is empty!  Group name:", sample_new)
+                continue
+            
             h_dict_grouped[sample_new] = self._stack_sum(
                 stack=hist.Stack.from_dict(
                     {s: h for s, h in self.h_dict.items() if s in samples_list}

--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -66,8 +66,8 @@ def get_xrootd_sites_map():
         json.dump(sites_xrootd_access, open(".sites_map.json", "w"))
 
     else:
-        print("Your .sites_map.json cond already exists! Will use that filr for sites configuration, will not overwrite it.")
-        print("\t If you need it to be updated remove the .sites_map.json and rerun this script.")
+        print("Your .sites_map.json file already exists! Will use that file for sites configuration, not overwriting it.")
+        print("\t If you need it to be updated remove the .sites_map.json and rerun this script again.")
 
     return json.load(open(".sites_map.json"))
 

--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -65,6 +65,10 @@ def get_xrootd_sites_map():
                             sites_xrootd_access[site["rse"]] = proc["prefix"]
         json.dump(sites_xrootd_access, open(".sites_map.json", "w"))
 
+    else:
+        print("Your .sites_map.json cond already exists! Will use that filr for sites configuration, will not overwrite it.")
+        print("\t If you need it to be updated remove the .sites_map.json and rerun this script.")
+
     return json.load(open(".sites_map.json"))
 
 
@@ -76,9 +80,9 @@ def _get_pfn_for_site(path, rules):
                 for i in range(len(grs)):
                     pfn = pfn.replace(f"${i+1}", grs[i])
                 return pfn
-    else: 
+    else:
         return rules + "/"+ path
-    
+
 
 def get_dataset_files(
     dataset,
@@ -122,6 +126,7 @@ def get_dataset_files(
                         continue
                     outfile.append(_get_pfn_for_site(filedata["name"], sites_xrootd_prefix[site]))
                     outsite.append(site)
+
                     found = True
 
             if not found:

--- a/scripts/plot/make_plots.py
+++ b/scripts/plot/make_plots.py
@@ -12,7 +12,8 @@ from pocket_coffea.parameters import defaults
 parser = argparse.ArgumentParser(description='Plot histograms from coffea file')
 parser.add_argument('input_dir', help='Directory with cofea files and parameters', type=str)
 parser.add_argument('--cfg', help='YAML file with all the analysis parameters', required=False)
-parser.add_argument('-op', '--overwrite_parameters', type=str, nargs="+", default=None, help='YAML file with plotting parameters to overwrite default parameters', required=False)
+parser.add_argument('-op', '--overwrite_parameters', type=str, nargs="+", default=None,
+                    help='YAML file with plotting parameters to overwrite default parameters', required=False)
 parser.add_argument("-o", "--outputdir", required=False, type=str, help="Output folder")
 parser.add_argument("-i", "--inputfile", required=False, type=str, help="Input file")
 parser.add_argument('-j', '--workers', type=int, default=8, help='Number of parallel workers to use for plotting', required=False)

--- a/scripts/plot/make_plots.py
+++ b/scripts/plot/make_plots.py
@@ -30,7 +30,7 @@ parser.add_argument('-v', '--verbose', type=int, default=1, help='Verbose level 
 args = parser.parse_args()
 
 
-# Using the input_dir obtain the config files and coffea file (if not set with argparse):
+# Using the input_dir to obtain the config files and coffea file (if they are not set with arguments):
 if args.cfg==None:
     args.cfg = args.input_dir+"/parameters_dump.yaml"
 if args.inputfile==None:

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -381,7 +381,7 @@ if __name__ == '__main__':
                     "error": f"{args.outputdir}/{log_folder}/dask_job_output.err",
                     "should_transfer_files": "Yes",
                     "when_to_transfer_output": "ON_EXIT",
-                   "+JobFlavour": f'"{run_options["queue"]}"'
+                    "+JobFlavour": f'"{run_options["queue"]}"'
                 },
                 env_extra=env_extra,
             )

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
     parser.add_argument("-e","--executor", type=str,
                         help="Overwrite executor from config (to be used only with the --test options)" )
     parser.add_argument("-s","--scaleout", type=int, help="Overwrite scalout config" )
-    parser.add_argument("-ll","--loglevel", type=str, help="Logging level", default="INFO" )
+    parser.add_argument("-ll","--loglevel", type=str, help="Console logging level", default="INFO" )
     parser.add_argument("-f","--full", action="store_true", help="Process all datasets at the same time", default=False )
     args = parser.parse_args()
 
@@ -63,10 +63,10 @@ if __name__ == '__main__':
     outfile = os.path.join(
         args.outputdir, "output_{}.coffea"
     )
-
+    logfile = os.path.join(args.outputdir, "logfile.log")
     # Prepare logging
     if (not setup_logging(console_log_output="stdout", console_log_level=args.loglevel, console_log_color=True,
-                        logfile_file="last_run.log", logfile_log_level="info", logfile_log_color=False,
+                        logfile_file=logfile, logfile_log_level="info", logfile_log_color=False,
                         log_line_template="%(color_on)s[%(levelname)-8s] %(message)s%(color_off)s")):
         print("Failed to setup logging, aborting.")
         exit(1)
@@ -183,8 +183,10 @@ if __name__ == '__main__':
         from parsl.executors import HighThroughputExecutor
         from parsl.launchers import SrunLauncher, SingleNodeLauncher
         from parsl.addresses import address_by_hostname, address_by_query
-        #parsl.set_stream_logger(name='PARSL', level=logging.ERROR, stream=sys.stdout)
 
+        # Setting Console loglevel to ERROR in order to avoid logs from Parsl
+        logging.getLogger().handlers[0].setLevel("ERROR")
+        
         if 'slurm' in run_options['executor']:
             slurm_htex = Config(
                 executors=[
@@ -445,3 +447,12 @@ if __name__ == '__main__':
     else:
         print(f"Executor {run_options['executor']} not defined!")
         exit(1)
+
+
+    #print("Logger handlers:", logging.getLogger().handlers )
+    log_file = logging.getLogger().handlers[1].baseFilename
+    #print("Logfile is saved at:", log_file)
+    # Copying logfile also to last_run.log
+    import shutil
+    shutil.copyfile(log_file, 'last_run.log')
+        

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -5,3 +5,9 @@ import pocket_coffea as m
 
 def test_version():
     assert m.__version__
+
+def main():
+    print("Pocket Version:", m.__version__)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Here is a description of the changes in the order of appearance:
* `jets.py`: allow for jets sorting based on CvsL score
* `histograms.py`: add CvsL and CvsB scores in the default list of histograms for jets
   * Also adding a counter on the axis label to distinguish distributions when saving multiple objects (jet 1, 2, 3 etc).
* `dataset.py`: just adding one more check for valid dataset names I stumbled upon. And raising Exception
*  `plot_utils.py`: if a sample specified in the `group_samples` in the config does not exist - the plotting would crash. This fix avoids the crash.
* `rucio.py`: printing a warning that `.sites_map.json` already exists. I encountered an issue that one T2 site has changed their xrootd prefix and so code crashed.  It took me a while to figure out that the reason was that `.sites_map.json` was outdated. Hence this warning. Perhaps a better solution would be to avoid saving any such *hidden* file. Just creating this map on the fly would be better, in my opinion. It does not take much runtime.
* `make_plots.py`: only some comments
* `runner.py`:  a few changes here:
   *  The `logfile.log` is to be placed in the `outputdir`. However, for backward compatibility, this file is also copied to `last_run.log`
  * Changing the Console logger level when running with Parsl. This is because Parsl also writes its logs with logger and they are too much to be shown on stdout. They are still saved in the logfile.
  * Running with Parsl is now done per-dataset by default (same as with Dask), with a `--full` option to run all datasets at once.
* `test_package.py`: just make use of this script to print version. I think the`tests` directory could be used for such simple test scripts. But currently the scripts there don't look very useful