### PR TITLE
Run3 sf defaults additions

### DIFF
--- a/pocket_coffea/lib/leptons.py
+++ b/pocket_coffea/lib/leptons.py
@@ -17,7 +17,8 @@ def lepton_selection(events, lepton_flavour, params):
         # Requirements on SuperCluster eta, isolation and id
         etaSC = abs(leptons.deltaEtaSC + leptons.eta)
         passes_SC = np.invert((etaSC >= 1.4442) & (etaSC <= 1.5660))
-        passes_iso = leptons.pfRelIso03_all < cuts["iso"]
+        if "iso" in cuts.keys():
+            passes_iso = leptons.pfRelIso03_all < cuts["iso"]
         passes_id = leptons[cuts['id']] == True
 
         good_leptons = passes_eta & passes_pt & passes_SC & passes_iso & passes_id

--- a/pocket_coffea/lib/leptons.py
+++ b/pocket_coffea/lib/leptons.py
@@ -17,6 +17,7 @@ def lepton_selection(events, lepton_flavour, params):
         # Requirements on SuperCluster eta, isolation and id
         etaSC = abs(leptons.deltaEtaSC + leptons.eta)
         passes_SC = np.invert((etaSC >= 1.4442) & (etaSC <= 1.5660))
+        passes_iso = True
         if "iso" in cuts.keys():
             passes_iso = leptons.pfRelIso03_all < cuts["iso"]
         passes_id = leptons[cuts['id']] == True

--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -21,7 +21,6 @@ def get_ele_sf(
         if key == 'reco':
             sfname = electronSF.JSONfiles[year]["reco"][pt_region]
         elif key == 'id':
-            print(params.object_preselection["Electron"]["id"])
             sfname = electronSF["id"][params.object_preselection["Electron"]["id"]]
 
         # translate the `year` key into the corresponding key in the correction file provided by the EGM-POG
@@ -165,65 +164,6 @@ def sf_ele_reco(params, events, year):
     )
     sfdown_reco = ak.prod(
         ak.concatenate(sfdown_reco, axis=1), axis=1
-    )
-
-    return sf_reco, sfup_reco, sfdown_reco
-
-
-
-
-def sf_ele_reco_old(params, events, year):
-    '''
-    This function computes the per-electron reco SF and returns the corresponding per-event SF, obtained by multiplying the per-electron SF in each event.
-    Additionally, also the up and down variations of the SF are returned.
-    Electrons are split into two categories based on a pt cut at 20 GeV, so that the proper SF is applied.
-    '''
-
-    ele_pt = events.ElectronGood.pt
-    ele_eta = events.ElectronGood.etaSC
-
-    Above20 = ele_pt >= 20
-    Below20 = ele_pt < 20
-
-    # Since `correctionlib` does not support jagged arrays as an input, the pt and eta arrays are flattened.
-    ele_pt_Above20, ele_counts_Above20 = ak.flatten(ele_pt[Above20]), ak.num(
-        ele_pt[Above20]
-    )
-    ele_eta_Above20 = ak.flatten(ele_eta[Above20])
-
-    ele_pt_Below20, ele_counts_Below20 = ak.flatten(ele_pt[Below20]), ak.num(
-        ele_pt[Below20]
-    )
-    ele_eta_Below20 = ak.flatten(ele_eta[Below20])
-
-    sf_reco_Above20, sfup_reco_Above20, sfdown_reco_Above20 = get_ele_sf(
-        params,
-        year,
-        ele_pt_Above20,
-        ele_eta_Above20,
-        ele_counts_Above20,
-        'reco',
-        'pt_gt_20',
-    )
-    sf_reco_Below20, sfup_reco_Below20, sfdown_reco_Below20 = get_ele_sf(
-        params,
-        year,
-        ele_pt_Below20,
-        ele_eta_Below20,
-        ele_counts_Below20,
-        'reco',
-        'pt_lt_20',
-    )
-
-    # The SF arrays corresponding to the electrons with pt above and below 20 GeV are concatenated and multiplied along the electron axis in order to obtain a per-event scale factor.
-    sf_reco = ak.prod(
-        ak.concatenate((sf_reco_Above20, sf_reco_Below20), axis=1), axis=1
-    )
-    sfup_reco = ak.prod(
-        ak.concatenate((sfup_reco_Above20, sfup_reco_Below20), axis=1), axis=1
-    )
-    sfdown_reco = ak.prod(
-        ak.concatenate((sfdown_reco_Above20, sfdown_reco_Below20), axis=1), axis=1
     )
 
     return sf_reco, sfup_reco, sfdown_reco

