### PR TITLE
New parameters exploration tool

### DIFF
--- a/pocket_coffea/__main__.py
+++ b/pocket_coffea/__main__.py
@@ -7,6 +7,7 @@ from pocket_coffea.scripts.dataset.dataset_query import dataset_discovery_cli
 from pocket_coffea.scripts.plot.make_plots import make_plots
 from pocket_coffea.scripts.hadd_skimmed_files import hadd_skimmed_files
 from pocket_coffea.scripts.merge_outputs import merge_outputs
+from pocket_coffea.scripts.print_parameters import print_parameters
 
 title = """[dodger_blue1]
     ____             __        __  ______      ________
@@ -38,6 +39,7 @@ cli.add_command(run)
 cli.add_command(make_plots)
 cli.add_command(hadd_skimmed_files)
 cli.add_command(merge_outputs)
+cli.add_command(print_parameters)
 
 if __name__ == '__main__':
     cli()

--- a/pocket_coffea/parameters/defaults.py
+++ b/pocket_coffea/parameters/defaults.py
@@ -61,6 +61,8 @@ def get_default_parameters():
         syst_variations,
         plotting_style
     )
+    # resolve the config to catch problems
+    OmegaConf.resolve(all)
     return all
 
 def get_default_run_options():

--- a/pocket_coffea/scripts/print_parameters.py
+++ b/pocket_coffea/scripts/print_parameters.py
@@ -1,0 +1,86 @@
+import click
+from omegaconf import OmegaConf
+from rich.pretty import pprint
+from rich import print
+from rich.prompt import Prompt
+import yaml
+
+from pocket_coffea.utils.utils import load_config
+
+@click.command()
+@click.option(
+    '-c',
+    '--cfg',
+    type=str,
+    help='Config file',
+)
+@click.option(
+    "-d",
+    "--dump",
+    type=str,
+    help="Dump the configuration to a file",
+)
+@click.option(
+    "-lk",
+    "--list-keys",
+    is_flag=True,
+    help="List all the keys in the configuration fragment"
+    )
+# optional argument to be used for filtering the parameters to print
+@click.argument(
+    'key',
+    required=False,
+    type=str,
+)
+@click.option(
+    "--cli",
+    is_flag=True,
+    help="Run interactively",
+    )
+
+def print_parameters(cfg, dump, list_keys,  key, cli):
+    '''Print the parameters from the PocketCoffea configuration'''
+    cfg = load_config(cfg, do_load=False, do_logging=False, save_config=False)
+    params_dict = cfg.parameters
+    
+    if key is not None:
+        try:
+            params_dict = OmegaConf.select(cfg.parameters, key)
+        except:
+            print(f"[red]Key {key} not found in the configuration[/]")
+            return
+        if key is not None:
+            print(f"[blue]Printing parameters for key: [/]{key}")
+
+    if list_keys:
+        print(f"[blue]Listing all the keys in the configuration[/]")
+        pprint(list(params_dict.keys()))
+
+    elif cli:
+        if key is not None:
+            #print the key that was asked
+            pprint(OmegaConf.to_container(params_dict, resolve=True), indent_guides=True)
+
+        print(f"Available keys in the configuration")
+        pprint(list(params_dict.keys()))
+        while True:
+            # Printing available keys
+            key = Prompt.ask("[bold cyan]Enter the key to print the parameters (or 'q' to quit)[/]")
+            if key == 'q':
+                break
+            try:
+                selected_params_dict = OmegaConf.select(params_dict, key)
+                pprint(OmegaConf.to_container(selected_params_dict, resolve=True), indent_guides=True)
+                # write available subkeys
+                print(f"[yellow]Available sub-keys in the configuration[/]")
+                pprint([f"{key}.{sub}" for sub in selected_params_dict.keys()])
+            except:
+                print(f"[red]Key {key} not found in the configuration[/]")
+    else:
+        #just print what has been selected
+        pprint(params_dictOmegaConf.to_container(params_dict, resolve=True), indent_guides=True)
+        
+    if dump:
+        with open(dump, "w") as f:
+            yaml.dump(params_dict, f)
+            print(f"[green]Parameters saved to {dump}[/]")

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -13,27 +13,10 @@ from coffea import processor
 from coffea.processor import Runner
 
 from pocket_coffea.utils.configurator import Configurator
-from pocket_coffea.utils import utils
+from pocket_coffea.utils.utils import load_config
 from pocket_coffea.utils.logging import setup_logging
 from pocket_coffea.parameters import defaults as parameters_utils
 from pocket_coffea.executors import executors_base
-
-def load_config(cfg, outputdir):
-    ''' Helper function to load a Configurator instance from a user defined python module'''
-    config_module =  utils.path_import(cfg)
-    try:
-        config = config_module.cfg
-        # Load the configuration
-        config.load()
-        logging.info(config)
-        config.save_config(outputdir)
-    except AttributeError as e:
-        print("Error: ", e)
-        raise("The provided configuration module does not contain a `cfg` attribute of type Configurator. Please check your configuration!")
-
-    if not isinstance(config, Configurator):
-        raise("The configuration module attribute `cfg` is not of type Configurator. Please check yuor configuration!")
-    return config
 
 
 @click.command()
@@ -73,7 +56,7 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
     print("Loading the configuration file...")
     if cfg[-3:] == ".py":
         # Load the script
-        config = load_config(cfg, outputdir)
+        config = load_config(cfg, save_config=True, outputdir=outputdir)
 
     elif cfg[-4:] == ".pkl":
         # WARNING: This has to be tested!!

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -23,6 +23,8 @@ def load_config(cfg, outputdir):
     config_module =  utils.path_import(cfg)
     try:
         config = config_module.cfg
+        # Load the configuration
+        config.load()
         logging.info(config)
         config.save_config(outputdir)
     except AttributeError as e:

--- a/pocket_coffea/utils/configurator.py
+++ b/pocket_coffea/utils/configurator.py
@@ -52,6 +52,10 @@ class Configurator:
         workflow_options=None,
         save_skimmed_files=None,
     ):
+        '''
+        Constructur of the Configurator class.
+        It saves the configuration of the analysis and the workflow to be used to load
+        the internal objects in the load() method.'''
 
         # Save the workflow object and its options
         self.workflow = workflow
@@ -82,23 +86,41 @@ class Configurator:
         self.years = []
         self.eras = []
 
-        self.load_datasets()
-        self.load_subsamples()
-
         # Load histogram settings
         # No manipulation is needed, maybe some check can be added
         self.variables = variables
+
+        self.skim_cfg = skim
+        self.preselections_cfg = preselections
+        self.categories_cfg = categories
+
+        self.skim = []
+        self.preselections = []
+
+        self.weights_cfg = weights
+        ## Weights configuration
+    
+        self.variations_cfg = variations
+       
+        # Column accumulator config
+        self.columns = {}
+        self.columns_cfg = columns
+
+        self.loaded = False
+
+    def load(self):
+        '''This function loads the configuration for samples/weights/variations and creates
+        the necessary objects for the processor to use. It also loads the workflow'''
+        self.load_datasets()
+        self.load_subsamples()
 
         # Categories: object handling categorization
         # - StandardSelection
         # - CartesianSelection
         ## Call the function which transforms the dictionary in the cfg
         # in the objects needed in the processors
-        self.skim = []
-        self.preselections = []
-        self.load_cuts_and_categories(skim, preselections, categories)
+        self.load_cuts_and_categories(self.skim_cfg, self.preselections_cfg, self.categories_cfg)
 
-        ## Weights configuration
         self.weights_config = {
             s: {
                 "inclusive": [],
@@ -107,7 +129,8 @@ class Configurator:
             }
             for s in self.samples
         }
-        self.load_weights_config(weights)
+         
+        self.load_weights_config(self.weights_cfg)
 
         ## Variations configuration
         # The structure is very similar to the weights one,
@@ -120,11 +143,12 @@ class Configurator:
             }
             for s in self.samples
         }
-        if "shape" not in variations:
-            variations["shape"] = {"common": {"inclusive": []}}
+        if "shape" not in self.variations_cfg:
+            self.variations_cfg["shape"] = {"common": {"inclusive": []}}
 
-        self.load_variations_config(variations["weights"], variation_type="weights")
-        self.load_variations_config(variations["shape"], variation_type="shape")
+        self.load_variations_config(self.variations_cfg["weights"], variation_type="weights")
+        self.load_variations_config(self.variations_cfg["shape"], variation_type="shape")
+            
         # Collecting overall list of available weights and shape variations per sample
         self.available_weights_variations = {s: ["nominal"] for s in self.samples}
         self.available_shape_variations = {s: [] for s in self.samples}
@@ -142,21 +166,24 @@ class Configurator:
             self.available_shape_variations[sample] = list(
                 set(self.available_shape_variations[sample])
             )
+            
+        # Columns configuration
+        self.load_columns_config(self.columns_cfg)
 
-        # Column accumulator config
-        self.columns = {}
-        self.load_columns_config(columns)
-
-        # Check the jet_calibration and create the file if needed
-        if not os.path.exists(self.parameters.jets_calibration.factory_file):
-            build_jets_calibrator.build(self.parameters.jets_calibration)
-        
-        # Load workflow passing the Configurator self object
+        # Load the workflow
         self.load_workflow()
 
-        # Some self consistency checks
+         # Some self consistency checks
         self.perform_checks()
 
+        # Alway run the jet calibration builder
+        if not os.path.exists(self.parameters.jets_calibration.factory_file):
+            build_jets_calibrator.build(self.parameters.jets_calibration,
+                                        filter_years=self.years)
+
+        # Mark the configurator as loaded
+        self.loaded = True
+        
 
     def load_datasets(self):
         for json_dataset in self.datasets_cfg["jsons"]:
@@ -269,7 +296,6 @@ class Configurator:
     def load_weights_config(self, wcfg):
         '''This function loads the weights definition and prepares a list of
         weights to be applied for each sample and category'''
-
         # Get the list of statically available weights defined in the workflow
         available_weights = self.workflow.available_weights()
         # Read the config and save the list of weights names for each sample (and category if needed)
@@ -495,6 +521,9 @@ class Configurator:
         self.processor_instance = self.workflow(cfg=self)
 
     def save_config(self, output):
+        if not self.loaded:
+            print("The configurator is not loaded yet, please load it before saving the configuration")
+            return
         ocfg = {}
         ocfg["datasets"] = {
             "names": self.datasets,
@@ -573,6 +602,13 @@ class Configurator:
         # dump also the parameters
 
     def __repr__(self):
+        if not self.loaded:
+            s = [
+            'Configurator instance (not loaded yet):',
+            f"  - Workflow: {self.workflow}",
+            f"  - Workflow options: {self.workflow_options}"]
+            return "\n".join(s)
+
         s = [
             'Configurator instance:',
             f"  - Workflow: {self.workflow}",

--- a/pocket_coffea/utils/utils.py
+++ b/pocket_coffea/utils/utils.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import awkward
 import pathlib
 import shutil
-
+from .configurator import Configurator
 
 
 @contextmanager
@@ -30,6 +30,27 @@ def path_import(absolute_path):
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module
+
+    
+def load_config(cfg, do_load=False, do_logging=True, save_config=True, outputdir=None):
+    ''' Helper function to load a Configurator instance from a user defined python module'''
+    config_module =  path_import(cfg)
+    try:
+        config = config_module.cfg
+        # Load the configuration
+        if do_load:
+            config.load()
+        if do_logging:
+            logging.info(config)
+        if save_config and outputdir is not None:
+            config.save_config(outputdir)
+    except AttributeError as e:
+        print("Error: ", e)
+        raise("The provided configuration module does not contain a `cfg` attribute of type Configurator. Please check your configuration!")
+
+    if not isinstance(config, Configurator):
+        raise("The configuration module attribute `cfg` is not of type Configurator. Please check yuor configuration!")
+    return config
 
 
 # Function taken from HiggsDNA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ build_datasets="pocket_coffea.scripts.dataset.build_datasets:build_datasets"
 dataset_discovery_cli="pocket_coffea.scripts.dataset:dataset_discovery_cli"
 hadd_skimmed_files="pocket_coffea.scripts.hadd_skimmed_files:hadd_skimmed_files"
 merge_outputs="pocket_coffea.scripts.merge_outputs:merge_outputs"
+print_parameters="pocket_coffea.scripts.print_parameters:print_parameters"
 
 # [tool.flake8]
 # extend-ignore = ["E203", "E501", "E722", "B950"]


### PR DESCRIPTION
A new command `pocket-coffea print-parameters` is added to explore somehow dynamically the parameters attached to a configuration. 

The end user usually overwrite existing default metadata, but getting to know the value of the default metadata requires looking at the central repo files or looking at the parameters_dump of a pocket-coffea run. 

With this new tool the user can explore the parameters, dump them locally, to cross-check his own configuration (default + custom parameters) before running. 

-------------

```
pocket-coffea) ➜  zmumu git:(main) ✗ pocket-coffea print-parameters -c example_config.py --cli

    ____             __        __  ______      ________
   / __ \____  _____/ /_____  / /_/ ____/___  / __/ __/__  ____ _
  / /_/ / __ \/ ___/ //_/ _ \/ __/ /   / __ \/ /_/ /_/ _ \/ __ `/
 / ____/ /_/ / /__/ ,< /  __/ /_/ /___/ /_/ / __/ __/  __/ /_/ /
/_/    \____/\___/_/|_|\___/\__/\____/\____/_/ /_/  \___/\__,_/


Available keys in the configuration
[
│   'pileupJSONfiles',
│   'event_flags',
│   'event_flags_data',
│   'lumi',
│   'default_jets_calibration',
│   'jets_calibration',
│   'jet_scale_factors',
│   'btagging',
│   'lepton_scale_factors',
│   'systematic_variations',
│   'plotting_style',
│   'object_preselection',
│   'HLT_triggers'
]
Enter the key to print the parameters (or 'q' to quit): lepton_scale_factors
{
│   'electron_sf': {
│   │   'id': {
│   │   │   'mvaIso_WP80': 'wp80iso',
│   │   │   'mvaIso_WP90': 'wp90iso',
│   │   │   'mvaNoIso_WP80': 'wp80noiso',
│   │   │   'mvaNoIso_WP90': 'wp90noiso',
│   │   │   'mvaFall17V2Iso_WP80': 'wp80iso',
│   │   │   'mvaFall17V2Iso_WP90': 'wp90iso',
│   │   │   'mvaFall17V2noIso_WP80': 'wp80noiso',
│   │   │   'mvaFall17V2noIso_WP90': 'wp90noiso'
│   │   },
│   │   'JSONfiles': {
│   │   │   '2016_PreVFP': {
│   │   │   │   'file': '/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2016preVFP_UL/electron.json.gz',
│   │   │   │   'name': 'UL-Electron-ID-SF',
│   │   │   │   'reco': {'pt_lt_20': 'RecoBelow20', 'pt_gt_20': 'RecoAbove20'}
│   │   │   },
│   │   │   '2016_PostVFP': {
│   │   │   │   'file': '/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2016postVFP_UL/electron.json.gz',
│   │   │   │   'name': 'UL-Electron-ID-SF',
│   │   │   │   'reco': {'pt_lt_20': 'RecoBelow20', 'pt_gt_20': 'RecoAbove20'}
│   │   │   },
│   │   │   '2017': {
│   │   │   │   'file': '/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2017_UL/electron.json.gz',
│   │   │   │   'name': 'U
[...]
Available sub-keys in the configuration
['lepton_scale_factors.electron_sf', 'lepton_scale_factors.muon_sf']

```

or with a specific key: 
```
(pocket-coffea) ➜  zmumu git:(main) ✗ pocket-coffea print-parameters -c example_config.py btagging --cli

    ____             __        __  ______      ________
   / __ \____  _____/ /_____  / /_/ ____/___  / __/ __/__  ____ _
  / /_/ / __ \/ ___/ //_/ _ \/ __/ /   / __ \/ /_/ /_/ _ \/ __ `/
 / ____/ /_/ / /__/ ,< /  __/ /_/ /___/ /_/ / __/ __/  __/ /_/ /
/_/    \____/\___/_/|_|\___/\__/\____/\____/_/ /_/  \___/\__,_/


Printing parameters for key: btagging
{
│   'working_point': {
│   │   '2016_PreVFP': {
│   │   │   'reference': {'btagging_WP': 'https://btv-wiki.docs.cern.ch/ScaleFactors/UL2016preVFP/'},
│   │   │   'btagging_algorithm': 'btagDeepFlavB',
│   │   │   'btagging_WP': {'L': 0.0508, 'M': 0.2598, 'H': 0.6502},
│   │   │   'bbtagging_algorithm': 'btagDDBvL',
│   │   │   'bbtagging_WP': 0.86,
│   │   │   'bbtagSF_DDBvL_M1_loPt': 0.86,
│   │   │   'bbtagSF_DDBvL_M1_loPt_up': 0.97,
│   │   │   'bbtagSF_DDBvL_M1_loPt_down': 0.82,
│   │   │   'bbtagSF_DDBvL_M1_hiPt': 0.86,
│   │   │   'bbtagSF_DDBvL_M1_hiPt_up': 0.97,
│   │   │   'bbtagSF_DDBvL_M1_hiPt_down': 0.82
│   │   },
│   │   '2016_PostVFP': {
│   │   │   'reference': {'btagging_WP': 'https://btv-wiki.docs.cern.ch/ScaleFactors/UL2016postVFP/'},
│   │   │   'btagging_algorithm': 'btagDeepFlavB',
│   │   │   'btagging_WP': {'L': 0.0816, 'M': 0.3657, 'H': 0.7565},
│   │   │   'bbtagging_algorithm': 'btagDDBvL',
│   │   │   'bbtagging_WP': 0.86,
│   │   │   'bbtagSF_DDBvL_M1_loPt': 0.86,
│   │   │   'bbtagSF_DDBvL_M1_loPt_up': 0.97,
│   │   │   'bbtagSF_DDBvL_M1_loPt_down': 0.82,
│   │   │   'bbtagSF_DDBvL_M1_hiPt': 0.86,
│   │   │   'bbtagSF_DDBvL_M1_hiPt_up': 0.97,
│   │   │   'bbtagSF_DDBvL_M1_hiPt_down': 0.82
│   │   },
...
```