### PR TITLE
Enhancement/plotting

### DIFF
--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -858,7 +858,7 @@ class Shape:
                     filepath = os.path.join(plot_dir, f"{self.name}_{cat}.png")
                 if self.verbose>0:
                     print("Saving", filepath)
-                plt.savefig(filepath, dpi=150, format="png")
+                plt.savefig(filepath, dpi=150, format="png", bbox_inches="tight")
             else:
                 plt.show(self.fig)
             plt.close(self.fig)

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -53,6 +53,11 @@ class Style:
         if not hasattr(self, "fontsize"):
             self.fontsize = 22
 
+        # default experiment label location: upper left inside plot
+        # https://twiki.cern.ch/twiki/bin/viewauth/CMS/Internal/FigGuidelines
+        if not hasattr(self, "experiment_label_loc"):
+            self.experiment_label_loc = 2
+
     def update(self, style_cfg):
         '''Updates the style options with a new dictionary.'''
         if not type(style_cfg) in [dict, defaultdict]:
@@ -600,14 +605,14 @@ class Shape:
             hep.cms.text(
                 "Simulation Preliminary",
                 fontsize=self.style.fontsize,
-                loc=0,
+                loc=self.style.experiment_label_loc,
                 ax=self.ax,
             )
         else:
             hep.cms.text(
                 "Preliminary",
                 fontsize=self.style.fontsize,
-                loc=0,
+                loc=self.style.experiment_label_loc,
                 ax=self.ax,
             )
         if self.toplabel:
@@ -1049,7 +1054,10 @@ class SystUnc:
             self.ax = ax
             self.fig = self.ax.get_figure
         hep.cms.text(
-            "Simulation Preliminary", fontsize=self.style.fontsize, loc=0, ax=self.ax
+            "Simulation Preliminary",
+            fontsize=self.style.fontsize,
+            loc=self.style.experiment_label_loc,
+            ax=self.ax,
         )
         # hep.cms.lumitext(text=f'{self.lumi[year]}' + r' fb$^{-1}$, 13 TeV,' + f' {year}', fontsize=self.style.fontsize, ax=self.ax)
         self.ax.hist(


### PR DESCRIPTION
- fixes Too large empty margins on the plots #167
- experiment label (CMS) location can be customized

the location of the experiment label can now be specified in the plotting parameters (yaml file)
e.g. `experiment_label_loc: 0' 
default is 2, i.e. upper left corner inside the plot, following current CMS guidelines