### PR TITLE
Correct under/overflow bins

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -166,7 +166,7 @@ git clone git@github.com:PocketCoffea/PocketCoffea.git
 
       ```bash
       # Install micromamba
-      curl micro.mamba.pm/install.sh | bash
+      "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
       micromamba create -n pocket-coffea python=3.9 -c conda-forge
       micromamba activate pocket-coffea
       ```

--- a/docs/plots.md
+++ b/docs/plots.md
@@ -159,3 +159,17 @@ plotting_style:
 
 If no alias or default `matplotlib` color corresponds to the string specified by the user,
 an exception is raised.
+
+## Additional custom axes
+
+In order to include an additional custom axis in the plotting, one has to specify the dictionary of categorical axes for data and MC separately.
+For example, to include an additional axis for data to keep track of different data-taking eras as an additional category, one can overwrite the custom `.yaml` file as follows:
+
+```
+plotting_style:
+
+    categorical_axes_data:
+        era: eras
+```
+
+where the key (`era`) in the dictionary corresponds to the name of the axis as saved in the histogram, while the value (`eras`) corresponds to the name assigned to the corresponding attribute of the `Shape` object.

--- a/pocket_coffea/parameters/plotting_style.yaml
+++ b/pocket_coffea/parameters/plotting_style.yaml
@@ -102,3 +102,11 @@ plotting_style:
         "2023_preBPix": "${pico_to_femto:${lumi.picobarns.2023_preBPix.tot}}"
         "2023_postBPix": "${pico_to_femto:${lumi.picobarns.2023_postBPix.tot}}"
 
+    categorical_axes_data:
+     year: years
+     cat: categories
+
+    categorical_axes_mc:
+     year: years
+     cat: categories
+     variation: variations

--- a/pocket_coffea/scripts/merge_outputs.py
+++ b/pocket_coffea/scripts/merge_outputs.py
@@ -21,7 +21,7 @@ from rich import print
 def merge_outputs(inputfiles, outputfile):
     '''Merge coffea output files'''
     print(f"[blue]Merging files into {outputfile}[/]")
-    print(inputfiles)
+    print(sorted(inputfiles))
     out = accumulate([load(f) for f in inputfiles])
     save(out, outputfile)
     print(f"[green]Output saved to {outputfile}")

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import re
-import argparse
 
 from omegaconf import OmegaConf
 from coffea.util import load

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -988,6 +988,14 @@ class Shape:
         y = stacks["data_sum"].values()
         # Add underflow and overflow bins to the first and last bin, respectively
         if self.style.opts_mc["flow"] == "sum":
+            has_underflow = True
+            has_overflow = True
+            try: stacks["data_sum"][hist.underflow]
+            except: has_underflow = False
+            try: stacks["data_sum"][hist.overflow]
+            except: has_overflow = False
+            if not all([has_underflow, has_overflow]):
+                raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
             y_underflow = stacks["data_sum"][hist.underflow].value
             y_overflow = stacks["data_sum"][hist.overflow].value
             y[0] += y_underflow
@@ -1370,6 +1378,14 @@ class SystUnc:
             self.nominal, self.bins = stacks["mc_nominal_sum"].to_numpy()
             # Add underflow and overflow bins to the first and last bin, respectively
             if self.style.opts_mc["flow"] == "sum":
+                has_underflow = True
+                has_overflow = True
+                try: stacks["mc_nominal_sum"][hist.underflow]
+                except: has_underflow = False
+                try: stacks["mc_nominal_sum"][hist.overflow]
+                except: has_overflow = False
+                if not all([has_underflow, has_overflow]):
+                    raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
                 self.nominal[0] += stacks["mc_nominal_sum"][hist.underflow].value
                 self.nominal[-1] += stacks["mc_nominal_sum"][hist.overflow].value
         elif syst_list:

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -905,10 +905,10 @@ class Shape:
                 exp = math.floor(math.log(max(stacks["data_sum"].values()), 10))
             self.ax.set_ylim((0.01, 10 ** (exp*1.75)))
         else:
