### PR TITLE
Improved b-tagging parameters

### DIFF
--- a/pocket_coffea/lib/columns_manager.py
+++ b/pocket_coffea/lib/columns_manager.py
@@ -8,7 +8,7 @@ import awkward as ak
 class ColOut:
     collection: str  # Collection
     columns: List[str]  # list of columns to export
-    flatten: bool = True  # Flatten by defaul
+    flatten: bool = True  # Flatten by default
     store_size: bool = True
     fill_none: bool = True
     fill_value: float = -999.0  # by default the None elements are filled
@@ -61,7 +61,7 @@ class ColumnsManager:
                 # Applying mask after getting the collection
                 if(outarray.collection=="events"):
                     data = events[mask]
-                else:    
+                else:
                     data = events[outarray.collection][mask]
 
                 # Filtering the position in the collection if needed
@@ -136,7 +136,10 @@ class ColumnsManager:
                             while exporting collection {outarray.collection}! Please check your categorization"
                         )
                 # Applying mask after getting the collection
-                data = events[outarray.collection][mask]
+                if(outarray.collection=="events"):
+                    data = events[mask]
+                else:
+                    data = events[outarray.collection][mask]
 
                 # Filtering the position in the collection if needed
                 if outarray.pos_start and outarray.pos_end:
@@ -146,8 +149,9 @@ class ColumnsManager:
                 elif not outarray.pos_start and outarray.pos_end:
                     data = data[:, : outarray.pos_end]
 
-                # if outarray.store_size and data.ndim > 1:
-                #     out_by_cat[f"{outarray.collection}_N"] = ak.num(data)
+                if outarray.store_size and data.ndim > 1:
+                    N = ak.num(data)
+                    out_by_cat[f"{outarray.collection}_N"] = N
 
                 # looping on the columns
                 for col in outarray.columns:

--- a/pocket_coffea/lib/cut_functions.py
+++ b/pocket_coffea/lib/cut_functions.py
@@ -201,7 +201,7 @@ def nBtagMin(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"]
+                        > btagparam["btagging_WP"][params["wp"]]
                     )
                     & (events[params["coll"]].pt >= params["minpt"]),
                     axis=1,
@@ -213,7 +213,7 @@ def nBtagMin(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"]
+                        > btagparam["btagging_WP"][params["wp"]]
                     ),
                     axis=1,
                 )
@@ -241,7 +241,7 @@ def nBtagEq(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"]
+                        > btagparam["btagging_WP"][params["wp"]]
                     )
                     & (events[params["coll"]].pt >= params["minpt"]),
                     axis=1,
@@ -253,7 +253,7 @@ def nBtagEq(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"]
+                        > btagparam["btagging_WP"][params["wp"]]
                     ),
                     axis=1,
                 )
@@ -285,19 +285,19 @@ def nMuon(events, params, year, **kwargs):
 ## Factory methods
 
 
-def get_nBtagMin(N, minpt=0, coll="BJetGood", name=None):
+def get_nBtagMin(N, minpt=0, coll="BJetGood", wp="M", name=None):
     if name == None:
         name = f"n{coll}_btagMin{N}_pt{minpt}"
     return Cut(
-        name=name, params={"N": N, "coll": coll, "minpt": minpt}, function=nBtagMin
+        name=name, params={"N": N, "coll": coll, "minpt": minpt, "wp": wp}, function=nBtagMin
     )
 
 
-def get_nBtagEq(N, minpt=0, coll="BJetGood", name=None):
+def get_nBtagEq(N, minpt=0, coll="BJetGood", wp="M", name=None):
     if name == None:
         name = f"n{coll}_btagEq{N}_pt{minpt}"
     return Cut(
-        name=name, params={"N": N, "coll": coll, "minpt": minpt}, function=nBtagEq
+        name=name, params={"N": N, "coll": coll, "minpt": minpt, "wp": wp}, function=nBtagEq
     )
 
 

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -235,8 +235,8 @@ def jet_selection(events, jet_type, params, leptons_collection=""):
     return jets[mask_good_jets], mask_good_jets
 
 
