### PR TITLE
Enable blinding data for certain histograms

### DIFF
--- a/docs/plots.md
+++ b/docs/plots.md
@@ -69,8 +69,30 @@ plotting_style:
     rescale_samples:
 	    ttbar: 1.12
 	    DY_LO: 1.33
+		
+    blind_hists:
+        categories: [SignalRegion1, SignalRegion2]
+        histograms:
+            mjj: [100, 150]
+            DNN: [0.7, 1]
+
 
 ```
 
-User can define custom labels for the MC samples and a custom coloring scheme. Additionally, the Data and MC samples can be merged between each other by specifying a dictionary of samples in the `samples_groups` key. In the example above, a single sample `ttbar` will be plotted by merging the samples `TTTo2L2Nu` and `TTToSemiLeptonic`. Certain samples can be excluded from plotting with `exclude_samples` key.
-One could also rescale certain samples by a multiplicative factor, using the `rescale_samples` keys.
+With `labels_mc` and `colors_mc` settings the user can define custom
+labels for the MC samples and a custom coloring scheme.  
+
+The `samples_groups` option allows for MC sub-samples to be merged
+into a common sample by specifying a dictionary of those sub-samples.
+In the example above, a single sample `ttbar` will be plotted by
+merging the samples `TTTo2L2Nu` and `TTToSemiLeptonic`.  
+
+Certain samples can be excluded from plotting with `exclude_samples` key.  
+
+One could also rescale certain samples by a multiplicative factor,
+using the `rescale_samples` keys.  
+
+The `blind_hists` would remove points from `data` distributions in a
+given range (set those bins to zero). One needs to specify a list of
+categories where blinding should be implemented and the names of the histograms, as
+shown in the example above.

--- a/pocket_coffea/parameters/variations.yaml
+++ b/pocket_coffea/parameters/variations.yaml
@@ -10,6 +10,11 @@ systematic_variations:
       "2017": "${.2016_PreVFP}" 
       "2018": "${.2016_PreVFP}"
 
+      "2022_preEE": "${.2016_PreVFP}"
+      "2022_postEE": "${.2016_PreVFP}"
+      "2023_preBPix": "${.2016_PreVFP}"
+      "2023_postBPix": "${.2016_PreVFP}"
+
     sf_btag:
       '2016_PreVFP':
         - hf
@@ -45,8 +50,10 @@ systematic_variations:
       '2017': "${.2016_PreVFP}"
       '2018': "${.2016_PreVFP}"
 
+      "2022_preEE": "${.2016_PreVFP}"
+      "2022_postEE": "${.2016_PreVFP}"
+      "2023_preBPix": "${.2016_PreVFP}"
+      "2023_postBPix": "${.2016_PreVFP}"
+
   shape_variations:
     JES:
-
-    
-


### PR DESCRIPTION
This will enable to blind some data distributions in Signal regions.
This addresses issue #175 
Documentation is also updated.

Also adding missing default values in variations for 2022/2023 eras.