-            if self.is_mc_only:
-                reference_shape = stacks["mc_nominal_sum"].values()
-            else:
+            if self.is_data_only:
                 reference_shape = stacks["data_sum"].values()
+            else:
+                reference_shape = stacks["mc_nominal_sum"].values()
             if self.density:
                 integral = sum(reference_shape) * np.array(self.style.opts_axes["xbinwidth"])
                 reference_shape = reference_shape / integral
@@ -1042,7 +1042,7 @@ class Shape:
                         if self.verbose>0:
                             print("WARNING: The range for blinding region is not correct:", blind_hname, blind_range)
                         continue
-                    hist_edges = stacks["data_sum"].axes[0].edges
+                    hist_edges = np.array(self.style.opts_axes["xedges"])
                     bins_to_zero = (hist_edges[:-1] >= blind_range[0]) & (hist_edges[:-1] < blind_range[1])
                     y[bins_to_zero] = 0
 

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -90,6 +90,11 @@ class Style:
 
         self.set_defaults()
 
+        if self.opts_mc["flow"] == "sum":
+            self.flow = True
+        else:
+            self.flow = False
+
         #print("Style config:\n", style_cfg)
 
     def set_defaults(self):
@@ -734,17 +739,13 @@ class Shape:
         hnum = stacks["data_sum"]
         hden = stacks["mc_nominal_sum"]
 
-        if self.style.opts_mc["flow"] == "sum":
-            flow = True
-        else:
-            flow = False
-        num = hnum.values(flow=flow)
-        den = hden.values(flow=flow)
-        num_variances = hnum.variances(flow=flow)
-        den_variances = hden.variances(flow=flow)
+        num = hnum.values(flow=self.style.flow)
+        den = hden.values(flow=self.style.flow)
+        num_variances = hnum.variances(flow=self.style.flow)
+        den_variances = hden.variances(flow=self.style.flow)
 
         # Sum underflow and overflow bins for the numerator and denominator, to restore an array of the same length
-        if self.style.opts_mc["flow"] == "sum":
+        if self.style.flow:
             if (len(num) != (len(hnum.values()) + 2)) | (len(den) != (len(hden.values()) + 2)):
                 raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
             num = np.concatenate([[num[0]+num[1]], num[2:-2], [num[-2]+num[-1]]])
@@ -790,15 +791,11 @@ class Shape:
         else:
             hden = stacks['mc_nominal'][ref]
 
-        if self.style.opts_mc["flow"] == "sum":
-            flow = True
-        else:
-            flow = False
-        den = hden.values(flow=flow)
-        den_variances = hden.variances(flow=flow)
+        den = hden.values(flow=self.style.flow)
+        den_variances = hden.variances(flow=self.style.flow)
 
         # Sum underflow and overflow bins for the denominator, to restore an array of the same length
-        if self.style.opts_mc["flow"] == "sum":
+        if self.style.flow:
             if (len(den) != (len(hden.values()) + 2)):
                 raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
             den = np.concatenate([[den[0]+den[1]], den[2:-2], [den[-2]+den[-1]]])
@@ -824,7 +821,7 @@ class Shape:
             num = hnum.values(flow=flow)
             num_variances = hnum.variances(flow=flow)
 
-            if self.style.opts_mc["flow"] == "sum":
+            if self.style.flow:
                 if (len(den) != (len(hden.values()) + 2)):
                     raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
                 num = np.concatenate([[num[0]+num[1]], num[2:-2], [num[-2]+num[-1]]])
@@ -1019,7 +1016,7 @@ class Shape:
                 self.define_figure(ratio=False)
         y = stacks["data_sum"].values()
         # Add underflow and overflow bins to the first and last bin, respectively
-        if self.style.opts_mc["flow"] == "sum":
+        if self.style.flow:
             has_underflow = True
             has_overflow = True
             try: stacks["data_sum"][hist.underflow]
@@ -1147,11 +1144,7 @@ class Shape:
 
             # If the histogram is in density mode, the systematic uncertainty has to be normalized to the integral of the MC stack
             if self.density:
