### PR TITLE
Added back the dataset discovery cli in PocketCoffea

### DIFF
--- a/pocket_coffea/__init__.py
+++ b/pocket_coffea/__init__.py
@@ -1,11 +1,11 @@
 """
-Copyright (c) 2024 Davide Valsecchi . All rights reserved.
+Copyright (c) 2024 Davide Valsecchi. All rights reserved.
 
 PocketCoffea: Configurable analysis framework based on Coffea for CMS NanoAOD events analysis
 """
 
 from __future__ import annotations
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 __all__ = ("__version__",)

--- a/pocket_coffea/__main__.py
+++ b/pocket_coffea/__main__.py
@@ -3,6 +3,7 @@ from rich import print
 import pocket_coffea
 from pocket_coffea.scripts.runner import run
 from pocket_coffea.scripts.dataset.build_datasets import build_datasets
+from pocket_coffea.scripts.dataset.dataset_query import dataset_discovery_cli
 from pocket_coffea.scripts.plot.make_plots import make_plots
 from pocket_coffea.scripts.hadd_skimmed_files import hadd_skimmed_files
 from pocket_coffea.scripts.merge_outputs import merge_outputs
@@ -32,6 +33,7 @@ def cli(ctx, version):
     pass
 
 cli.add_command(build_datasets)
+cli.add_command(dataset_discovery_cli)
 cli.add_command(run)
 cli.add_command(make_plots)
 cli.add_command(hadd_skimmed_files)

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -1,6 +1,6 @@
 general: 
   scaleout: 1
-  chunksize: 50000
+  chunksize: 150000
   limit-files: null
   limit-chunks: null
   retries: 20

