### PR TITLE
Removed default skim cuts from base processor

### DIFF
--- a/docs/analysis_example.md
+++ b/docs/analysis_example.md
@@ -410,23 +410,35 @@ reducing the computational load on the processor.  In the config file, we specif
 with at least one 18 GeV muon and the second is requiring the HLT ``SingleMuon`` path.
 
 Triggers are specified in a parameter yaml files under the `params` dir (but the localtion is up to the user).
-The parameters are then loadedand added to the default parameters in the preamble of the config file.
+The parameters are then loaded and added to the default parameters in the preamble of `example_config.py`,  which we pass as an argument to the factory function ``get_HLTsel()``.
 
 
-In the preamble of `example_config.py`,  which we pass as an argument to the factory function ``get_HLTsel()``:
+Moreover, standard selections as the following should be applied at the skim stage: 
+- event flags for MC and Data
+- number of primary vertex selection
+- application of the golden JSON selection to Data lumisections
+
+:::{warning}
+The above skimming was applied by default until PocketCoffea v0.9.4. After that the user has to specify the skim cuts,
+with Cut objects provided by the library.
+:::
+
 
 ```python
+from pocket_coffea.lib.cut_functions import get_nObj_min, get_HLTsel, eventFlags, get_nPVgood, goldenJson
+
 cfg = Configurator(
     # .....
 
-    skim = [get_nObj_min(1, 18., "Muon"),
+    skim = [
+            eventFlags,
+            goldenJson,
+            get_nPVgood(1),
+            get_nObj_min(1, 18., "Muon"),
             # Asking only SingleMuon triggers since we are only using SingleMuon PD data
             get_HLTsel(primaryDatasets=["SingleMuon"])],
 
 ```
-
-
-
 
 ### Event preselection
 

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -11,7 +11,6 @@ import os
 import logging
 
 from coffea import processor
-from coffea.lumi_tools import LumiMask
 from coffea.analysis_tools import PackedSelection
 
 from ..lib.weights_manager import WeightsManager
@@ -154,24 +153,6 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
         define the cut at the preselection level, not at skim level.
         '''
         self._skim_masks = PackedSelection()
-        mask_flags = np.ones(self.nEvents_initial, dtype=bool)
-        flags = self.params.event_flags[self._year]
-        if not self._isMC:
-            flags += self.params.event_flags_data[self._year]
-        for flag in flags:
-            mask_flags &= getattr(self.events.Flag, flag).to_numpy()
-        self._skim_masks.add("event_flags", mask_flags)
-
-        # Primary vertex requirement
-        self._skim_masks.add("PVgood", self.events.PV.npvsGood > 0)
-
-        # In case of data: check if event is in golden lumi file
-        if not self._isMC:
-            # mask_lumi = lumimask(self.events.run, self.events.luminosityBlock)
-            mask_lumi = LumiMask(self.params.lumi.goldenJSON[self._year])(
-                self.events.run, self.events.luminosityBlock
-            )
-            self._skim_masks.add("lumi_golden", mask_lumi)
 
         for skim_func in self._skim:
             # Apply the skim function and add it to the mask


### PR DESCRIPTION
Removed default skim cuts from base processor and defined corresponding cut objects in the `cut_functions` lib. 

- nPV_good > 0 selection
- goldenJson
- event flags

Solves #104 