### PR TITLE
Various improvements

### DIFF
--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -249,8 +249,11 @@ def jet_selection(events, jet_type, params, leptons_collection=""):
     return jets[mask_good_jets], mask_good_jets
 
 
-def btagging(Jet, btag, wp):
-    return Jet[Jet[btag["btagging_algorithm"]] > btag["btagging_WP"][wp]]
+def btagging(Jet, btag, wp, veto=False):
+    if veto:
+        return Jet[Jet[btag["btagging_algorithm"]] < btag["btagging_WP"][wp]]
+    else:
+        return Jet[Jet[btag["btagging_algorithm"]] > btag["btagging_WP"][wp]]
 
 
 def CvsLsorted(jets, ctag):

--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -92,6 +92,8 @@ def get_ele_sf(
                 output[variation][i] = ak.unflatten(sf, counts)
 
         return output
+    else:
+        raise Exception(f"Invalid key `{key}` for get_ele_sf. Available keys are 'reco', 'id', 'trigger'.")
 
 
 def get_mu_sf(params, year, pt, eta, counts, key=''):
@@ -226,8 +228,9 @@ def sf_ele_trigger(params, events, year, variations=["nominal"]):
         year,
         ele_pt_flat,
         ele_eta_flat,
-        ele_counts,
-        'trigger',
+        phi=None,
+        counts=ele_counts,
+        key='trigger',
         variations=variations,
     )
 

--- a/pocket_coffea/utils/configurator.py
+++ b/pocket_coffea/utils/configurator.py
@@ -495,7 +495,7 @@ class Configurator:
                                 self.columns[sample][cat].append(w)
                             elif self.has_subsamples[sample]:
                                 for subs in self.subsamples[sample].keys():
-                                    self.columns[subs][cat].append(w)
+                                    self.columns[f"{sample}__{subs}"][cat].append(w)
                             else:
                                 self.columns[sample][cat].append(w)
         #prune the empty categories


### PR DESCRIPTION
Minor improvements to the framework:
- Argument to veto the b-tagging requirement using the `btagging()` function, to select light jets
- Update single electron trigger SF function for Run-2 retrocompatibility
- Fix configurator to save columns with subsamples