### PR TITLE
Fixed wildcard weights variation implementation 

### DIFF
--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -135,6 +135,8 @@ class HistManager:
         self.available_categories = set(self.categories_config.keys())
         self.available_weights_variations = ["nominal"]
         self.available_shape_variations = []
+        # variations that are expanded in the parameters
+        self.wildcard_variations = {}
         if self.isMC:
             self.available_weights_variations_bycat = defaultdict(list)
             self.available_shape_variations_bycat = defaultdict(list)
@@ -155,6 +157,7 @@ class HistManager:
                         ][
                             self.year
                         ]:
+                            self.wildcard_variations[var] = f"{var}_{subvariation}"
                             self.available_weights_variations += [
                                 f"{var}_{subvariation}Up",
                                 f"{var}_{subvariation}Down",
@@ -167,7 +170,6 @@ class HistManager:
                         vv = [f"{var}Up", f"{var}Down"]
                         self.available_weights_variations += vv
                         self.available_weights_variations_bycat[cat] += vv
-
             # Shape variations
             for cat, vars in self.variations_config["shape"].items():
                 for var in vars:
@@ -184,6 +186,7 @@ class HistManager:
                         ][
                             self.year
                         ]:
+                            self.wildcard_variations[var] = f"{var}_{subvariation}"
                             self.available_weights_variations += [
                                 f"{var}_{subvariation}Up",
                                 f"{var}_{subvariation}Down",
@@ -235,27 +238,36 @@ class HistManager:
                 allvariat = []
                 for c in cats:
                     # Summing all the variations for all the categories
-                    allvariat += self.variations_config["weights"][c]
-                    allvariat += self.variations_config["shape"][c]
-                allvariat = set(allvariat)
+                    allvariat += self.available_weights_variations_bycat[c]
+                    allvariat += self.available_shape_variations_bycat[c]
+
                 if hcfg.only_variations != None:
+                    # expand wild card and Up/Down
+                    only_variations = []
+                    for var in hcfg.only_variations:
+                        if var in self.wildcard_variations:
+                            only_variations += [
+                                f"{self.wildcard_variations[var]}Up",
+                                f"{self.wildcard_variations[var]}Down",
+                            ]
+                        else:
+                            only_variations += [
+                                f"{var}Up",
+                                f"{var}Down",
+                            ]
                     # filtering the variation list with the available ones
                     allvariat = set(
-                        filter(lambda v: v in hcfg.only_variations, allvariat)
+                        filter(lambda v: v in only_variations, allvariat)
                     )
 
-                hcfg.only_variations = ["nominal"] + list(
-                    sorted(
-                        [var + "Up" for var in allvariat]
-                        + [var + "Down" for var in allvariat]
-                    )
-                )
+                hcfg.only_variations = list(set(sorted(allvariat)))
             else:
                 hcfg.only_variations = ["nominal"]
             # Defining the variation axis
             var_ax = hist.axis.StrCategory(
                 hcfg.only_variations, name="variation", label="Variation", growth=False
             )
+
             # Axis in the configuration + custom axes
             if self.isMC:
                 all_axes = [cat_ax, var_ax]

--- a/pocket_coffea/lib/weights_manager.py
+++ b/pocket_coffea/lib/weights_manager.py
@@ -4,7 +4,7 @@ import awkward as ak
 import numpy as np
 from collections.abc import Callable
 from collections import defaultdict
-
+from copy import deepcopy
 from coffea.analysis_tools import Weights
 
 # Scale factors functions
@@ -168,7 +168,7 @@ class WeightsManager:
                         w, events, self._shape_variation
                     )
                 for we in _weightsCache[w]:
-                    weight_obj.add(*we)
+                    weight_obj.add(*deepcopy(we))
                     if len(we) > 2:
                         # the weights has variations
                         installed_modifiers += [we[0] + "Up", we[0] + "Down"]


### PR DESCRIPTION
Wildcard weights variations (like btagSF) taken from parameters are handled by the weights manager. 

The wildcard was not solved correctly by the hist_manager.