### PR TITLE
Preparing executor for CERN Swan

### DIFF
--- a/pocket_coffea/executors/executors_cern_swan.py
+++ b/pocket_coffea/executors/executors_cern_swan.py
@@ -1,0 +1,39 @@
+from pocket_coffea.executors.executors_base import ExecutorFactoryABC
+from pocket_coffea.executors.executors_base import IterativeExecutorFactory, FuturesExecutorFactory
+from coffea import processor as coffea_processor
+from dask.distributed import Client, PipInstall, WorkerPlugin
+from distributed.diagnostics.plugin import UploadFile
+
+
+class DaskExecutorFactory(ExecutorFactoryABC):
+
+    def __init__(self, run_options, sched_port, proxy_path, outputdir, **kwargs):
+        self.outputdir = outputdir
+        self.sched_port = sched_port
+        self.proxy_path = proxy_path
+        super().__init__(run_options, **kwargs)
+        
+    def setup(self):
+        ''' Start the DASK cluster here'''
+        # At INFN AF, the best way to handle DASK clusters is to create them via the Dask labextension and then connect the client to it in your code
+        self.dask_client = Client(address="tcp://127.0.0.1:"+str(self.sched_port))
+        self.dask_client.restart()
+        
+    def customized_args(self):
+        args = super().customized_args()
+        args["client"] = self.dask_client
+        return args
+    
+    def get(self):
+        return coffea_processor.dask_executor(**self.customized_args())
+
+    def close(self):
+        self.dask_client.close()
+
+def get_executor_factory(executor_name, **kwargs):
+    if executor_name == "iterative":
+        return IterativeExecutorFactory(**kwargs)
+    elif executor_name == "futures":
+        return FuturesExecutorFactory(**kwargs)
+    elif  executor_name == "dask":
+        return DaskExecutorFactory(**kwargs)

--- a/pocket_coffea/executors/executors_cern_swan.py
+++ b/pocket_coffea/executors/executors_cern_swan.py
@@ -7,17 +7,16 @@ from distributed.diagnostics.plugin import UploadFile
 
 class DaskExecutorFactory(ExecutorFactoryABC):
 
-    def __init__(self, run_options, sched_port, proxy_path, outputdir, **kwargs):
-        self.outputdir = outputdir
-        self.sched_port = sched_port
-        self.proxy_path = proxy_path
+    def __init__(self, run_options, outputdir, **kwargs):
+        if "sched_url" not in run_options:
+            raise Exception("Dask scheduler url not provided in the custom run options!")
+        self.sched_url = run_options["sched_url"]
         super().__init__(run_options, **kwargs)
         
     def setup(self):
         ''' Start the DASK cluster here'''
         # At INFN AF, the best way to handle DASK clusters is to create them via the Dask labextension and then connect the client to it in your code
-        self.dask_client = Client(address="tcp://127.0.0.1:"+str(self.sched_port))
-        self.dask_client.restart()
+        self.dask_client = Client(address=self.sched_url)
         
     def customized_args(self):
         args = super().customized_args()

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -139,6 +139,8 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
     # if site is known we can load the corresponding module
     elif site == "lxplus":
         from pocket_coffea.executors import executors_lxplus as executors_lib
+    elif site == "swan":
+        from pocket_coffea.executors import executors_cern_swan as executors_lib
     elif site == "T3_CH_PSI":
         from pocket_coffea.executors import executors_T3_CH_PSI as executors_lib
     elif site == "purdue-af":


### PR DESCRIPTION
The CERN Swan executor uses the Dask scheduler created by the Swan interface and connects to that. 