-def btagging(Jet, btag):
-    return Jet[Jet[btag["btagging_algorithm"]] > btag["btagging_WP"]]
+def btagging(Jet, btag, wp):
+    return Jet[Jet[btag["btagging_algorithm"]] > btag["btagging_WP"][wp]]
 
 
 def CvsLsorted(jets, ctag):

--- a/pocket_coffea/parameters/btagging.yaml
+++ b/pocket_coffea/parameters/btagging.yaml
@@ -3,6 +3,8 @@
 btagging:
   working_point:
     2016_PreVFP:
+      reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/UL2016preVFP/
       btagging_algorithm: btagDeepFlavB
       btagging_WP:
         L: 0.0508
@@ -17,6 +19,8 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_up: 0.97
       bbtagSF_DDBvL_M1_hiPt_down: 0.82
     2016_PostVFP:
+      reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/UL2016postVFP/
       btagging_algorithm: btagDeepFlavB
       btagging_WP:
         L: 0.0816
@@ -31,6 +35,8 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_up: 0.97
       bbtagSF_DDBvL_M1_hiPt_down: 0.82
     '2017':
+    reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/UL2017/
       btagging_algorithm: btagDeepFlavB
       btagging_WP:
         L: 0.0532
@@ -45,6 +51,8 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_up: 0.83
       bbtagSF_DDBvL_M1_hiPt_down: 0.67
     '2018':
+      reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/UL2018/
       btagging_algorithm: btagDeepFlavB
       btagging_WP:
         L: 0.0490
@@ -60,8 +68,15 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_down: 0.71
 
     '2022_preEE':
+      reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer22/#ak4-b-tagging
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.277
+      btagging_WP:
+        L: 0.0583
+        M: 0.3086
+        T: 0.7183
+        XT: 0.8111
+        XXT: 0.9512
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81
@@ -71,8 +86,15 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_up: 0.82
       bbtagSF_DDBvL_M1_hiPt_down: 0.71
     '2022_postEE':
+      reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer22EE/
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.277
+      btagging_WP:
+        L: 0.0614
+        M: 0.3196
+        T: 0.7300
+        XT: 0.8184
+        XXT: 0.9542
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81
@@ -82,8 +104,15 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_up: 0.82
       bbtagSF_DDBvL_M1_hiPt_down: 0.71
     '2023_preBPix':
+      reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer23/
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.277
+      btagging_WP:
+        L: 0.0479
+        M: 0.2431
+        T: 0.6553
+        XT: 0.7667
+        XXT: 0.9459
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81
@@ -93,8 +122,15 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_up: 0.82
       bbtagSF_DDBvL_M1_hiPt_down: 0.71
     '2023_postBPix':
+      reference:
+        btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer23BPix/
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.277
+      btagging_WP:
+        L: 0.048
+        M: 0.2435
+        T: 0.6563
+        XT: 0.7671
+        XXT: 0.9483
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81

--- a/pocket_coffea/parameters/btagging.yaml
+++ b/pocket_coffea/parameters/btagging.yaml
@@ -4,7 +4,10 @@ btagging:
   working_point:
     2016_PreVFP:
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.3093
+      btagging_WP:
+        L: 0.0508
+        M: 0.2598
+        H: 0.6502
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.86
@@ -15,7 +18,10 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_down: 0.82
     2016_PostVFP:
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.3093
+      btagging_WP:
+        L: 0.0816
+        M: 0.3657
+        H: 0.7565
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.86
@@ -26,7 +32,10 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_down: 0.82
     '2017':
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.3033
+      btagging_WP:
+        L: 0.0532
+        M: 0.3040
+        H: 0.7476
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.82
@@ -37,7 +46,10 @@ btagging:
       bbtagSF_DDBvL_M1_hiPt_down: 0.67
     '2018':
       btagging_algorithm: btagDeepFlavB
-      btagging_WP: 0.277
+      btagging_WP:
+        L: 0.0490
+        M: 0.2783
+        H: 0.7100
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81

