### PR TITLE
fix check of genWeight in weights config

### DIFF
--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -818,7 +818,7 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                     rescale = True
                     if 'signOf_genWeight' in wei and 'genWeight' not in wei:
                         sumgenw_dict = output["sum_signOf_genweights"]
-                    elif "genWeight" in wei and not "signOf_genWeight":
+                    elif "genWeight" in wei and "signOf_genWeight" not in wei:
                         sumgenw_dict = output["sum_genweights"]
                     elif "genWeight" in wei and "signOf_genWeight" in wei:
                         print("!!! Both genWeight and signOf_genWeight are present in the weights config. This is not allowed.")
@@ -842,7 +842,7 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                 rescale = True
                 if 'signOf_genWeight' in wei and 'genWeight' not in wei:
                     sumgenw_dict = output["sum_signOf_genweights"]
-                elif "genWeight" in wei and not "signOf_genWeight":
+                elif "genWeight" in wei and "signOf_genWeight" not in wei:
                     sumgenw_dict = output["sum_genweights"]
                 elif "genWeight" in wei and "signOf_genWeight" in wei:
                     print("!!! Both genWeight and signOf_genWeight are present in the weights config. This is not allowed.")
@@ -864,7 +864,7 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                 rescale = True
                 if 'signOf_genWeight' in wei and 'genWeight' not in wei:
                     sumgenw_dict = output["sum_signOf_genweights"]
-                elif "genWeight" in wei and not "signOf_genWeight":
+                elif "genWeight" in wei and "signOf_genWeight" not in wei:
                     sumgenw_dict = output["sum_genweights"]
                 elif "genWeight" in wei and "signOf_genWeight" in wei:
                     print("!!! Both genWeight and signOf_genWeight are present in the weights config. This is not allowed.")


### PR DESCRIPTION
wrong syntax for check of `"genWeight"` and `"signOf_genWeight"` in weights config. genWeights have not been applied to the histograms

old syntax 
```python
elif "genWeight" in wei and not "signOf_genWeight":
    sumgenw_dict = output["sum_genweights"]
```
the `not "signOf_genWeight"` always evaluates to `False`, so histograms are not rescaled

changed to
```python
elif "genWeight" in wei and "signOf_genWeight" not in wei:
    sumgenw_dict = output["sum_genweights"]
```