--- a/pocket_coffea/scripts/dataset/build_datasets.py
+++ b/pocket_coffea/scripts/dataset/build_datasets.py
@@ -47,20 +47,20 @@ from pocket_coffea.utils import dataset
 @click.option("-l", "--local-prefix", type=str, default=None)
 @click.option(
     "-ws",
-    "--whitelist-sites",
+    "--allowlist-sites",
     type=str,
     multiple=True,
 )
 @click.option(
     "-bs",
-    "--blacklist-sites",
+    "--blocklist-sites",
     type=str,
     multiple=True,
 )
 @click.option("-rs", "--regex-sites", type=str)
 @click.option("-p", "--parallelize", type=int, default=4)
 def build_datasets(cfg, keys, download, overwrite, check,
-         split_by_year, local_prefix, whitelist_sites, blacklist_sites, regex_sites, parallelize):
+         split_by_year, local_prefix, allowlist_sites, blocklist_sites, regex_sites, parallelize):
     '''Build dataset fileset in json format'''
     dataset.build_datasets(cfg=cfg,
                            keys=keys,
@@ -69,8 +69,8 @@ def build_datasets(cfg, keys, download, overwrite, check,
                            check=check,
                            split_by_year=split_by_year,
                            local_prefix=local_prefix,
-                           whitelist_sites=whitelist_sites,
-                           blacklist_sites=blacklist_sites,
+                           allowlist_sites=allowlist_sites,
+                           blocklist_sites=blocklist_sites,
                            regex_sites=regex_sites,
                            parallelize=parallelize)
 

--- a/pocket_coffea/scripts/dataset/dataset_query.py
+++ b/pocket_coffea/scripts/dataset/dataset_query.py
@@ -116,7 +116,6 @@ class DataDiscoveryCLI:
             "replicas",
             "list-replicas",
             "save",
-            "preprocess",
             "allow-sites",
             "block-sites",
             "regex-sites",

--- a/pocket_coffea/scripts/dataset/dataset_query.py
+++ b/pocket_coffea/scripts/dataset/dataset_query.py
@@ -1,0 +1,609 @@
+import argparse
+import gzip
+import json
+import os
+import random
+from collections import defaultdict
+from typing import List
+
+import yaml
+import click
+from rich import print
+from rich.console import Console
+from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.table import Table
+from rich.tree import Tree
+
+from pocket_coffea.utils import rucio as rucio_utils
+
+def print_dataset_query(query, dataset_list, console, selected=[]):
+    table = Table(title=f"Query: [bold red]{query}")
+    table.add_column("Name", justify="left", style="cyan", no_wrap=True)
+    table.add_column("Tag", style="magenta", no_wrap=True)
+    table.add_column("Selected", justify="center")
+    table.row_styles = ["dim", "none"]
+    j = 1
+    for name, conds in dataset_list.items():
+        ic = 0
+        ncond = len(conds)
+        for c, tiers in conds.items():
+            dataset = f"/{name}/{c}/{tiers[0]}"
+            sel = dataset in selected
+            if ic == 0:
+                table.add_row(
+                    name,
+                    f"[bold]({j})[/bold] {c}/{'-'.join(tiers)}",
+                    "[green bold]Y" if sel else "[red]N",
+                    end_section=ic == ncond - 1,
+                )
+            else:
+                table.add_row(
+                    "",
+                    f"[bold]({j})[/bold] {c}/{'-'.join(tiers)}",
+                    "[green bold]Y" if sel else "[red]N",
+                    end_section=ic == ncond - 1,
+                )
+            ic += 1
+            j += 1
+
+    console.print(table)
+
+
+def get_indices_query(input_str: str, maxN: int) -> List[int]:
+    tokens = input_str.strip().split(" ")
+    final_tokens = []
+    for t in tokens:
+        if t.isdigit():
+            if int(t) > maxN:
+                print(
+                    f"[red bold]Requested index {t} larger than available elements {maxN}"
+                )
+                return False
+            final_tokens.append(int(t) - 1)  # index 0
+        elif "-" in t:
+            rng = t.split("-")
+            try:
+                for i in range(
+                    int(rng[0]), int(rng[1]) + 1
+                ):  # including the last index
+                    if i > maxN:
+                        print(
+                            f"[red bold]Requested index {t} larger than available elements {maxN}"
+                        )
+                        return False
+                    final_tokens.append(i - 1)
+            except Exception:
+                print(
+                    "[red]Error! Bad formatting for selection string. Use e.g. 1 4 5-9"
+                )
+                return False
+        elif t == "all":
+            final_tokens = list(range(0, maxN))
+        else:
+            print("[red]Error! Bad formatting for selection string. Use e.g. 1 4 5-9")
+            return False
+    return final_tokens
+
+
+class DataDiscoveryCLI:
+    def __init__(self):
+        self.console = Console()
+        self.rucio_client = None
+        self.selected_datasets = []
+        self.selected_datasets_metadata = []
+        self.last_query = ""
+        self.last_query_tree = None
+        self.last_query_list = None
+        self.sites_allowlist = None
+        self.sites_blocklist = None
+        self.sites_regex = None
+        self.last_replicas_results = None
+        self.final_output = None
+        self.preprocessed_total = None
+        self.preprocessed_available = None
+
+        self.replica_results = defaultdict(list)
+        self.replica_results_metadata = {}
+        self.replica_results_bysite = {}
+
+        self.commands = [
+            "help",
+            "login",
+            "query",
+            "query-results",
+            "select",
+            "list-selected",
+            "replicas",
+            "list-replicas",
+            "save",
+            "preprocess",
+            "allow-sites",
+            "block-sites",
+            "regex-sites",
+            "sites-filters",
+            "quit",
+        ]
+
+    def start_cli(self):
+        while True:
+            command = Prompt.ask(">", choices=self.commands)
+            if command == "help":
+                print(
+                    r"""[bold yellow]Welcome to the datasets discovery coffea CLI![/bold yellow]
+Use this CLI tool to query the CMS datasets and to select interactively the grid sites to use for reading the files in your analysis.
+Some basic commands:
+  - [bold cyan]query[/]: Look for datasets with * wildcards (like in DAS)
+  - [bold cyan]select[/]: Select datasets to process further from query results
+  - [bold cyan]replicas[/]: Query rucio to look for files replica and then select the preferred sites
+  - [bold cyan]query-results[/]: List the results of the last dataset query
+  - [bold cyan]list-selected[/]: Print a list of the selected datasets
+  - [bold cyan]list-replicas[/]: Print the selected files replicas for the selected dataset
+  - [bold cyan]sites-filters[/]: show the active sites filters and ask to clear them
+  - [bold cyan]allow-sites[/]: Restrict the grid sites available for replicas query only to the requested list
+  - [bold cyan]block-sites[/]: Exclude grid sites from the available sites for replicas query
+  - [bold cyan]regex-sites[/]: Select sites with a regex for replica queries: e.g.  "T[123]_(FR|IT|BE|CH|DE)_\w+"
+  - [bold cyan]save[/]: Save the replicas query results to file (json or yaml) for further processing
+  - [bold cyan]help[/]: Print this help message
+            """
+                )
+            elif command == "login":
+                self.do_login()
+            elif command == "quit":
+                print("Bye!")
+                break
+            elif command == "query":
+                self.do_query()
+            elif command == "query-results":
+                self.do_query_results()
+            elif command == "select":
+                self.do_select()
+            elif command == "list-selected":
+                self.do_list_selected()
+            elif command == "replicas":
+                self.do_replicas()
+            elif command == "list-replicas":
+                self.do_list_replicas()
+            elif command == "save":
+                self.do_save()
+            elif command == "allow-sites":
+                self.do_allowlist_sites()
+            elif command == "block-sites":
+                self.do_blocklist_sites()
+            elif command == "regex-sites":
+                self.do_regex_sites()
+            elif command == "sites-filters":
+                self.do_sites_filters()
+            else:
+                break
+
+    def do_login(self, proxy=None):
+        """Login to the rucio client. Optionally a specific proxy file can be passed to the command.
+        If the proxy file is not specified, `voms-proxy-info` is used"""
+        if proxy:
+            self.rucio_client = rucio_utils.get_rucio_client(proxy)
+        else:
+            self.rucio_client = rucio_utils.get_rucio_client()
+        print(self.rucio_client)
+
+    def do_whoami(self):
+        # Your code here
+        if not self.rucio_client:
+            print("First [bold]login (L)[/] to the rucio server")
+            return
+        print(self.rucio_client.whoami())
+
+    def do_query(self, query=None):
+        # Your code here
+        if query is None:
+            query = Prompt.ask(
+                "[yellow bold]Query for[/]",
+            )
+        with self.console.status(f"Querying rucio for: [bold red]{query}[/]"):
+            outlist, outtree = rucio_utils.query_dataset(
+                query,
+                client=self.rucio_client,
+                tree=True,
+                scope="cms",  # TODO configure scope
+            )
+            # Now let's print the results as a tree
+            print_dataset_query(query, outtree, self.console, self.selected_datasets)
+            self.last_query = query
+            self.last_query_list = outlist
+            self.last_query_tree = outtree
+        print("Use the command [bold red]select[/] to selected the datasets")
+
+    def do_query_results(self):
+        if self.last_query_list:
+            print_dataset_query(
+                self.last_query,
+                self.last_query_tree,
+                self.console,
+                self.selected_datasets,
+            )
+        else:
+            print("First [bold red]query (Q)[/] for a dataset")
+
+    def do_select(self, selection=None, metadata=None):
+        """Selected the datasets from the list of query results. Input a list of indices
+        also with range 4-6 or "all"."""
+        if not self.last_query_list:
+            print("First [bold red]query (Q)[/] for a dataset")
+            return
+
+        if selection is None:
+            selection = Prompt.ask(
+                "[yellow bold]Select datasets indices[/] (e.g 1 4 6-10)", default="all"
+            )
+        final_tokens = get_indices_query(selection, len(self.last_query_list))
+        if not final_tokens:
+            return
+
+        Nresults = len(self.last_query_list)
+        print("[cyan]Selected datasets:")
+
+        for s in final_tokens:
+            if s < Nresults:
+                self.selected_datasets.append(self.last_query_list[s])
+                if metadata:
+                    self.selected_datasets_metadata.append(metadata)
+                else:
+                    self.selected_datasets_metadata.append({})
+                print(f"- ({s+1}) {self.last_query_list[s]}")
+            else:
+                print(
+                    f"[red]The requested dataset is not in the list. Please insert a position <={Nresults}"
+                )
+
+    def do_list_selected(self):
+        print("[cyan]Selected datasets:")
+        table = Table(title="Selected datasets")
+        table.add_column("Index", justify="left", style="cyan", no_wrap=True)
+        table.add_column("Dataset", style="magenta", no_wrap=True)
+        table.add_column("Replicas selected", justify="center")
+        table.add_column("N. of files", justify="center")
+        for i, ds in enumerate(self.selected_datasets):
+            table.add_row(
+                str(i + 1),
+                ds,
+                "[green bold]Y" if ds in self.replica_results else "[red]N",
+                (
+                    str(len(self.replica_results[ds]))
+                    if ds in self.replica_results
+                    else "-"
+                ),
+            )
+        self.console.print(table)
+
+    def do_replicas(self, mode=None, selection=None):
+        """Query Rucio for replicas.
+        mode: - None:  ask the user about the mode
+              - round-robin (take files randomly from available sites),
+              - choose: ask the user to choose from a list of sites
+              - first: take the first site from the rucio query
+        selection: list of indices or 'all' to select all the selected datasets for replicas query
+        """
+        if selection is None:
+            selection = Prompt.ask(
+                "[yellow bold]Select datasets indices[/] (e.g 1 4 6-10)", default="all"
+            )
+        indices = get_indices_query(selection, len(self.selected_datasets))
+        if not indices:
+            return
+        datasets = [
+            (self.selected_datasets[ind], self.selected_datasets_metadata[ind])
+            for ind in indices
+        ]
+
+        for dataset, dataset_metadata in datasets:
+            with self.console.status(
+                f"Querying rucio for replicas: [bold red]{dataset}[/]"
+            ):
+                try:
+                    (
+                        outfiles,
+                        outsites,
+                        sites_counts,
+                    ) = rucio_utils.get_dataset_files_replicas(
+                        dataset,
+                        allowlist_sites=self.sites_allowlist,
+                        blocklist_sites=self.sites_blocklist,
+                        regex_sites=self.sites_regex,
+                        mode="full",
+                        client=self.rucio_client,
+                    )
+                except Exception as e:
+                    print(f"\n[red bold] Exception: {e}[/]")
+                    return
+                self.last_replicas_results = (outfiles, outsites, sites_counts)
+
+            print(f"[cyan]Sites availability for dataset: [red]{dataset}")
+            table = Table(title="Available replicas")
+            table.add_column("Index", justify="center")
+            table.add_column("Site", justify="left", style="cyan", no_wrap=True)
+            table.add_column("Files", style="magenta", no_wrap=True)
+            table.add_column("Availability", justify="center")
+            table.row_styles = ["dim", "none"]
+            Nfiles = len(outfiles)
+
+            sorted_sites = dict(
+                sorted(sites_counts.items(), key=lambda x: x[1], reverse=True)
+            )
+            for i, (site, stat) in enumerate(sorted_sites.items()):
+                table.add_row(
+                    str(i), site, f"{stat} / {Nfiles}", f"{stat*100/Nfiles:.1f}%"
+                )
+
+            self.console.print(table)
+            if mode is None:
+                mode = Prompt.ask(
+                    "Select sites",
+                    choices=["round-robin", "choose", "first", "quit"],
+                    default="round-robin",
+                )
+
+            files_by_site = defaultdict(list)
+
+            if mode == "choose":
+                ind = list(
+                    map(
+                        int,
+                        Prompt.ask(
+                            "Enter list of sites index to be used", default="0"
+                        ).split(" "),
+                    )
+                )
+                sites_to_use = [list(sorted_sites.keys())[i] for i in ind]
+                print(f"Filtering replicas with [green]: {' '.join(sites_to_use)}")
+
+                output = []
+                for ifile, (files, sites) in enumerate(zip(outfiles, outsites)):
+                    random.shuffle(sites_to_use)
+                    found = False
+                    # loop on shuffled selected sites until one is found
+                    for site in sites_to_use:
+                        try:
+                            iS = sites.index(site)
+                            output.append(files[iS])
+                            files_by_site[sites[iS]].append(files[iS])
+                            found = True
+                            break  # keep only one replica
+                        except ValueError:
+                            # if the index is not found just go to the next site
+                            pass
+
+                    if not found:
+                        print(
+                            f"[bold red]No replica found compatible with sites selection for file #{ifile}. The available sites are:"
+                        )
+                        for f, s in zip(files, sites):
+                            print(f"\t- [green]{s} [cyan]{f}")
+                        return
+
+                self.replica_results[dataset] = output
+                self.replica_results_metadata[dataset] = dataset_metadata
+
+            elif mode == "round-robin":
+                output = []
+                for ifile, (files, sites) in enumerate(zip(outfiles, outsites)):
+                    # selecting randomly from the sites
+                    iS = random.randint(0, len(sites) - 1)
+                    output.append(files[iS])
+                    files_by_site[sites[iS]].append(files[iS])
+                self.replica_results[dataset] = output
+                self.replica_results_metadata[dataset] = dataset_metadata
+
+            elif mode == "first":
+                output = []
+                for ifile, (files, sites) in enumerate(zip(outfiles, outsites)):
+                    output.append(files[0])
+                    files_by_site[sites[0]].append(files[0])
+                self.replica_results[dataset] = output
+                self.replica_results_metadata[dataset] = dataset_metadata
+
+            elif mode == "quit":
+                print("[orange]Doing nothing...")
+                return
+
+            self.replica_results_bysite[dataset] = files_by_site
+
+            # Now let's print the results
+            tree = Tree(label=f"[bold orange]Replicas for [green]{dataset}")
+            for site, files in files_by_site.items():
+                T = tree.add(f"[green]{site}")
+                for f in files:
+                    T.add(f"[cyan]{f}")
+            self.console.print(tree)
+
+        # Building an uproot compatible output
+        self.final_output = {}
+        for fileset, files in self.replica_results.items():
+            self.final_output[fileset] = {
+                "files": {f: "Events" for f in files},
+                "metadata": self.replica_results_metadata[fileset],
+            }
+        return self.final_output
+
+    @property
+    def as_dict(self):
+        return self.final_output
+
+    def do_allowlist_sites(self, sites=None):
+        if sites is None:
+            sites = Prompt.ask(
+                "[yellow]Restrict the available sites to (comma-separated list)"
+            ).split(",")
+        if self.sites_allowlist is None:
+            self.sites_allowlist = sites
+        else:
+            self.sites_allowlist += sites
+        print("[green]Allowlisted sites:")
+        for s in self.sites_allowlist:
+            print(f"- {s}")
+
+    def do_blocklist_sites(self, sites=None):
+        if sites is None:
+            sites = Prompt.ask(
+                "[yellow]Exclude the sites (comma-separated list)"
+            ).split(",")
+        if self.sites_blocklist is None:
+            self.sites_blocklist = sites
+        else:
+            self.sites_blocklist += sites
+        print("[red]Blocklisted sites:")
+        for s in self.sites_blocklist:
+            print(f"- {s}")
+
+    def do_regex_sites(self, regex=None):
+        if regex is None:
+            regex = Prompt.ask("[yellow]Regex to restrict the available sites")
+        if len(regex):
+            self.sites_regex = rf"{regex}"
+            print(f"New sites regex: [cyan]{self.sites_regex}")
+
+    def do_sites_filters(self, ask_clear=True):
+        print("[green bold]Allow-listed sites:")
+        if self.sites_allowlist:
+            for s in self.sites_allowlist:
+                print(f"- {s}")
+
+        print("[bold red]Block-listed sites:")
+        if self.sites_blocklist:
+            for s in self.sites_blocklist:
+                print(f"- {s}")
+
+        print(f"[bold cyan]Sites regex: [italics]{self.sites_regex}")
+
+        if ask_clear:
+            if Confirm.ask("Clear sites restrinction?", default=False):
+                self.sites_allowlist = None
+                self.sites_blocklist = None
+                self.sites_regex = None
+                print("[bold green]Sites filters cleared")
+
+    def do_list_replicas(self):
+        selection = Prompt.ask(
+            "[yellow bold]Select datasets indices[/] (e.g 1 4 6-10)", default="all"
+        )
+        indices = get_indices_query(selection, len(self.selected_datasets))
+        datasets = [self.selected_datasets[ind] for ind in indices]
+
+        for dataset in datasets:
+            if dataset not in self.replica_results:
+                print(
+                    f"[red bold]No replica info for dataset {dataset}. You need to selected the replicas with [cyan] replicas [/cyan] command[/]"
+                )
+                return
+            tree = Tree(label=f"[bold orange]Replicas for [/][green]{dataset}[/]")
+            for site, files in self.replica_results_bysite[dataset].items():
+                T = tree.add(f"[green]{site}")
+                for f in files:
+                    T.add(f"[cyan]{f}")
+
+            self.console.print(tree)
+
+    def do_save(self, filename=None):
+        """Save the replica information in yaml format"""
+        if not filename:
+            filename = Prompt.ask(
+                "[yellow bold]Output file name (.yaml or .json)", default="output.json"
+            )
+        format = os.path.splitext(filename)[1]
+        if not format:
+            raise Exception("[red] Please use a .json or .yaml filename for the output")
+        with open(filename, "w") as file:
+            if format == ".yaml":
+                yaml.dump(self.final_output, file, default_flow_style=False)
+            elif format == ".json":
+                json.dump(self.final_output, file, indent=2)
+        print(f"[green]File {filename} saved!")
+    def load_dataset_definition(
+        self,
+        dataset_definition,
+        query_results_strategy="all",
+        replicas_strategy="round-robin",
+    ):
+        """
+        Initialize the DataDiscoverCLI by querying a set of datasets defined in `dataset_definitions`
+        and selected results and replicas following the options.
+
+        - query_results_strategy:  "all" or "manual" to be prompt for selection
+        - replicas_strategy:
+            - "round-robin": select randomly from the available sites for each file
+            - "choose": filter the sites with a list of indices for all the files
+            - "first": take the first result returned by rucio
+            - "manual": to be prompt for manual decision dataset by dataset
+        """
+        for dataset_query, dataset_meta in dataset_definition.items():
+            print(f"\nProcessing query: {dataset_query}")
+            # Adding queries
+            self.do_query(dataset_query)
+            # Now selecting the results depending on the interactive mode or not.
+            # Metadata are passed to the selection function to associated them with the selected dataset.
+            if query_results_strategy not in ["all", "manual"]:
+                raise ValueError(
+                    "Invalid query-results-strategy option: please choose between: manual|all"
+                )
+            elif query_results_strategy == "manual":
+                self.do_select(selection=None, metadata=dataset_meta)
+            else:
+                self.do_select(selection="all", metadata=dataset_meta)
+
+        # Now list all
+        self.do_list_selected()
+
+        # selecting replicas
+        self.do_sites_filters(ask_clear=False)
+        print("Getting replicas")
+        if replicas_strategy == "manual":
+            out_replicas = self.do_replicas(mode=None, selection="all")
+        else:
+            if replicas_strategy not in ["round-robin", "choose", "first"]:
+                raise ValueError(
+                    "Invalid replicas-strategy: please choose between manual|round-robin|choose|first"
+                )
+            out_replicas = self.do_replicas(mode=replicas_strategy, selection="all")
+        # Now list all
+        self.do_list_selected()
+        return out_replicas
+
+
+    
+
+# This is the main function that will be called by the CLI
+      
+@click.command()
+@click.option("--dataset-definition", help="Dataset definition file", type=str, required=False)
+@click.option("--output", help="Output name for dataset discovery output (no fileset preprocessing)", type=str, required=False, default="output_dataset.json")
+@click.option("--fileset-output", help="Output name for fileset", type=str, required=False, default="output_fileset")
+@click.option("--allow-sites", help="List of sites to be allowlisted", nargs="+", type=str)
+@click.option("--block-sites", help="List of sites to be blocklisted", nargs="+", type=str)
+@click.option("--regex-sites", help="Regex string to be used to filter the sites", type=str)
+@click.option("--query-results-strategy", help="Mode for query results selection: [all|manual]", type=str, default="all")
+@click.option("--replicas-strategy", help="Mode for selecting replicas for datasets: [manual|round-robin|first|choose]", default="round-robin", required=False)
+def dataset_discovery_cli(dataset_definition, output, fileset_output, allow_sites, block_sites, regex_sites, query_results_strategy, replicas_strategy):
+    '''CLI for interactive dataset discovery'''
+    cli = DataDiscoveryCLI()
+
+    if allow_sites:
+        cli.sites_allowlist = allow_sites
+    if block_sites:
+        cli.sites_blocklist = block_sites
+    if regex_sites:
+        cli.sites_regex = regex_sites
+
+    if dataset_definition:
+        with open(dataset_definition) as file:
+            dd = json.load(file)
+        cli.load_dataset_definition(
+            dd,
+            query_results_strategy=query_results_strategy,
+            replicas_strategy=replicas_strategy,
+        )
+        # Save
+        if output:
+            cli.do_save(filename=output)
+
+    cli.start_cli()
+
+if __name__ == "__main__":
+    dataset_query_cli()

--- a/pocket_coffea/scripts/merge_outputs.py
+++ b/pocket_coffea/scripts/merge_outputs.py
@@ -21,6 +21,7 @@ from glob import glob
     help="Output file",
 )
 def merge_outputs(inputfiles, outputfile):
