### PR TITLE
Include dask performance report

### DIFF
--- a/pocket_coffea/__main__.py
+++ b/pocket_coffea/__main__.py
@@ -18,7 +18,7 @@ title = """[dodger_blue1]
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-@click.option("-v","--version", default=False, help="Print PocketCoffea package version")
+@click.option("-v","--version", is_flag=True, default=False, help="Print PocketCoffea package version")
 def cli(ctx, version):
     print(title)
 

--- a/pocket_coffea/executors/executors_T3_CH_PSI.py
+++ b/pocket_coffea/executors/executors_T3_CH_PSI.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import socket
+from dask.distributed import performance_report
+
 from coffea import processor as coffea_processor
 from .executors_base import ExecutorFactoryABC
 from .executors_base import IterativeExecutorFactory, FuturesExecutorFactory
@@ -83,10 +85,10 @@ class DaskExecutorFactory(ExecutorFactoryABC):
         self.dask_client.wait_for_workers(1)
         print(">> You can connect to the Dask viewer at http://localhost:8787")
 
-        # if self.run_options["performance-report"]:
-        #     self.performance_report_path = os.path.join(self.outputdir, f"{log_folder}/dask-report.html")
-        #     print(f"Saving performance report to {self.performance_report_path}")
-        #     self.performance_report(filename=performance_report_path):
+        if self.run_options["performance-report"]:
+            self.performance_report_path = os.path.join(self.outputdir, "dask_log/dask-report.html")
+            print(f"Saving performance report to {self.performance_report_path}")
+            self.performance_report = performance_report(filename=self.performance_report_path)
 
         
     def get(self):

--- a/pocket_coffea/executors/executors_lxplus.py
+++ b/pocket_coffea/executors/executors_lxplus.py
@@ -98,10 +98,10 @@ class DaskExecutorFactory(ExecutorFactoryABC):
         self.dask_client.wait_for_workers(1)
         print(">> You can connect to the Dask viewer at http://localhost:8787")
 
-        # if self.run_options["performance-report"]:
-        #     self.performance_report_path = os.path.join(self.outputdir, f"{log_folder}/dask-report.html")
-        #     print(f"Saving performance report to {self.performance_report_path}")
-        #     self.performance_report(filename=performance_report_path):
+        if self.run_options["performance-report"]:
+            self.performance_report_path = os.path.join(self.outputdir, "dask_log/dask-report.html")
+            print(f"Saving performance report to {self.performance_report_path}")
+            self.performance_report = performance_report(filename=self.performance_report_path)
 
         
     def get(self):


### PR DESCRIPTION
The Dask performance report is saved in a dedicated `dask_log/dask-report.html` file, when the DaskExecutor is used on `T3_CH_PSI` and `lxplus` sites.

**To do:** test the performance report on lxplus in a singularity image.

**Additional fixes:** fix the behavior of the `pocket-coffea --version` command in the CLI

**WIP: do not merge yet**