--- a/pocket_coffea/parameters/event_flags.yaml
+++ b/pocket_coffea/parameters/event_flags.yaml
@@ -36,34 +36,43 @@ event_flags :
     - "BadPFMuonFilter"
      # "BadChargedCandidateFilter" "ecalBadCalibFilter
 
+# "HBHENoiseFilter" and "HBHENoiseIsoFilter" no longer recommended for Run 3
   "2022_preEE":
     - "goodVertices"
     - "globalSuperTightHalo2016Filter"
-    - "HBHENoiseFilter"
-    - "HBHENoiseIsoFilter"
     - "EcalDeadCellTriggerPrimitiveFilter"
     - "BadPFMuonFilter"
+    - "BadPFMuonDzFilter"
+    - "hfNoisyHitsFilter"
+    - "eeBadScFilter"
+    - "ecalBadCalibFilter"
   "2022_postEE":
     - "goodVertices"
     - "globalSuperTightHalo2016Filter"
-    - "HBHENoiseFilter"
-    - "HBHENoiseIsoFilter"
     - "EcalDeadCellTriggerPrimitiveFilter"
     - "BadPFMuonFilter"
+    - "BadPFMuonDzFilter"
+    - "hfNoisyHitsFilter"
+    - "eeBadScFilter"
+    - "ecalBadCalibFilter"
   "2023_preBPix":
     - "goodVertices"
     - "globalSuperTightHalo2016Filter"
-    - "HBHENoiseFilter"
-    - "HBHENoiseIsoFilter"
     - "EcalDeadCellTriggerPrimitiveFilter"
     - "BadPFMuonFilter"
+    - "BadPFMuonDzFilter"
+    - "hfNoisyHitsFilter"
+    - "eeBadScFilter"
+    - "ecalBadCalibFilter"
   "2023_postBPix":
     - "goodVertices"
     - "globalSuperTightHalo2016Filter"
-    - "HBHENoiseFilter"
-    - "HBHENoiseIsoFilter"
     - "EcalDeadCellTriggerPrimitiveFilter"
     - "BadPFMuonFilter"
+    - "BadPFMuonDzFilter"
+    - "hfNoisyHitsFilter"
+    - "eeBadScFilter"
+    - "ecalBadCalibFilter"
 
 event_flags_data:
   "2018":

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -44,7 +44,6 @@ parsl-condor@DESY_NAF:
   logs-dir: logs_parsl
   queue: ""
   walltime: "12:00:00"
-  ignore-grid-certificate: false
 
 parsl-condor@RWTH:
   scaleout: 1
@@ -53,4 +52,3 @@ parsl-condor@RWTH:
   local-virtualenv: false
   cores-per-worker: 1
   walltime: "12:00:00"
-  ignore-grid-certificate: false

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -44,6 +44,7 @@ parsl-condor@DESY_NAF:
   logs-dir: logs_parsl
   queue: ""
   walltime: "12:00:00"
+  ignore-grid-certificate: false
 
 parsl-condor@RWTH:
   scaleout: 1
@@ -52,3 +53,4 @@ parsl-condor@RWTH:
   local-virtualenv: false
   cores-per-worker: 1
   walltime: "12:00:00"
+  ignore-grid-certificate: false

