### PR TITLE
fix: add hist/dask-histogram pins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,12 +43,12 @@ install_requires =
     awkward>=2.6.1
     cloudpickle
     vector
-    hist
+    hist>=2.7.2
     pyaml
     requests
     dask>=2021.10.0
     dask_jobqueue
-    dask-histogram
+    dask-histogram>=2024.2.0
     dask-awkward>=2024.2.0
     bokeh==2.4.2
     parsl
@@ -66,7 +66,7 @@ scripts =
     scripts/plot/make_plots.py
     scripts/hadd_skimmed_files.py
     scripts/merge_outputs.py
-    
+
 
 
 [options.extras_require]


### PR DESCRIPTION
Let's add these pins and see if the ci can create docker containers.
We absolutely need hist >= 2.6.1 because that's when the dask interface was added.
We also need dask-histogram>=2024.2.0 because https://github.com/dask-contrib/dask-histogram/pull/120 reduces the graph sizes significantly.
In principle, a lot of these dependencies can be removed and we can rely on coffea for the correct uproot/awkward/dask-stuff dependencies.