-                if self.style.opts_mc["flow"] == "sum":
-                    flow = True
-                else:
-                    flow = False
-                mc_integral = sum(self._get_stacks(cat)["mc_nominal_sum"].values(flow=flow)) * np.array(self.style.opts_axes["xbinwidth"])
+                mc_integral = sum(self._get_stacks(cat)["mc_nominal_sum"].values(flow=self.style.flow)) * np.array(self.style.opts_axes["xbinwidth"])
                 up = up / mc_integral
                 down = down / mc_integral
 
@@ -1419,7 +1412,7 @@ class SystUnc:
             self.h_mc_nominal = stacks["mc_nominal_sum"]
             self.nominal, self.bins = stacks["mc_nominal_sum"].to_numpy()
             # Add underflow and overflow bins to the first and last bin, respectively
-            if self.style.opts_mc["flow"] == "sum":
+            if self.style.flow:
                 has_underflow = True
                 has_overflow = True
                 try: stacks["mc_nominal_sum"][hist.underflow]

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -20,9 +20,11 @@ from mplhep.error_estimation import poisson_interval
 from cycler import cycler
 
 from omegaconf import OmegaConf
-from pocket_coffea.parameters.defaults import merge_parameters
+from pocket_coffea.parameters.defaults import merge_parameters, get_default_parameters
 
 np.seterr(divide="ignore", invalid="ignore", over="ignore")
+
+plotting_style_defaults = get_default_parameters()["plotting_style"]
 
 # colormaps according to CMS guidelines
 # https://cms-analysis.docs.cern.ch/guidelines/plotting/colors/#categorical-data-eg-1d-stackplots
@@ -92,7 +94,11 @@ class Style:
         #print("Style config:\n", style_cfg)
 
     def set_defaults(self):
-        self.opts_mc["stack"] = "stack" not in self.opts_mc
+        for key in self._required_keys:
+            for subkey, val_default in plotting_style_defaults[key].items():
+                if subkey not in self.style_cfg[key]:
+                    self.style_cfg[key][subkey] = val_default
+
         self.fontsize = getattr(self, "fontsize", 22)
 
         # default experiment label location: upper left inside plot

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -67,7 +67,6 @@ class Style:
             ), f"The key `{key}` is not defined in the style dictionary."
         for key, item in style_cfg.items():
             setattr(self, key, item)
-        self.has_lumi = False
         self.has_labels = "labels_mc" in style_cfg
         self.has_samples_groups = "samples_groups" in style_cfg
         self.has_exclude_samples = "exclude_samples" in style_cfg
@@ -346,8 +345,6 @@ class Shape:
         self.only_cat = only_cat if only_cat is not None else []
         self.style = Style(style_cfg)
         self.toplabel = toplabel if toplabel else ""
-        if self.style.has_lumi:
-            self.lumi_fraction = {year : l / lumi[year]['tot'] for year, l in self.style.lumi_processed.items()}
         self.log = log
         self.density = density
         self.datasets_metadata=datasets_metadata

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -736,7 +736,7 @@ class Shape:
         # Total uncertainy propagation of num / den :
         # ratio_variance = np.power(ratio,2)*( num_variances*np.power(num, -2) + den_variances*np.power(den, -2))
         # Only the uncertainty of num (DATA) propagated:
-        ratio_variance = num_variances*np.power(hden, -2)
+        ratio_variance = num_variances*np.power(den, -2)
 
         ratio_uncert = np.abs(poisson_interval(ratio, ratio_variance) - ratio)
         ratio_uncert[np.isnan(ratio_uncert)] = np.inf

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -756,9 +756,11 @@ class Shape:
             num_integral = sum(num * np.array(self.style.opts_axes["xbinwidth"]) )
             if num_integral>0:
                 num = num * (1./num_integral)
+                num_variances = num_variances * (1./num_integral)**2
             den_integral = sum(den * np.array(self.style.opts_axes["xbinwidth"]) )
             if den_integral>0:
                 den = den * (1./den_integral)
+                den_variances = den_variances * (1./den_integral)**2
 
         ratio = num / den
         # Total uncertainy propagation of num / den :
