### PR TITLE
Added functionality to run on RWTH parsl/condor

### DIFF
--- a/pocket_coffea/executors/executors_RWTH.py
+++ b/pocket_coffea/executors/executors_RWTH.py
@@ -1,0 +1,101 @@
+import os, getpass
+import sys
+import socket
+from coffea import processor as coffea_processor
+from .executors_base import ExecutorFactoryABC
+from .executors_base import IterativeExecutorFactory, FuturesExecutorFactory
+from pocket_coffea.utils.network import check_port
+from pocket_coffea.parameters.dask_env import setup_dask
+
+import parsl
+from parsl.providers import CondorProvider, LocalProvider, SlurmProvider
+from parsl.channels import LocalChannel
+from parsl.config import Config
+from parsl.executors import HighThroughputExecutor
+from parsl.launchers import SrunLauncher, SingleNodeLauncher
+from parsl.addresses import address_by_hostname, address_by_query
+    
+
+class ParslCondorExecutorFactory(ExecutorFactoryABC):
+    '''
+    Parsl executor based on condor for RWTH
+    '''
+
+    def __init__(self, run_options, outputdir, **kwargs):
+        self.outputdir = outputdir
+        super().__init__(run_options)
+
+    def get_worker_env(self):
+        env_worker = [
+            'export XRD_RUNFORKHANDLER=1',
+            f'export X509_USER_PROXY={self.x509_path}',
+            f'export PYTHONPATH=$PYTHONPATH:{os.getcwd()}',
+            f'cd {os.getcwd()}',
+            f'source {os.environ["HOME"]}/.bashrc', # Conda should be setup by .bashrc for this to work
+            f'conda activate {os.environ["CONDA_PREFIX"]}'
+            ]
+        
+        # Adding list of custom setup commands from user defined run options
+        if self.run_options.get("custom-setup-commands", None):
+            env_worker += self.run_options["custom-setup-commands"]
+
+        return env_worker
+    
+        
+    def setup(self):
+        ''' Start the slurm cluster here'''
+        self.setup_proxyfile()
+
+        condor_htex = Config(
+                executors=[
+                    HighThroughputExecutor(
+                        label="coffea_parsl_condor",
+                        address=address_by_hostname(),
+                        max_workers=1,
+                        worker_debug=False,
+                        prefetch_capacity=0,
+                        provider=CondorProvider(
+                            nodes_per_block=1,
+                            cores_per_slot=self.run_options["cores-per-worker"],
+                            #channel=LocalChannel(script_dir='logs_parsl'),
+                            mem_per_slot=self.run_options.get("mem_per_worker_parsl", 2),
+                            init_blocks=self.run_options["scaleout"],
+                            max_blocks=(self.run_options["scaleout"]) + 5,
+                            worker_init="\n".join(self.get_worker_env()),
+                            walltime=self.run_options["walltime"],
+                            requirements=self.run_options.get("requirements", ""),
+                            #transfer_input_files=xfer_files,
+                            #scheduler_options=condor_cfg,
+
+                        ),
+                    )
+                ],
+                retries=self.run_options["retries"],
+	        #run_dir="/tmp/"+getpass.getuser()+"/parsl_runinfo",
+            )
+
+        self.condor_cluster = parsl.load(condor_htex)
+        print('Ready to run with parsl')
+        
+    def get(self):
+        return coffea_processor.parsl_executor(**self.customized_args())
+
+    def customized_args(self):
+        args = super().customized_args()
+        # in the futures executor Nworkers == N scalout
+        #args["treereduction"] = self.run_options["tree-reduction"]
+        return args
+    
+    def close(self):
+        parsl.clear()
+
+
+
+
+def get_executor_factory(executor_name, **kwargs):
+    if executor_name == "iterative":
+        return IterativeExecutorFactory(**kwargs)
+    elif executor_name == "futures":
+        return FuturesExecutorFactory(**kwargs)
+    elif  executor_name == "parsl-condor":
+        return ParslCondorExecutorFactory(**kwargs)

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -43,3 +43,12 @@ parsl-condor@DESY_NAF:
   logs-dir: logs_parsl
   queue: ""
   walltime: "12:00:00"
+
+parsl-condor@RWTH:
+  scaleout: 1
+  mem_per_worker: 2 # GB
+  logs-dir: logs_parsl
+  local-virtualenv: false
+  cores-per-worker: 1
+  walltime: "12:00:00"
+  ignore-grid-certificate: false

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -143,6 +143,8 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
         from pocket_coffea.executors import executors_purdue as executors_lib
     elif site == "DESY_NAF":
         from pocket_coffea.executors import executors_DESY_NAF as executors_lib
+    elif site == "RWTH":
+        from pocket_coffea.executors import executors_RWTH as executors_lib
     elif site == "casa":
         from pocket_coffea.executors import executors_casa as executors_lib
     else:


### PR DESCRIPTION
**PR Summary:** 

This PR introduces an executor class tailored for RWTH clusters to facilitate the execution of the PocketCoffea framework using the parsl distributor.

**Changes Made:**

*   Introduces `executors_RWTH.py` in `pocket_coffea/executors` to support RWTH clusters.
*   Modifies `executor_options_defaults.yaml` and `runner.py` in `pocket_coffea/parameters` and `pocket_coffea/scripts` respectively.

**Context:** 

This update is crucial for users operating on RWTH clusters, as it streamlines the execution process of the PocketCoffea framework, enabling compatibility within this specific environment.

**Testing:** 

Tests have been successfully conducted on [AnalysisConfigs/blob/main/configs/zmumu/example\_config.py](https://github.com/PocketCoffea/AnalysisConfigs/blob/main/configs/zmumu/example_config.py) for a small set of jobs, with all tests passing without any failures.

**Future Work:** 

Further enhancements will include improvement of passing the conda environment in a better way (already existing in other executors, but doesn't work seamlessly in RWTH clusters).