### PR TITLE
Basic methods to deal with GenParticles and GenJets, and more tagger options for Jets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ AnalysisConfigs/
 VHccPoCo/
 output*
 plots*
+.pkl.gz

--- a/pocket_coffea/lib/deltaR_matching.py
+++ b/pocket_coffea/lib/deltaR_matching.py
@@ -72,8 +72,14 @@ def metric_pt(obj, obj2):
 def metric_eta(obj, obj2):
     return abs(obj.eta - obj2.eta)
 
+def delta_phi(a, b):
+    """Compute difference in angles between two phi values
+    Returns a value within [-pi, pi)
+    """
+    return (a - b + np.pi) % (2 * np.pi) - np.pi
+
 def metric_phi(obj, obj2):
-    return abs(obj.phi - obj2.phi)
+    return abs(delta_phi(obj.phi,obj2.phi))
 
 
 def object_matching(obj, obj2, dr_min, dpt_max=None, return_indices=False):

--- a/pocket_coffea/lib/deltaR_matching.py
+++ b/pocket_coffea/lib/deltaR_matching.py
@@ -73,7 +73,7 @@ def metric_eta(obj, obj2):
     return abs(obj.eta - obj2.eta)
 
 def delta_phi(a, b):
-    """Compute difference in angles between two phi values
+    """Compute difference in between two phi values, modulo 2pi
     Returns a value within [-pi, pi)
     """
     return (a - b + np.pi) % (2 * np.pi) - np.pi

--- a/pocket_coffea/lib/gen_objects.py
+++ b/pocket_coffea/lib/gen_objects.py
@@ -26,12 +26,12 @@ def Gen_leptons(events, lepton_flavour, params):
 
 
 
-def Gen_jets(events, GenLepCollName, params):
+def Gen_jets(events, GenLepCollNameForCleaning, params):
 
     cuts = params.object_preselection.GEN_Jet
     jets = events.GenJet[(np.abs(events.GenJet.eta) < cuts["eta"]) & (events.GenJet.pt > cuts["pt"])]
 
-    dR_jets_lep = jets.metric_table(events[GenLepCollName])
+    dR_jets_lep = jets.metric_table(events[GenLepCollNameForCleaning])
     mask_lepton_cleaning = ak.prod(dR_jets_lep > 0.4, axis=2) == 1
 
     mask_good_jets = mask_lepton_cleaning

--- a/pocket_coffea/lib/gen_objects.py
+++ b/pocket_coffea/lib/gen_objects.py
@@ -1,0 +1,38 @@
+import awkward as ak
+import numpy as np
+
+def Gen_leptons(events, lepton_flavour, params):
+
+    cuts = params.object_preselection.GEN
+    particles = events.GenPart
+
+    leptons = particles[
+        ((np.abs(particles.pdgId) == 11) | (np.abs(particles.pdgId) == 13))
+        & ak.fill_none((np.abs(particles.parent.pdgId) != 15), True)
+        & (particles.status == 1)
+        & (np.abs(particles.eta) < cuts["eta"])
+	    & (particles.pt > cuts["pt"])
+    ]
+    leptons = leptons[ak.argsort(leptons.pt, axis=1, ascending=False)]
+
+    if lepton_flavour == "Muon":
+        return leptons[np.abs(particles.pdgId) == 13]
+    elif lepton_flavour == "Electron":
+        return leptons[np.abs(particles.pdgId) == 11]
+    elif lepton_flavour == "Both":
+        return leptons
+    else:
+        raise("This lepton flavour in GEN particles is not supported:", lepton_flavour)
+
+
+
+def Gen_jets(events, params):
+
+    jets = events.GenJet[(np.abs(events.GenJet.eta) < 2.5) & (events.GenJet.pt > 25)]
+
+    dR_jets_lep = jets.metric_table(events["GenLep"])
+    mask_lepton_cleaning = ak.prod(dR_jets_lep > 0.4, axis=2) == 1
+
+    mask_good_jets = mask_lepton_cleaning
+
+    return jets[mask_good_jets]

--- a/pocket_coffea/lib/gen_objects.py
+++ b/pocket_coffea/lib/gen_objects.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def Gen_leptons(events, lepton_flavour, params):
 
-    cuts = params.object_preselection.GEN
+    cuts = params.object_preselection.GEN_Lep
     particles = events.GenPart
 
     leptons = particles[
@@ -26,11 +26,12 @@ def Gen_leptons(events, lepton_flavour, params):
 
 
 
-def Gen_jets(events, params):
+def Gen_jets(events, GenLepCollName, params):
 
-    jets = events.GenJet[(np.abs(events.GenJet.eta) < 2.5) & (events.GenJet.pt > 25)]
+    cuts = params.object_preselection.GEN_Jet
+    jets = events.GenJet[(np.abs(events.GenJet.eta) < cuts["eta"]) & (events.GenJet.pt > cuts["pt"])]
 
-    dR_jets_lep = jets.metric_table(events["GenLep"])
+    dR_jets_lep = jets.metric_table(events[GenLepCollName])
     mask_lepton_cleaning = ak.prod(dR_jets_lep > 0.4, axis=2) == 1
 
     mask_good_jets = mask_lepton_cleaning

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -258,11 +258,20 @@ def btagging(Jet, btag, wp, veto=False):
         return Jet[Jet[btag["btagging_algorithm"]] > btag["btagging_WP"][wp]]
 
 
-def CvsLsorted(jets, ctag):
-    return jets[ak.argsort(jets[ctag["tagger"]], axis=1, ascending=False)]
+def CvsLsorted(jets, tagger):
+    if tagger == "PNet":
+        ctag = "btagPNetCvL"
+    elif tagger == "DeepFlav":
+        ctag = "btagDeepFlavCvL"
+    elif tagger == "RobustParT":
+        ctag = "btagRobustParTAK4CvL"
+    else:
+        raise("This tagger is not implemented:", tagger)
+    
+    return jets[ak.argsort(jets[ctag], axis=1, ascending=False)]
 
 
-def get_dijet(jets, tagger = False):
+def get_dijet(jets, tagger = 'PNet'):
     
     fields = {
         "pt": 0.,
@@ -290,11 +299,24 @@ def get_dijet(jets, tagger = False):
     fields["j2Phi"] = ak.where( (njet >= 2), jets[:,1].phi, -1)
     fields["j1pt"] = ak.where( (njet >= 2), jets[:,0].pt, -1)
     fields["j2pt"] = ak.where( (njet >= 2), jets[:,1].pt, -1)
+
+    if tagger == "PNet":
+        CvL = "btagPNetCvL"
+        CvB = "btagPNetCvB"
+    elif tagger == "DeepFlav":
+        CvL = "btagDeepFlavCvL"
+        CvB = "btagDeepFlavCvB"
+    elif tagger == "RobustParT":
+        CvL = "btagRobustParTAK4CvL"
+        CvB = "btagRobustParTAK4CvB"
+    else:
+        raise("This tagger is not implemented:", tagger)
+
     if tagger:
-        fields["j1CvsL"] = ak.where( (njet >= 2), jets[:,0].btagDeepFlavCvL, -1)
-        fields["j2CvsL"] = ak.where( (njet >= 2), jets[:,1].btagDeepFlavCvL, -1)
-        fields["j1CvsB"] = ak.where( (njet >= 2), jets[:,0].btagDeepFlavCvB, -1)
-        fields["j2CvsB"] = ak.where( (njet >= 2), jets[:,1].btagDeepFlavCvB, -1)
+        fields["j1CvsL"] = ak.where( (njet >= 2), jets[:,0][CvL], -1)
+        fields["j2CvsL"] = ak.where( (njet >= 2), jets[:,1][CvL], -1)
+        fields["j1CvsB"] = ak.where( (njet >= 2), jets[:,0][CvB], -1)
+        fields["j2CvsB"] = ak.where( (njet >= 2), jets[:,1][CvB], -1)
     
     
     dijet = ak.zip(fields, with_name="PtEtaPhiMCandidate")

--- a/pocket_coffea/lib/leptons.py
+++ b/pocket_coffea/lib/leptons.py
@@ -1,10 +1,6 @@
 import awkward as ak
 import numpy as np
 
-# from ..parameters.object_preselection import object_preselection
-from ..lib.deltaR_matching import get_matching_pairs_indices, object_matching
-
-
 def lepton_selection(events, lepton_flavour, params):
 
     leptons = events[lepton_flavour]
@@ -72,9 +68,18 @@ def get_dilepton(electrons, muons, transverse=False):
         "mass": 0.,
         "charge": 0.,
     }
+
+    if muons is None and electrons is None:
+        raise("Must specify either muon or electron collection in get_dilepton() function")
+    elif muons is None and electrons is not None:
+        leptons = ak.pad_none(ak.with_name(electrons, "PtEtaPhiMCandidate"), 2)
+    elif electrons is None and muons is not None:
+        leptons = ak.pad_none(ak.with_name(muons, "PtEtaPhiMCandidate"), 2)
+    else:
+        leptons = ak.pad_none(ak.with_name(ak.concatenate([ muons[:, 0:2], electrons[:, 0:2]], axis=1), "PtEtaPhiMCandidate"), 2)
+        
+    nlep = ak.num(leptons[~ak.is_none(leptons, axis=1)])
     
-    leptons = ak.pad_none(ak.with_name(ak.concatenate([ muons[:, 0:2], electrons[:, 0:2]], axis=1), "PtEtaPhiMCandidate"), 2)
-    nlep =  ak.num(leptons[~ak.is_none(leptons, axis=1)])
     ll = leptons[:,0] + leptons[:,1]
 
     for var in fields.keys():

--- a/pocket_coffea/lib/objects.py
+++ b/pocket_coffea/lib/objects.py
@@ -1,2 +1,3 @@
 from .jets import *
 from .leptons import *
+from .gen_objects import *

--- a/pocket_coffea/parameters/histograms.py
+++ b/pocket_coffea/parameters/histograms.py
@@ -143,6 +143,46 @@ default_axis_settings = {
         "lim": (-math.pi, math.pi),
         'label': "$\phi_{j}$",
     },
+    'genjet_pt': {
+        "field": "pt",
+        "bins": 50,
+        "start": 0,
+        'stop': 300,
+        "lim": (0, 300),
+        'label': "$p_{T}^{j}$ [GeV]",
+    },
+    'genjet_eta': {
+        "field": "eta",
+        "bins": 50,
+        "start": -2.5,
+        'stop': 2.5,
+        "lim": (-2.5, 2.5),
+        'label': "$\eta_{j}$",
+    },
+    'genjet_phi': {
+        "field": "phi",
+        "bins": 64,
+        "start": -math.pi,
+        'stop': math.pi,
+        "lim": (-math.pi, math.pi),
+        'label': "$\phi_{j}$",
+    },
+    'genjet_hadronFlavour': {
+        "field": "hadronFlavour",
+        "bins": 8,
+        "start": -1,
+        'stop': 7,
+        "lim": (-1, 7),
+        'label': "hadron flavor",
+    },
+    'genjet_partonFlavour': {
+        "field": "partonFlavour",
+        "bins": 33,
+        "start": -10,
+        'stop': 23,
+        "lim": (-10, 23),
+        'label': "parton flavor",
+    },
     'jet_btagDeepFlavB': {
         "field": "btagDeepFlavB",
         "bins": 50,
@@ -452,6 +492,7 @@ collection_fields = {
         "btagHbb",
     ],
     'parton': ["eta", "pt", "phi", "dRMatchedJet", "pdgId"],
+    'genjet': ["eta", "pt", "phi", "hadronFlavour", "partonFlavour"],
     'electron': ["eta", "pt", "phi", "etaSC"],
     'muon': ["eta", "pt", "phi"],
     'lepton': ["eta", "pt", "phi", "pdgId"],
@@ -506,6 +547,11 @@ def jet_hists(coll="JetGood", pos=None, fields=None, name=None, axis_settings=No
     if name == None:
         name = coll
     return _get_default_hist(name, "jet", coll, pos, fields, axis_settings, **kwargs)
+
+def genjet_hists(coll="MyGenJets", pos=None, fields=None, name=None, axis_settings=None, **kwargs):
+    if name == None:
+        name = coll
+    return _get_default_hist(name, "genjet", coll, pos, fields, axis_settings, **kwargs)
 
 
 def fatjet_hists(coll="FatJetGood", pos=None, fields=None, name=None, axis_settings=None, **kwargs):

--- a/pocket_coffea/parameters/histograms.py
+++ b/pocket_coffea/parameters/histograms.py
@@ -207,6 +207,54 @@ default_axis_settings = {
         "lim": (0, 1),
         'label': "AK4 DeepJet CvsB score",
     },
+    'jet_btagPNetB': {
+        "field": "btagPNetB",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 PNet b-tag score",
+    },
+    'jet_btagPNetCvL': {
+        "field": "btagPNetCvL",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 PNet CvsL score",
+    },
+    'jet_btagPNetCvB': {
+        "field": "btagPNetCvB",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 PNet CvsB score",
+    },
+    'jet_btagRobustParTAK4B': {
+        "field": "btagRobustParTAK4B",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 RobustParT b-tag score",
+    },
+    'jet_btagRobustParTAK4CvL': {
+        "field": "btagRobustParTAK4CvL",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 RobustParT CvsL score",
+    },
+    'jet_btagRobustParTAK4CvB': {
+        "field": "btagRobustParTAK4CvB",
+        "bins": 50,
+        "start": 0.0,
+        'stop': 1.0,
+        "lim": (0, 1),
+        'label': "AK4 RobustParT CvsB score",
+    },
     'fatjet_pt': {
         "field": "pt",
         "bins": 100,
@@ -474,7 +522,9 @@ default_axis_settings = {
 }
 
 collection_fields = {
-    'jet': ["eta", "pt", "phi", "btagDeepFlavB", "btagDeepFlavCvL", "btagDeepFlavCvB"],
+    'jet': ["eta", "pt", "phi", "btagDeepFlavB", "btagDeepFlavCvL", "btagDeepFlavCvB",
+            "btagPNetB", "btagPNetCvL", "btagPNetCvB",
+            "btagRobustParTAK4B", "btagRobustParTAK4CvL", "btagRobustParTAK4CvB",],
     'fatjet': [
         "eta",
         "pt",

--- a/pocket_coffea/parameters/plotting_style.yaml
+++ b/pocket_coffea/parameters/plotting_style.yaml
@@ -1,9 +1,9 @@
 plotting_style:
 
-    collapse_datasets: true     # Plot all the datasets with the same sample as a single shape 
+    collapse_datasets: true     # Plot all the datasets with the same sample as a single shape
     fontsize: 22
     fontsize_legend_ratio: 12
-    
+
 
     opts_figure:
       datamc:
@@ -13,7 +13,7 @@ plotting_style:
         gridspec_kw:
           height_ratios: [3,1]
         sharex: true
-        
+
       partial:
         figsize: [12,15]
         gridspec_kw:
@@ -36,7 +36,7 @@ plotting_style:
       linewidth: 0
       marker: .
       markersize: 5.0
-      
+
     opts_mc:
       histtype: "fill"
       stack: true
@@ -50,7 +50,7 @@ plotting_style:
       edges: true
       linestyle: solid
       linewidth: 1
-            
+
     opts_syst:
       down:
         color: blue
@@ -64,7 +64,7 @@ plotting_style:
         color: red
         linestyle: dashed
         linewidth: 1
-        
+
     opts_unc:
       Down:
         elinewidth: 1
@@ -78,7 +78,7 @@ plotting_style:
         linewidth: 1
         marker: .
         markersize: 1.0
-        
+
       total:
         color: [0.,0.,0.,0.4]
         facecolor: [0.,0.,0.,0.]
@@ -90,7 +90,7 @@ plotting_style:
     print_info:
       category: False
       year: false
-      
+
     plot_upper_label:
       by_year:
         "2016_PreVFP": "${pico_to_femto:${lumi.picobarns.2016_PreVFP.tot}}"

--- a/pocket_coffea/parameters/plotting_style.yaml
+++ b/pocket_coffea/parameters/plotting_style.yaml
@@ -50,7 +50,7 @@ plotting_style:
       edges: true
       linestyle: solid
       linewidth: 1
-      
+            
     opts_syst:
       down:
         color: blue

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -842,7 +842,7 @@ class Shape:
             # ratio_variance = np.power(ratio,2)*den_variances*np.power(den, -2)
 
             ratio_uncert = np.abs(poisson_interval(ratio, ratio_variance) - ratio)
-            ratio_uncert[np.isnan(ratio_uncert)] = np.inf
+            #ratio_uncert[np.isnan(ratio_uncert)] = np.inf
 
             ratios[hnum.name] = ratio
             ratios_unc[hnum.name] = ratio_uncert
@@ -974,9 +974,9 @@ class Shape:
             )
 
         if self.style.print_info["year"]:
-            self.ax.text(0.04, 0.75, f'Year: {self.year}', fontsize=12, transform=self.ax.transAxes)
+            self.ax.text(0.04, 0.75, f'Year: {self.year}', fontsize=0.7*self.style.fontsize, transform=self.ax.transAxes)
         if self.style.print_info["category"]:
-            self.ax.text(0.04, 0.70, f'Cat: {cat}', fontsize=12, transform=self.ax.transAxes)
+            self.ax.text(0.04, 0.70, f'Cat: {cat}', fontsize=0.7*self.style.fontsize, transform=self.ax.transAxes)
 
     def plot_mc(self, cat, ax=None):
         '''Plots the MC histograms as a stacked plot.'''
@@ -1090,7 +1090,7 @@ class Shape:
         )
         self.format_figure(cat, ratio=True)
         self.rax.axhline(1.0, color="black", linestyle="--")
-
+                        
     def plot_compare_ratios(self, cat, ref, ax=None):
         '''Plots the ratios as an errorbar plots.'''
         if self.dense_dim > 1:
@@ -1114,25 +1114,30 @@ class Shape:
                 unity = np.ones_like(ratios_unc[proc])
                 down = unity[0] - ratios_unc[proc][0]
                 up = unity[1] + ratios_unc[proc][1]
+                
                 #print("Ratio unc:", ratios_unc[proc])
+                #print("Up-down:", up-down)
+                
                 if ref=='data_sum':
                     color = 'black'
                 else:
                     color = self.colors[proc]
                 self.rax.stairs(down, baseline=up, edges=self.style.opts_axes["xedges"],
-                                color=color, alpha=0.4, linewidth=0, hatch='////')
+                                color=color, alpha=0.4, linewidth=0, facecolor="none", hatch='////')
             else:
                 if proc=='data_sum':
                     color = 'black'
                 else:
                     color = self.colors[proc]
                 self.rax.errorbar(self.style.opts_axes["xcenters"], ratios[proc], yerr=ratios_unc[proc],
-                                  **self.style.opts_ratios, color=color)
+                                  color=color, linewidth=0, elinewidth=1, marker='o', markersize=4)
         ref_label = ref
         if ref_label in self.style.labels_mc:
             ref_label = self.style.labels_mc[ref_label]
-        self.rax.text(0.04, 0.85, f'Ref = {ref_label}', fontsize=12, transform=self.rax.transAxes)
+        self.rax.text(0.04, 0.85, f'Ref = {ref_label}', fontsize=self.style.fontsize, transform=self.rax.transAxes)
 
+        self.format_figure(cat, ref=ref, ratio=True)
+        self.rax.axhline(1.0, color="gray", linestyle="--")
 
     def plot_systematic_uncertainty(self, cat, ratio=False, ax=None):
         '''Plots the asymmetric systematic uncertainty band on top of the MC stack, if `ratio` is set to False.

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -813,7 +813,8 @@ class Shape:
         # Create ratios for all MC hist compared to the reference
         histograms_list = [h for h in stacks['mc_nominal'] ]
 
-        histograms_list.append(stacks['data_sum'])
+        if not self.is_mc_only:
+            histograms_list.append(stacks['data_sum'])
         for hnum in histograms_list:
             #print("Process:", hnum.name, type(hnum))
             num = hnum.values(flow=self.style.flow)


### PR DESCRIPTION
Adding some tools for generator-only analysis. Namely, selecting leptons from GenParticles and selecting GenJets

Plus, a few  other minor changes: `delta_phi` function; new histograms for gen objects, new histograms for PNet and RobustParT tagger scores; minor changes for plotting with --compare option.