--- a/pocket_coffea/parameters/jet_scale_factors.yaml
+++ b/pocket_coffea/parameters/jet_scale_factors.yaml
@@ -99,3 +99,29 @@ jet_scale_factors:
                 M: 6
                 T: 7
             name: PUJetID_eff
+        '2022_preEE':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetvetomaps.json.gz
+            name: "deepJet_shape"
+        '2022_postEE':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22EE/jetvetomaps.json.gz
+            name: "deepJet_shape"
+        '2023_preBPIX':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23/jetvetomaps.json.gz
+            name: "deepJet_shape"
+        '2023_postBPIX':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23BPix/jetvetomaps.json.gz
+            name: "deepJet_shape"
+
+    vetomaps:
+        '2022_preEE':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetvetomaps.json.gz
+            name: "Summer22_23Sep2023_RunCD_V1"
+        '2022_postEE':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22EE/jetvetomaps.json.gz
+            name: "Summer22EE_23Sep2023_RunEFG_V1"
+        '2023_preBPIX':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23/jetvetomaps.json.gz
+            name: "Summer23Prompt23_RunC_V1"
+        '2023_postBPIX':
+            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23BPix/jetvetomaps.json.gz
+            name: "Summer23BPixPrompt23_RunD_V1"

--- a/pocket_coffea/parameters/jet_scale_factors.yaml
+++ b/pocket_coffea/parameters/jet_scale_factors.yaml
@@ -99,18 +99,6 @@ jet_scale_factors:
                 M: 6
                 T: 7
             name: PUJetID_eff
-        '2022_preEE':
-            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetvetomaps.json.gz
-            name: "deepJet_shape"
-        '2022_postEE':
-            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22EE/jetvetomaps.json.gz
-            name: "deepJet_shape"
-        '2023_preBPIX':
-            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23/jetvetomaps.json.gz
-            name: "deepJet_shape"
-        '2023_postBPIX':
-            file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23BPix/jetvetomaps.json.gz
-            name: "deepJet_shape"
 
     vetomaps:
         '2022_preEE':

--- a/pocket_coffea/parameters/lepton_scale_factors.yaml
+++ b/pocket_coffea/parameters/lepton_scale_factors.yaml
@@ -129,33 +129,6 @@ lepton_scale_factors:
       '2022_postEE':
           file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2022EE_27Jun2023/muon_Z.json.gz
     
-    iso_mapping:
-      "tightId":
-        id: NUM_TightID_DEN_TrackerMuons
-        iso: 
-          "TightPFIso": 
-            name: NUM_TightPFIso_DEN_TightID
-          "LoosePFIso":
-            name: NUM_LoosePFIso_DEN_TightID
-      "mediumId":
-        id: NUM_MediumID_DEN_TrackerMuons
-        iso: 
-          "TightPFIso": 
-            name: NUM_TightPFIso_DEN_MediumID
-          "LoosePFIso":
-            name: NUM_LoosePFIso_DEN_MediumID
-      "mediumPromptId":
-        id: NUM_MediumPromptID_DEN_TrackerMuons
-        iso: 
-          "TightPFIso": 
-            name: NUM_TightPFIso_DEN_MediumPromptID
-          "LoosePFIso":
-            name: NUM_LoosePFIso_DEN_MediumPromptID
-      "looseId":
-        id: NUM_LooseID_DEN_TrackerMuons
-        iso: 
-          "LoosePFIso":
-            name: NUM_LoosePFIso_DEN_LooseID
         
 
     era_mapping:

--- a/pocket_coffea/parameters/lepton_scale_factors.yaml
+++ b/pocket_coffea/parameters/lepton_scale_factors.yaml
@@ -4,6 +4,9 @@ lepton_scale_factors:
   electron_sf:
 
     id: 
+    # mapping of the electron id working point of NanoAOD 
+    # to the name of the corresponding scale factors
+    # in the correction set provided by EGM 
       mvaIso_WP80: wp80iso
       mvaIso_WP90: wp90iso
       mvaNoIso_WP80: wp80noiso