@@ -808,6 +810,7 @@ class Shape:
             print("Integral = ", den_integral)
             if den_integral>0:
                 den = den * (1./den_integral)
+                den_variances = den_variances * (1./den_integral)**2
 
         ratios = {}
         ratios_unc = {}
@@ -830,6 +833,7 @@ class Shape:
             if self.density:
                 num_integral = sum(num * np.array(self.style.opts_axes["xbinwidth"]) )
                 num = num * (1./num_integral)
+                num_variances = num_variances * (1./num_integral)**2
 
             ratio = num / den
             # Total uncertainy of num x den :

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -719,10 +719,10 @@ class Shape:
         if self.style.opts_mc["flow"] == "sum":
             if (len(num) != (len(hnum.values()) + 2)) | (len(den) != (len(hden.values()) + 2)):
                 raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-            num = np.concatenate([num[0]+num[1], num[2:-2], num[-2]+num[-1]])
-            den = np.concatenate([den[0]+den[1], den[2:-2], den[-2]+den[-1]])
-            num_variances = np.concatenate([num_variances[0]+num_variances[1], num_variances[2:-2], num_variances[-2]+num_variances[-1]])
-            den_variances = np.concatenate([den_variances[0]+den_variances[1], den_variances[2:-2], den_variances[-2]+den_variances[-1]])
+            num = np.concatenate([[num[0]+num[1]], num[2:-2], [num[-2]+num[-1]]])
+            den = np.concatenate([[den[0]+den[1]], den[2:-2], [den[-2]+den[-1]]])
+            num_variances = np.concatenate([[num_variances[0]+num_variances[1]], num_variances[2:-2], [num_variances[-2]+num_variances[-1]]])
+            den_variances = np.concatenate([[den_variances[0]+den_variances[1]], den_variances[2:-2], [den_variances[-2]+den_variances[-1]]])
 
         if self.density:
             num_integral = sum(num * np.array(self.style.opts_axes["xbinwidth"]) )
@@ -771,8 +771,8 @@ class Shape:
         if self.style.opts_mc["flow"] == "sum":
             if (len(den) != (len(hden.values()) + 2)):
                 raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-            den = np.concatenate([den[0]+den[1], den[2:-2], den[-2]+den[-1]])
-            den_variances = np.concatenate([den_variances[0]+den_variances[1], den_variances[2:-2], den_variances[-2]+den_variances[-1]])
+            den = np.concatenate([[den[0]+den[1]], den[2:-2], [den[-2]+den[-1]]])
+            den_variances = np.concatenate([[den_variances[0]+den_variances[1]], den_variances[2:-2], [den_variances[-2]+den_variances[-1]]])
 
         if self.density:
             den_integral = sum(den * np.array(self.style.opts_axes["xbinwidth"]) )
@@ -796,8 +796,8 @@ class Shape:
             if self.style.opts_mc["flow"] == "sum":
                 if (len(den) != (len(hden.values()) + 2)):
                     raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-                num = np.concatenate([num[0]+num[1], num[2:-2], num[-2]+num[-1]])
-                num_variances = np.concatenate([num_variances[0]+num_variances[1], num_variances[2:-2], num_variances[-2]+num_variances[-1]])
+                num = np.concatenate([[num[0]+num[1]], num[2:-2], [num[-2]+num[-1]]])
+                num_variances = np.concatenate([[num_variances[0]+num_variances[1]], num_variances[2:-2], [num_variances[-2]+num_variances[-1]]])
 
             if self.density:
                 num_integral = sum(num * np.array(self.style.opts_axes["xbinwidth"]) )

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -899,10 +899,10 @@ class Shape:
         self.ax.set_xlim(self.style.opts_axes["xedges"][0], self.style.opts_axes["xedges"][-1])
         if self.log:
             self.ax.set_yscale("log")
-            if self.is_mc_only:
-                exp = math.floor(math.log(max(stacks["mc_nominal_sum"].values()), 10))
-            else:
+            if self.is_data_only:
                 exp = math.floor(math.log(max(stacks["data_sum"].values()), 10))