--- a/pocket_coffea/parameters/lepton_scale_factors.yaml
+++ b/pocket_coffea/parameters/lepton_scale_factors.yaml
@@ -73,13 +73,13 @@ lepton_scale_factors:
           trigger: NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight
     JSONfiles:
       '2016_PreVFP':
-          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2016preVFP_UL/muon_Z_v2.json.gz
+          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2016preVFP_UL/muon_Z.json.gz
       '2016_PostVFP':
-          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2016postVFP_UL/muon_Z_v2.json.gz
+          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2016postVFP_UL/muon_Z.json.gz
       '2017':
-          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2017_UL/muon_Z_v2.json.gz
+          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2017_UL/muon_Z.json.gz
       '2018':
-          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2018_UL/muon_Z_v2.json.gz
+          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2018_UL/muon_Z.json.gz
 
     era_mapping:
         # this is needed because the correction set provided by MUO

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -458,8 +458,8 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
 
     def define_column_accumulators(self):
         '''
-        Define the ColumsManagers to handle the requested columns from the configuration.
-        If Subsamples are defined a columnsmager is created for each of them.
+        Define the ColumnsManagers to handle the requested columns from the configuration.
+        If Subsamples are defined a columnsmanager is created for each of them.
         '''
         self.column_managers = {}
         for subs in self._subsamples[self._sample].keys():
@@ -504,8 +504,8 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                         + ".parquet")
                     for category, akarr in out_arrays.items():
                         # building the file name
-                        subdirs = [self._dataset, sub, category]
-                        dump_ak_array(akarray, fname, self.workflow_options["dump_columns_as_arrays_per_chunk"]+"/", subdirs)
+                        subdirs = [self._dataset, subs, category]
+                        dump_ak_array(akarr, fname, self.workflow_options["dump_columns_as_arrays_per_chunk"]+"/", subdirs)
 
 
                 else:

--- a/pocket_coffea/workflows/tthbb_base_processor.py
+++ b/pocket_coffea/workflows/tthbb_base_processor.py
@@ -44,7 +44,7 @@ class ttHbbBaseProcessor(BaseProcessorABC):
             self.events, "Jet", self.params, "LeptonGood"
         )
         self.events["BJetGood"] = btagging(
-            self.events["JetGood"], self.params.btagging.working_point[self._year], wp="M"
+            self.events["JetGood"], self.params.btagging.working_point[self._year], wp=self.params.object_preselection.Jet["btag"]["wp"]
         )
 
         # self.events["FatJetGood"], self.jetGoodMask = jet_selection(

--- a/pocket_coffea/workflows/tthbb_base_processor.py
+++ b/pocket_coffea/workflows/tthbb_base_processor.py
@@ -44,7 +44,7 @@ class ttHbbBaseProcessor(BaseProcessorABC):
             self.events, "Jet", self.params, "LeptonGood"
         )
         self.events["BJetGood"] = btagging(
-            self.events["JetGood"], self.params.btagging.working_point[self._year]
+            self.events["JetGood"], self.params.btagging.working_point[self._year], wp="M"
         )
 
         # self.events["FatJetGood"], self.jetGoodMask = jet_selection(


### PR DESCRIPTION
The scheme for b-tagging parameters is updated to support multiple working points of b-tagging:
- The b-tagging working points for Run-2 have been updated to the latest recommendation from the BTV-POG (https://btv-wiki.docs.cern.ch/PerformanceCalibration/#working-points).
- The Run-3 parameters are updated according to the latest recommendation for the DeepJet tagger. If another tagger has to be used, the user needs to define their custom tagger and working points parameters to override the defaults.
- A key `reference` is included in the b-tagging parameters in `btagging.yaml` to trace the source of the parameters. This entry needs to be updated whenever the WPs are updated and helps the user to keep track of the origin of the defaults.
- The function to apply b-tagging in the processor and the helper functions to require a certain number of b-tagged jets have been updated accordingly, taking now the working point as an additional argument.
- The `wp` argument is set to `M` by default, meaning that the medium working point is applied if the argument is not specified.
- A small fix to the base processor is performed in order to dump arrays to parquet files.