--- a/pocket_coffea/parameters/lepton_scale_factors.yaml
+++ b/pocket_coffea/parameters/lepton_scale_factors.yaml
@@ -2,28 +2,59 @@
 lepton_scale_factors:
   ####################################################################################################
   electron_sf:
-    reco:
-      pt_gt_20: RecoAbove20
-      pt_lt_20: RecoBelow20
 
-    id: wp80iso
+    id: 
+      mvaIso_WP80: wp80iso
+      mvaIso_WP90: wp90iso
+      mvaNoIso_WP80: wp80noiso
+      mvaNoIso_WP90: wp90noiso
 
     JSONfiles: 
       '2016_PreVFP':
         file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2016preVFP_UL/electron.json.gz
         name: UL-Electron-ID-SF
+        reco:
+          pt_lt_20: RecoBelow20
+          pt_gt_20: RecoAbove20
   
       '2016_PostVFP':
         file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2016postVFP_UL/electron.json.gz
         name: UL-Electron-ID-SF    
+        reco:
+          pt_lt_20: RecoBelow20
+          pt_gt_20: RecoAbove20
 
       '2017':
         file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2017_UL/electron.json.gz
         name: UL-Electron-ID-SF
+        reco:
+          pt_lt_20: RecoBelow20
+          pt_gt_20: RecoAbove20
 
       '2018':
         file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2018_UL/electron.json.gz
         name: UL-Electron-ID-SF
+        reco:
+          pt_lt_20: RecoBelow20
+          pt_gt_20: RecoAbove20
+
+      '2022_preEE':
+        file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2022_Summer22/electron.json.gz
+        fileSS: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2022_Summer22/electronSS.json.gz
+        name: Electron-ID-SF
+        reco:
+          pt_lt_20: RecoBelow20
+          pt_gt_20_lt_75: Reco20to75
+          pt_gt_75: RecoAbove75
+
+      '2022_postEE':
+        file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2022_Summer22EE/electron.json.gz
+        fileSS: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2022_Summer22EE/electronSS.json.gz
+        name: Electron-ID-SF
+        reco:
+          pt_lt_20: RecoBelow20
+          pt_gt_20_lt_75: Reco20to75
+          pt_gt_75: RecoAbove75
 
     era_mapping:
       # this is needed because the correction set provided by EGM
@@ -32,6 +63,8 @@ lepton_scale_factors:
       "2016_PostVFP": "2016postVFP"
       "2017": "2017"
       "2018": "2018"
+      "2022_preEE": "2022Re-recoBCD"
+      "2022_postEE": "2022Re-recoE+PromptFG"
     
     # The trigger SF configuration is expected to have this structure
     # needs to be provided by the user.
@@ -71,6 +104,17 @@ lepton_scale_factors:
           id: NUM_TightID_DEN_TrackerMuons
           iso: NUM_LooseRelIso_DEN_TightIDandIPCut
           trigger: NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight
+
+      '2022_preEE':
+          id: NUM_TightID_DEN_TrackerMuons
+          iso: NUM_LoosePFIso_DEN_TightID
+          # trigger: NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight
+
+      '2022_postEE':
+          id: NUM_TightID_DEN_TrackerMuons
+          iso: NUM_LoosePFIso_DEN_TightID
+          # trigger: NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight
+
     JSONfiles:
       '2016_PreVFP':
           file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2016preVFP_UL/muon_Z.json.gz
@@ -80,6 +124,39 @@ lepton_scale_factors:
           file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2017_UL/muon_Z.json.gz
       '2018':
           file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2018_UL/muon_Z.json.gz