+    '''Merge coffea output files'''
     files = []
     for f in inputfiles:
         files += glob(f)

--- a/pocket_coffea/utils/dataset.py
+++ b/pocket_coffea/utils/dataset.py
@@ -33,8 +33,8 @@ def do_dataset(key, config, local_prefix, whitelist_sites, blacklist_sites, rege
             name=key,
             cfg=dataset_cfg,
             sites_cfg={
-                "whitelist_sites": whitelist_sites,
-                "blacklist_sites": blacklist_sites,
+                "allowlist_sites": allowlist_sites,
+                "blocklist_sites": blocklist_sites,
                 "regex_sites": regex_sites,
             },
         )
@@ -46,7 +46,7 @@ def do_dataset(key, config, local_prefix, whitelist_sites, blacklist_sites, rege
 
 
 def build_datasets(cfg, keys=None, overwrite=False, download=False, check=False, split_by_year=False, local_prefix=None,
-                   whitelist_sites=None, blacklist_sites=None, regex_sites=None, parallelize=4):
+                   allowlist_sites=None, blocklist_sites=None, regex_sites=None, parallelize=4):
 
     config = json.load(open(cfg))
 
@@ -60,8 +60,8 @@ def build_datasets(cfg, keys=None, overwrite=False, download=False, check=False,
         "check": check,
         "split_by_year": split_by_year,
         "local_prefix": local_prefix,
-        "whitelist_sites": whitelist_sites,
-        "blacklist_sites": blacklist_sites,
+        "allowlist_sites": allowlist_sites,
+        "blocklist_sites": blocklist_sites,
         "regex_sites": regex_sites,
         "parallelize": parallelize
     }
