### PR TITLE
Adding Run2 sf_ele default mappings

### DIFF
--- a/pocket_coffea/parameters/lepton_scale_factors.yaml
+++ b/pocket_coffea/parameters/lepton_scale_factors.yaml
@@ -11,6 +11,10 @@ lepton_scale_factors:
       mvaIso_WP90: wp90iso
       mvaNoIso_WP80: wp80noiso
       mvaNoIso_WP90: wp90noiso
+      mvaFall17V2Iso_WP80: wp80iso
+      mvaFall17V2Iso_WP90: wp90iso
+      mvaFall17V2noIso_WP80: wp80noiso
+      mvaFall17V2noIso_WP90: wp90noiso
 
     JSONfiles: 
       '2016_PreVFP':


### PR DESCRIPTION
Addition of the proper mappins of the lepton ID name in NanoAOD to the naming in the correctionlib set provided by EGM for the Run2 UL working points.