### PR TITLE
Executors based on parsl for DESY NAF

### DIFF
--- a/pocket_coffea/executors/executors_DESY_NAF.py
+++ b/pocket_coffea/executors/executors_DESY_NAF.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import socket
+from coffea import processor as coffea_processor
+from .executors_base import ExecutorFactoryABC
+from .executors_base import IterativeExecutorFactory, FuturesExecutorFactory
+from pocket_coffea.utils.network import check_port
+from pocket_coffea.parameters.dask_env import setup_dask
+
+import parsl
+from parsl.providers import CondorProvider
+from parsl.channels import LocalChannel
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SrunLauncher, SingleNodeLauncher
+from parsl.addresses import address_by_hostname, address_by_query
+    
+
+class ParslCondorExecutorFactory(ExecutorFactoryABC):
+    '''
+    Parsl executor based on condor for DESY NAF
+    '''
+
+    def __init__(self, run_options, outputdir, **kwargs):
+        self.outputdir = outputdir
+        super().__init__(run_options)
+
+    def get_worker_env(self):
+        env_worker = [
+            'export XRD_RUNFORKHANDLER=1',
+            'export MALLOC_TRIM_THRESHOLD_=0',
+            f'export X509_USER_PROXY={self.x509_path}',
+            'ulimit -u unlimited',
+            'export PYTHONPATH=$PYTHONPATH:$PWD'
+            ]
+        
+        # Adding list of custom setup commands from user defined run options
+        if self.run_options.get("custom-setup-commands", None):
+            env_worker += self.run_options["custom-setup-commands"]
+
+        # Now checking for conda environment  conda-env:true
+        if self.run_options.get("conda-env", False):
+            env_worker.append(f'export PATH={os.environ["CONDA_PREFIX"]}/bin:$PATH')
+            if "CONDA_ROOT_PREFIX" in os.environ:
+                env_worker.append(f"{os.environ['CONDA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
+            elif "MAMBA_ROOT_PREFIX" in os.environ:
+                env_worker.append(f"{os.environ['MAMBA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
+            else:
+                raise Exception("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
+
+        # if local-virtual-env: true the dask job is configured to pickup
+        # the local virtual environment. 
+        if self.run_options.get("local-virtualenv", False):
+            env_worker.append(f"source {sys.prefix}/bin/activate")
+
+        return env_worker
+    
+        
+    def setup(self):
+        ''' Start the slurm cluster here'''
+        self.setup_proxyfile()
+
+        condor_htex = Config(
+                executors=[
+                    HighThroughputExecutor(
+                        label="coffea_parsl_condor",
+                        address=address_by_hostname(),
+                        max_workers=1,
+                        # Condor
+                        provider=CondorProvider(
+                            nodes_per_block=1,
+                            cores_per_slot=self.run_options["cores-per-worker"],
+                            mem_per_slot=self.run_options["mem-per-worker"],
+                            init_blocks=self.run_options["scaleout"],
+                            max_blocks=(self.run_options["scaleout"]) + 10,
+                            worker_init="\n".join(self.get_worker_env()),
+                            walltime=self.run_options["walltime"],
+                            requirements=self.run_options.get("requirements", ""),
+                        ),
+                    )
+                ],
+                retries=self.run_options["retries"],
+            )
+
+        self.condor_cluster = parsl.load(condor_htex)
+
+        
+    def get(self):
+        return coffea_processor.parsl_executor(**self.customized_args())
+
+    def customized_args(self):
+        args = super().customized_args()
+        # in the futures executor Nworkers == N scalout
+        args["treereduction"] = self.run_options["tree-reduction"]
+        args["skip-bad-files"] = self.run_options["skip-bad-files"]
+        return args
+
+    def close(self):
+        self.condor_cluster.close()
+
+
+
+
+def get_executor_factory(executor_name, **kwargs):
+    if executor_name == "iterative":
+        return IterativeExecutorFactory(**kwargs)
+    elif executor_name == "futures":
+        return FuturesExecutorFactory(**kwargs)
+    elif  executor_name == "parsl-condor":
+        return ParslCondorExecutorFactory(**kwargs)

--- a/pocket_coffea/executors/executors_T3_PSI_CH.py
+++ b/pocket_coffea/executors/executors_T3_PSI_CH.py
@@ -38,8 +38,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
             elif "MAMBA_ROOT_PREFIX" in os.environ:
                 env_worker.append(f"{os.environ['MAMBA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
             else:
-                print("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
-                exit(1)
+                raise Exception("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
 
         # if local-virtual-env: true the dask job is configured to pickup
         # the local virtual environment. 
@@ -98,6 +97,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
         args["client"] = self.dask_client
         args["treereduction"] = self.run_options["tree-reduction"]
         args["retries"] = self.run_options["retries"]
+        args["skip-bad-files"] = self.run_options["skip-bad-files"]
         return args
 
     def close(self):

--- a/pocket_coffea/executors/executors_lxplus.py
+++ b/pocket_coffea/executors/executors_lxplus.py
@@ -34,8 +34,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
             elif "MAMBA_ROOT_PREFIX" in os.environ:
                 env_worker.append(f"{os.environ['MAMBA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
             else:
-                print("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
-                exit(1)
+                raise Exception("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
 
         # if local-virtual-env: true the dask job is configured to pickup
         # the local virtual environment. 
@@ -112,6 +111,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
         # in the futures executor Nworkers == N scalout
         args["client"] = self.dask_client
         args["treereduction"] = self.run_options["tree-reduction"]
+        args["skip-bad-files"] = self.run_options["skip-bad-files"]
         args["retries"] = self.run_options["retries"]
         return args
 

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -34,3 +34,11 @@ dask@T3_PSI_CH:
   custom-setup-commands: null
   conda-env: false
   local-virtualenv: false
+
+
+parsl@NAF_DESY:
+  scaleout: 10
+  cores-per-worker: 1
+  mem-per-worker: "4GB"
+  logs-dir: logs_parsl
+  queue: ""


### PR DESCRIPTION
Preparing a draft for executors at DESY NAF using parls and condor. 

To use this with a conda/mamba environment add the following to your user-defined `run_options.yaml` file. 

```
conda-env: true
custom-setup-commands:   "whatever needed to find out the conda installation"
```
The executor code identifies the current conda environment and instructs the workers to use it. If you need to add any `source /etc/conda` or `source .bashrc` you can add it to the executor_DESY_NAF.py directly or in the custom-setup-comamnds. 

FYI:  @andreypz @Ming-Yan 