+            else:
+                exp = math.floor(math.log(max(stacks["mc_nominal_sum"].values()), 10))
             self.ax.set_ylim((0.01, 10 ** (exp*1.75)))
         else:
             if self.is_data_only:

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -900,9 +900,12 @@ class Shape:
         if self.log:
             self.ax.set_yscale("log")
             if self.is_data_only:
-                exp = math.floor(math.log(max(stacks["data_sum"].values()), 10))
+                arg_log = max(stacks["data_sum"].values())
+            elif self.is_mc_only:
+                arg_log = max(stacks["mc_nominal_sum"].values())
             else:
-                exp = math.floor(math.log(max(stacks["mc_nominal_sum"].values()), 10))
+                arg_log = 100
+            exp = math.floor(math.log(arg_log, 10))
             self.ax.set_ylim((0.01, 10 ** (exp*1.75)))
         else:
             if self.is_data_only:

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -1145,6 +1145,16 @@ class Shape:
             up = self.syst_manager.total(cat).up
             down = self.syst_manager.total(cat).down
 
+            # If the histogram is in density mode, the systematic uncertainty has to be normalized to the integral of the MC stack
+            if self.density:
+                if self.style.opts_mc["flow"] == "sum":
+                    flow = True
+                else:
+                    flow = False
+                mc_integral = sum(self._get_stacks(cat)["mc_nominal_sum"].values(flow=flow)) * np.array(self.style.opts_axes["xbinwidth"])
+                up = up / mc_integral
+                down = down / mc_integral
+
         unc_band = np.array([down, up])
         ax.fill_between(
             self.style.opts_axes["xedges"],

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -904,6 +904,10 @@ class Shape:
             elif self.is_mc_only:
                 arg_log = max(stacks["mc_nominal_sum"].values())
             else:
+                arg_log = max(
+                    max(stacks["data_sum"].values()), max(stacks["mc_nominal_sum"].values())
+                )
+            if arg_log == 0:
                 arg_log = 100
             exp = math.floor(math.log(arg_log, 10))
             self.ax.set_ylim((0.01, 10 ** (exp*1.75)))


### PR DESCRIPTION
New features:
- **Bugfix:** Correct computation of underflow and overflow bins in MC and systematic uncertainty
- **Bugfix:** Improved defaults for the `Style` class and sanity checks
- **Enhancement:** Generalization of the categorical axes parameters for data and MC with defaults
- **Docs:** Updated documentation

**Correct underflow and overflow bins**
The computation of the MC yield and systematic uncertainty for the underflow and overflow bins is now correctly computed. The underflow and overflow bins are correctly summed to the first and last bin respectively.
The present default is that the user has to set both `underflow` and `overflow` axis parameters to the same value, i.e. the configurations with `underflow=True` and `overflow=False` and viceversa are not supported. However, this can be changed in the future for better flexibility.

**Improved defaults for `Style`**
The defaults for the `Style` object are now taken from the central default parameters of PocketCoffea, from `pocket_coffea/parameters/plotting_style.yaml`. In this way, if the user does not specify any required parameter needed for plotting, the default value is used.

**Generalization of categorical axes**
Two new dictionaries `categorical_axes_data` and `categorical_axes_mc` are introduced as attributes of the `Style` object to parametrize the categorical axes in data and MC histograms and included in the default parameters in `pocket_coffea/parameters/plotting_style.yaml`:
```
plotting_style:
     categorical_axes_data:
          year: years
          cat: categories
      
     categorical_axes_mc:
          year: years
          cat: categories
          variation: variations
```
This feature is needed in order for the user to include additional custom axes in the plotting, for example to include the `era` axis for data. This is done by overwriting the default parameters with the usual `--overwrite-parameters` option of the `make_plots.py` script, redefining the default dictionary such as:
```
plotting_style:
     categorical_axes_data:
          era: eras
```
At present only `era` is supported as additional custom axis for data, while no additional axis is supported for MC. However, in case of future developments the newly supported axes can be specified in the `_available_categorical_axes` method of the `Style` class.

**Updated documentation**
New section for the definition of custom categorical axes in the plotting.