@@ -92,7 +92,7 @@ class Sample:
          -- year
          -- isMC: true/false
          -- era: A/B/C/D (only for data)
-        - sites_cfg is a dictionary contaning whitelist, blacklist and regex to filter the SITES
+        - sites_cfg is a dictionary contaning allowlist, blocklist and regex to filter the SITES
         '''
         self.name = name
         self.das_names = das_names
@@ -154,8 +154,8 @@ class Sample:
 
             if self.metadata.get("dbs_instance", "prod/global") == "prod/global":
                 # Now query rucio to get the concrete dataset passing the sites filtering options
-                files_replicas, sites = rucio.get_dataset_files(
-                    das_name, **self.sites_cfg, output="first"
+                files_replicas, sites = rucio.get_dataset_files_replicas(
+                    das_name, **self.sites_cfg, mode="first"
                 )
             else:
                 # Use DBS to get the site
@@ -228,8 +228,8 @@ class Dataset:
             sites_cfg
             if sites_cfg
             else {
-                "whitelist_sites": None,
-                "blacklist_sites": None,
+                "allowlist_sites": None,
+                "blocklist_sites": None,
                 "regex_sites": None,
             }
         )

--- a/pocket_coffea/utils/dataset.py
+++ b/pocket_coffea/utils/dataset.py
@@ -18,7 +18,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 from .network import get_proxy_path
 from . import rucio
 
-def do_dataset(key, config, local_prefix, whitelist_sites, blacklist_sites, regex_sites, **kwargs):
+def do_dataset(key, config, local_prefix, allowlist_sites, blocklist_sites, regex_sites, **kwargs):
     print("*" * 40)
     print("> Working on dataset: ", key)
     if key not in config:
@@ -154,12 +154,12 @@ class Sample:
 
             if self.metadata.get("dbs_instance", "prod/global") == "prod/global":
                 # Now query rucio to get the concrete dataset passing the sites filtering options
-                files_replicas, sites = rucio.get_dataset_files_replicas(
+                files_replicas, sites, sites_counts = rucio.get_dataset_files_replicas(
                     das_name, **self.sites_cfg, mode="first"
                 )
             else:
                 # Use DBS to get the site
-                files_replicas, sites = rucio.get_dataset_files_from_dbs(das_name, self.metadata["dbs_instance"])
+                files_replicas, sites, sites_counts = rucio.get_dataset_files_from_dbs(das_name, self.metadata["dbs_instance"])
                 
             self.fileslist_concrete += files_replicas
 

--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -163,7 +163,6 @@ def get_dataset_files_replicas(
            Metadata counting the coverage of the dataset by site
 
     """
-    print("CIAOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
     sites_xrootd_prefix = get_xrootd_sites_map()
     client = client if client else get_rucio_client()
     outsites = []

--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -3,29 +3,35 @@ import os
 import getpass
 import re
 import json
+import time
 import requests
 from rucio.client import Client
 from collections import defaultdict
 
-os.environ["RUCIO_HOME"] = "/cvmfs/cms.cern.ch/rucio/x86_64/rhel7/py3/current"
 
-def get_rucio_client():
+# Rucio needs the default configuration --> taken from CMS cvmfs defaults
+if "RUCIO_HOME" not in os.environ:
+    os.environ["RUCIO_HOME"] = "/cvmfs/cms.cern.ch/rucio/current"
 
-    # If the local username account is different than CERN username
-    # one has to setup an environment variable to be accessible here:
-    CERN_USERNAME = os.getenv('CERN_USERNAME')
 
-    if CERN_USERNAME=='':
-        # If the username is not setup - take a local one
-        CERN_USERNAME = getpass.getuser()
+def get_rucio_client(proxy=None) -> Client:
+    """
+    Open a client to the CMS rucio server using x509 proxy.
+
+    Parameters
+    ----------
+        proxy : str, optional
+            Use the provided proxy file if given, if not use `voms-proxy-info` to get the current active one.
+
+    Returns
+    -------
+        nativeClient: rucio.Client
+            Rucio client
+    """
     try:
-        nativeClient = Client(
-            rucio_host="https://cms-rucio.cern.ch",
-            auth_host="https://cms-rucio-auth.cern.ch",
-            account=CERN_USERNAME,
-            creds={"client_cert": get_proxy_path(), "client_key": get_proxy_path()},
-            auth_type='x509',
-        )
+        if not proxy:
+            proxy = get_proxy_path()
+        nativeClient = Client()
         return nativeClient
 
     except Exception as e:
@@ -33,9 +39,25 @@ def get_rucio_client():
         raise e
 
 
+   
 def get_xrootd_sites_map():
+    """
+    The mapping between RSE (sites) and the xrootd prefix rules is read
+    from `/cvmfs/cms/cern.ch/SITECONF/*site*/storage.json`.
+
+    This function returns the list of xrootd prefix rules for each site.
+    """
     sites_xrootd_access = defaultdict(dict)
-    if not os.path.exists(".sites_map.json"):
+    # Check if the cache file has been modified in the last 10 minutes
+    cache_valid = False
+    if os.path.exists(".sites_map.json"):
+        file_time = os.path.getmtime(".sites_map.json")
+        current_time = time.time()
+        ten_minutes_ago = current_time - 600
+        if file_time > ten_minutes_ago:
+            cache_valid = True
+
+    if not os.path.exists(".sites_map.json") or not cache_valid:
         print("Loading SITECONF info")
         sites = [
             (s, "/cvmfs/cms.cern.ch/SITECONF/" + s + "/storage.json")
@@ -47,12 +69,12 @@ def get_xrootd_sites_map():
                 continue
             try:
                 data = json.load(open(conf))
-            except:
+            except Exception:
                 continue
             for site in data:
                 if site["type"] != "DISK":
                     continue
-                if site["rse"] == None:
+                if site["rse"] is None:
                     continue
                 for proc in site["protocols"]:
                     if proc["protocol"] == "XRootD":
@@ -61,28 +83,188 @@ def get_xrootd_sites_map():
                         if "prefix" not in proc:
                             if "rules" in proc:
                                 for rule in proc["rules"]:
-                                    sites_xrootd_access[site["rse"]][rule["lfn"]] = rule["pfn"]
+                                    sites_xrootd_access[site["rse"]][rule["lfn"]] = (
+                                        rule["pfn"]
+                                    )
                         else:
                             sites_xrootd_access[site["rse"]] = proc["prefix"]
-        json.dump(sites_xrootd_access, open(".sites_map.json", "w"))
 
-    else:
-        print("Your .sites_map.json file already exists! Will use that file for sites configuration, not overwriting it.")
-        print("\t If you need it to be updated remove the .sites_map.json and rerun this script again.")
+        json.dump(sites_xrootd_access, open(".sites_map.json", "w"))
 
     return json.load(open(".sites_map.json"))
 
 
 def _get_pfn_for_site(path, rules):
+    """
+    Utility function that converts the file path to a valid pfn matching
+    the file path with the site rules (regexes).
+    """
     if isinstance(rules, dict):
         for rule, pfn in rules.items():
-            if m:=re.match(rule, path):
+            if m := re.match(rule, path):
                 grs = m.groups()
                 for i in range(len(grs)):
                     pfn = pfn.replace(f"${i+1}", grs[i])
                 return pfn
     else:
-        return rules + "/"+ path
+        # not adding any slash as the path usually starts with it
+        return rules + "/" + path if not path.startswith("/") else rules + path
+
+def get_dataset_files_replicas(
+    dataset,
+    allowlist_sites=None,
+    blocklist_sites=None,
+    regex_sites=None,
+    mode="full",
+    partial_allowed=False,
+    client=None,
+    scope="cms",
+):
+    """
+    This function queries the Rucio server to get information about the location
+    of all the replicas of the files in a CMS dataset.
+
+    The sites can be filtered in 3 different ways:
+    - `allowlist_sites`: list of sites to select from. If the file is not found there, raise an Exception.
+    - `blocklist_sites`: list of sites to avoid. If the file has no left site, raise an Exception
+    - `regex_sites`: regex expression to restrict the list of sites.
+
+    The fileset returned by the function is controlled by the `mode` parameter:
+    - "full": returns the full set of replicas and sites (passing the filtering parameters)
+    - "first": returns the first replica found for each file
+    - "best": to be implemented (ServiceX..)
+    - "roundrobin": try to distribute the replicas over different sites
+
+    Parameters
+    ----------
+
+        dataset: str
+        allowlist_sites: list
+        blocklist_sites: list
+        regex_sites: list
+        mode:  str, default "full"
+        client: rucio Client, optional
+        partial_allowed: bool, default False
+        scope:  rucio scope, "cms"
+
+    Returns
+    -------
+        files: list
+           depending on the `mode` option.
+           - If `mode=="full"`, returns the complete list of replicas for each file in the dataset
+           - If `mode=="first"`, returns only the first replica for each file.
+
+        sites: list
+           depending on the `mode` option.
+           - If `mode=="full"`, returns the list of sites where the file replica is available for each file in the dataset
+           - If `mode=="first"`, returns a list of sites for the first replica of each file.
+
+        sites_counts: dict
+           Metadata counting the coverage of the dataset by site
+
+    """
+    sites_xrootd_prefix = get_xrootd_sites_map()
+    client = client if client else get_rucio_client()
+    outsites = []
+    outfiles = []
+    for filedata in client.list_replicas([{"scope": scope, "name": dataset}]):
+        outfile = []
+        outsite = []
+        rses = filedata["rses"]
+        found = False
+        if allowlist_sites:
+            for site in allowlist_sites:
+                if site in rses:
+                    # Check actual availability
+                    meta = filedata["pfns"][rses[site][0]]
+                    if (
+                        meta["type"] != "DISK"
+                        or meta["volatile"]
+                        or filedata["states"][site] != "AVAILABLE"
+                        or site not in sites_xrootd_prefix
+                    ):
+                        continue
+                    outfile.append(
+                        _get_pfn_for_site(filedata["name"], sites_xrootd_prefix[site])
+                    )
+                    outsite.append(site)
+                    found = True
+
+            if not found and not partial_allowed:
+                raise Exception(
+                    f"No SITE available in the allowlist for file {filedata['name']}"
+                )
+        else:
+            possible_sites = list(rses.keys())
+            if blocklist_sites:
+                possible_sites = list(
+                    filter(lambda key: key not in blocklist_sites, possible_sites)
+                )
+
+            if len(possible_sites) == 0 and not partial_allowed:
+                raise Exception(f"No SITE available for file {filedata['name']}")
+
+            # now check for regex
+            for site in possible_sites:
+                if regex_sites:
+                    if re.search(regex_sites, site):
+                        # Check actual availability
+                        meta = filedata["pfns"][rses[site][0]]
+                        if (
+                            meta["type"] != "DISK"
+                            or meta["volatile"]
+                            or filedata["states"][site] != "AVAILABLE"
+                            or site not in sites_xrootd_prefix
+                        ):
+                            continue
+                        outfile.append(
+                            _get_pfn_for_site(
+                                filedata["name"], sites_xrootd_prefix[site]
+                            )
+                        )
+                        outsite.append(site)
+                        found = True
+                else:
+                    # Just take the first one
+                    # Check actual availability
+                    meta = filedata["pfns"][rses[site][0]]
+                    if (
+                        meta["type"] != "DISK"
+                        or meta["volatile"]
+                        or filedata["states"][site] != "AVAILABLE"
+                        or site not in sites_xrootd_prefix
+                    ):
+                        continue
+                    outfile.append(
+                        _get_pfn_for_site(filedata["name"], sites_xrootd_prefix[site])
+                    )
+                    outsite.append(site)
+                    found = True
+
+        if not found and not partial_allowed:
+            raise Exception(f"No SITE available for file {filedata['name']}")
+        else:
+            if mode == "full":
+                outfiles.append(outfile)
+                outsites.append(outsite)
+            elif mode == "first":
+                outfiles.append(outfile[0])
+                outsites.append(outsite[0])
+            else:
+                raise NotImplementedError(f"Mode {mode} not yet implemented!")
+
+    # Computing replicas by site:
+    sites_counts = defaultdict(int)
+    if mode == "full":
+        for sites_by_file in outsites:
+            for site in sites_by_file:
+                sites_counts[site] += 1
+    elif mode == "first":
+        for site_by_file in outsites:
+            sites_counts[site] += 1
+
+    return outfiles, outsites, sites_counts
+
 
 
 def get_dataset_files(
@@ -223,3 +405,42 @@ def get_dataset_files_from_dbs(
     return outputfiles, outputsites
 
 
+
+def query_dataset(
+    query: str, client=None, tree: bool = False, datatype="container", scope="cms"
+):
+    """
+    This function uses the rucio client to query for containers or datasets.
+
+    Parameters
+    ---------
+        query: str = query to filter datasets / containers with the rucio list_dids functions
+        client: rucio client
+        tree: bool = if True return the results splitting the dataset name in parts parts
+        datatype: "container/dataset":  rucio terminology. "Container"==CMS dataset. "Dataset" == CMS block.
+        scope: "cms". Rucio instance
+
+    Returns
+    -------
+       list of containers/datasets
+
+       if tree==True, returns the list of dataset and also a dictionary decomposing the datasets
+       names in the 1st command part and a list of available 2nd parts.
+
+    """
+    client = client if client else get_rucio_client()
+    out = list(
+        client.list_dids(
+            scope=scope, filters={"name": query, "type": datatype}, long=False
+        )
+    )
+    if tree:
+        outdict = {}
+        for dataset in out:
+            split = dataset[1:].split("/")
+            if split[0] not in outdict:
+                outdict[split[0]] = defaultdict(list)
+            outdict[split[0]][split[1]].append(split[2])
+        return out, outdict
+    else:
+        return out

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ console_scripts =
     runner.py = pocket_coffea.scripts.runner:run
     make_plots.py = pocket_coffea.scripts.plot.make_plots:make_plots
     build_datasets.py = pocket_coffea.scripts.dataset.build_datasets:build_datasets
+    dataset_discovery_cli.py = pocket_coffea.scripts.dataset:dataset_discovery_cli
     hadd_skimmed_files.py = pocket_coffea.scripts.hadd_skimmed_files:hadd_skimmed_files
     merge_outputs.py = pocket_coffea.scripts.merge_outputs:merge_outputs
     


### PR DESCRIPTION
The dataset discovery CLI interface has been implemented in coffea calVer for easy lookup of datasets and replicas in a interactive interface. 

I have added it back in PocketCoffea making it compatible with the `dataset_definition.json` format. 
In practice it can be used to dynamically lookup and build a dataset definition file.