### PR TITLE
change run option

### DIFF
--- a/docs/analysis_example.md
+++ b/docs/analysis_example.md
@@ -631,7 +631,7 @@ In this tutorial we **assume the use of lxplus**, but the example should work fi
 
 ```bash
 ## First let's test the running locally with  --test for iterative processor with ``--limit-chunks/-lc``(default:2) and ``--limit-files/-lf``(default:1)
-pocket-coffea run --cfg example_config.py --test  -o output_test
+pocket-coffea run --cfg example_config.py --test --process-separately  -o output_test
 ```
 
 We can now submit the full processing on the HTcondor cluster with dask:
@@ -639,7 +639,7 @@ We can now submit the full processing on the HTcondor cluster with dask:
 ```bash
 ## change the --executor and numbers of jobs with -s/--scaleout
 
-pocket-coffea run --cfg example_config.py  --full --executor dask@lxplus  --scaleout 10  -o output_dask
+pocket-coffea run --cfg example_config.py  --executor dask@lxplus  --scaleout 10  -o output_dask
 ```
 
 The scaleout configurations really depends on cluster and schedulers with different sites(lxplus, LPC, naf-desy).
@@ -655,7 +655,7 @@ scaleout: 20
 
 Try now to run with custom options: 
 ```bash
-pocket-coffea run --cfg example_config.py  --full --executor dask@lxplus --custom-run-options custom_run_options.yaml  -o output_dask
+pocket-coffea run --cfg example_config.py --executor dask@lxplus --custom-run-options custom_run_options.yaml  -o output_dask
 ```
 
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -88,7 +88,7 @@ Options:
   -c, --chunksize INTEGER         Overwrite chunksize config
   -q, --queue TEXT                Overwrite queue config
   -ll, --loglevel TEXT            Console logging level
-  -f, --full                      Process all datasets at the same time
+  -ps, --process-separately       Process each dataset separately
   --executor-custom-setup TEXT    Python module to be loaded as custom
                                   executor setup
   --help                          Show this message and exit.
@@ -244,7 +244,7 @@ your running session are visible with `tmux ls`. To reconnect do `tmux a -t your
 
 The easiest way to debug a new processor is to run locally on a single process. The `run` command has
 the `--test` options which enables the `iterative` processor independently from the running configuration specified in
-the configuration file. The processor is run on a file of each input dataset.
+the configuration file. The processor is run on a file of each input dataset. If you set the `--process-separately` flag, the datasets are processed separately. Otherwise all datasets are processed at once.
 
 ```bash
 $ pocket-coffea run --cfg config.py --test

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -47,12 +47,12 @@ def load_config(cfg, outputdir):
 @click.option("-c","--chunksize", type=int, help="Overwrite chunksize config" )
 @click.option("-q","--queue", type=str, help="Overwrite queue config" )
 @click.option("-ll","--loglevel", type=str, help="Console logging level", default="INFO" )
-@click.option("-f","--full", is_flag=True, help="Process all datasets at the same time", default=False )
+@click.option("-ps","--process-separately", is_flag=True, help="Process each dataset separately", default=False )
 @click.option("--executor-custom-setup", type=str, help="Python module to be loaded as custom executor setup")
 
 def run(cfg,  custom_run_options, outputdir, test, limit_files,
            limit_chunks, executor, scaleout, chunksize,
-           queue, loglevel, full, executor_custom_setup):
+           queue, loglevel, process_separately, executor_custom_setup):
     '''Run an analysis on NanoAOD files using PocketCoffea processors'''
 
     # Setting up the output dir
@@ -166,7 +166,7 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
     # Instantiate the executor
     executor = executor_factory.get()
 
-    if full:
+    if not process_separately:
         # Running on all datasets at once
         fileset = config.filesets
         logging.info(f"Working on samples: {list(fileset.keys())}")


### PR DESCRIPTION
`--full` renamed to `--process-separately`
docs updated
new name better reflects its purpose
it is clear that the `--full` (now --process-separately) and `--test` option are not related