+      '2022_preEE':
+          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2022_27Jun2023/muon_Z.json.gz
+      '2022_postEE':
+          file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/MUO/2022EE_27Jun2023/muon_Z.json.gz
+    
+    iso_mapping:
+      "tightId":
+        id: NUM_TightID_DEN_TrackerMuons
+        iso: 
+          "TightPFIso": 
+            name: NUM_TightPFIso_DEN_TightID
+          "LoosePFIso":
+            name: NUM_LoosePFIso_DEN_TightID
+      "mediumId":
+        id: NUM_MediumID_DEN_TrackerMuons
+        iso: 
+          "TightPFIso": 
+            name: NUM_TightPFIso_DEN_MediumID
+          "LoosePFIso":
+            name: NUM_LoosePFIso_DEN_MediumID
+      "mediumPromptId":
+        id: NUM_MediumPromptID_DEN_TrackerMuons
+        iso: 
+          "TightPFIso": 
+            name: NUM_TightPFIso_DEN_MediumPromptID
+          "LoosePFIso":
+            name: NUM_LoosePFIso_DEN_MediumPromptID
+      "looseId":
+        id: NUM_LooseID_DEN_TrackerMuons
+        iso: 
+          "LoosePFIso":
+            name: NUM_LoosePFIso_DEN_LooseID
+        
 
     era_mapping:
         # this is needed because the correction set provided by MUO

--- a/pocket_coffea/parameters/lumi.yaml
+++ b/pocket_coffea/parameters/lumi.yaml
@@ -27,20 +27,20 @@ lumi:
       tot: 59832.47534
 
     "2022_preEE":
-      C: 4953
-      D: 2922
-      tot: 7875
+      C: 5010.4
+      D: 2970.0
+      tot: 7980.4
     "2022_postEE":
-      E: 5672
-      F: 17610
-      G: 3055
-      tot: 26337
+      E: 5807.0 
+      F: 17781.9
+      G: 3082.8
+      tot: 26671.7
     "2023_preBPix": 
-      C: 17981
-      tot: 17981
+      C: 17650 
+      tot: 17650
     "2023_postBPix":
-      D: 9516 
-      tot: 9516
+      D: 9451  
+      tot: 9451
       
   goldenJSON:
     '2016_PreVFP': "${default_params_dir:}/datacert/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt"

--- a/pocket_coffea/parameters/pileup.yaml
+++ b/pocket_coffea/parameters/pileup.yaml
@@ -11,4 +11,16 @@ pileupJSONfiles:
   '2018':
     file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2018_UL/puWeights.json.gz
     name: Collisions18_UltraLegacy_goldenJSON
+  2022_preEE: 
+    file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2022_Summer22/puWeights.json.gz
+    name: Collisions2022_355100_357900_eraBCD_GoldenJson
+  2022_postEE: 
+    file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2022_Summer22EE/puWeights.json.gz
+    name: Collisions2022_359022_362760_eraEFG_GoldenJson
+  2023_preBPix:
+    file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2023_Summer23/puWeights.json.gz
+    name: Collisions2023_366403_369802_eraBC_GoldenJson
+  2023_postBPix:
+    file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2023_Summer23BPix/puWeights.json.gz
+    name: Collisions2023_369803_370790_eraD_GoldenJson
 


### PR DESCRIPTION
Added some new defaults for Run3:

1.  PUid: Added 2022/2023 periods in `pocket_coffea/parameters/pileup.yaml`
2. Lumi: Corrected the defaults in `pocket_coffea/parameters/lumi.yaml` according to the current recommentations (with normtag, see [here](https://twiki.cern.ch/twiki/bin/view/CMS/LumiRecommendationsRun3))
3. Added feature, that iso cut on electrons is not needed to be given in params, since current recommendation includes no iso cut on electrons, since mva ID includes iso information
4. sf_ele_reco/id: 
  - Changed mapping of params for electron id/reco sfs, since pt_regions are different for Run3 and therefore depend on the year
 - Adapted `sf_ele_reco` function to account for the changes and enable more than 2 pt_regions
 - Cross checked implementation for 2018, seems to give same results, still left old function in for reference
5. Added "jetVetoMaps" params according to current recommentdation, could also add my corresponding function evaluating the correctionlib file to `cut_functions.py`? Currently have it in my `custom_cut_functions.py`