### PR TITLE
Update Mu SFs for latest convention from POG

### DIFF
--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -84,30 +84,19 @@ def get_mu_sf(params, year, pt, eta, counts, key=''):
     muon_correctionset = correctionlib.CorrectionSet.from_file(
         muonSF.JSONfiles[year]['file']
     )
+    
     sfName = muonSF.sf_name[year][key]
-
-    if year in ['2016_PreVFP', '2016_PostVFP','2017','2018']:
-        year_pog = muonSF.era_mapping[year]
-        sf = muon_correctionset[sfName].evaluate(
-            year_pog, np.abs(eta.to_numpy()), pt.to_numpy(), "sf"
-        )
-        sfup = muon_correctionset[sfName].evaluate(
-            year_pog, np.abs(eta.to_numpy()), pt.to_numpy(), "systup"
-        )
-        sfdown = muon_correctionset[sfName].evaluate(
-            year_pog, np.abs(eta.to_numpy()), pt.to_numpy(), "systdown"
-        )
-    else: 
-        sf = muon_correctionset[sfName].evaluate(
-            np.abs(eta.to_numpy()), pt.to_numpy(), "nominal"
-        )
-        sfup = muon_correctionset[sfName].evaluate(
-            np.abs(eta.to_numpy()), pt.to_numpy(), "systup"
-        )
-        sfdown = muon_correctionset[sfName].evaluate(
-            np.abs(eta.to_numpy()), pt.to_numpy(), "systdown"
-        )
-
+    
+    sf = muon_correctionset[sfName].evaluate(
+        np.abs(eta.to_numpy()), pt.to_numpy(), "nominal"
+    )
+    sfup = muon_correctionset[sfName].evaluate(
+        np.abs(eta.to_numpy()), pt.to_numpy(), "systup"
+    )
+    sfdown = muon_correctionset[sfName].evaluate(
+        np.abs(eta.to_numpy()), pt.to_numpy(), "systdown"
+    )
+    
     # The unflattened arrays are returned in order to have one row per event.
     return (
         ak.unflatten(sf, counts),


### PR DESCRIPTION
Simple change to make Muon SFs work again. The POG unified the corrections for Run2 and Run3, now year/era is not needed anymore. It is defined by the correction file itself.