### PR TITLE
Update/law tasks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ analysis phase space and metadata from CMS groups, and an analysis's run configu
 changelog.md
 installation.md
 running.md
+law_tasks.md
 analysis_example.md
 recipes.md
 plots.md

--- a/docs/law_tasks.md
+++ b/docs/law_tasks.md
@@ -1,16 +1,40 @@
-# Run pocket-coffea Analysis with law Tasks
+# Run a PocketCoffea Analysis with law
 
 ## Introduction
 
-[law documentation](https://law.readthedocs.io/en/latest/)
+A typical analysis with PocketCoffea consists of several steps, such as e.g. dataset preparation, dataset processing and plotting, which depend on each other. To handle these dependencies the python package [law](https://law.readthedocs.io/en/latest/) can be used to structure the analysis. With law you can define tasks that depend on each other by defining requirements and outputs.
+```python
+import law
+
+
+class MyTask(law.Task):
+    def requires(self):
+        return MyOtherTask.req(self)
+
+    def output(self):
+        return law.LocalFileTarget("output.txt")
+
+    def run(self):
+        self.output().dump("Hello, World!")
+```
+law checks wether the output of a tasks exists and runs the task and its dependencies if the output is missing.
+
+The following tasks are available in PocketCoffea (`pocket_coffea/law_tasks/tasks`):
+  - `CreateDatasets`: prepare datasets for processing
+  - `JetCalibration`: build jet calibration factory
+  - `Runner`: run the analysis on the datasets
+  - `Plotter`: create histogram plots from the processed datasets
+  - `PlotSystematics`: create histogram plots for systematic shifts
 
 ## Analysis Setup
 
-- assume you are familiar with general setup of an analysis config in PocketCoffea (https://pocketcoffea.readthedocs.io/en/stable/analysis_example.html)
-- additional files are
-  - law.cfg: configuration file for law tasks
-  - setup.sh: setup script to set environment variables and index law (optional, but recommended)
+For a general setup of an analysis with PocketCoffea see the [analysis example](https://pocketcoffea.readthedocs.io/en/stable/analysis_example.html). Here we focus on the setup with law.
 
+Two additional files are needed to setup the analysis with law:
+  - law.cfg: configuration file for law
+  - setup.sh: setup script to set environment variables and index law tasks
+
+So the directory structure looks like this:
 ```
 analysis-config
 |   config.py
@@ -26,10 +50,50 @@ analysis-config
 |   |   ...
 ```
 
+The setup file could look like this:
+```bash
+# setup PATHs and configurations for law
+
+setup_analysis() {
+    # get important paths
+    orig="${PWD}"
+    this_file="$( [ ! -z "${ZSH_VERSION}" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
+    cd "${orig}"
+
+    # === analysis ===
+    export ANALYSIS_STORE="/net/scratch/analysis_outputs"
+
+    # === law ===
+    export LAW_CONFIG_FILE="${this_dir}/law.cfg"
+    export LAW_HOME="${this_dir}/.law"
+
+    if which law &> /dev/null; then
+        # source law's bash completion script
+        source "$( law completion )" ""
+        # index law and check if it was successful
+        law index -q
+        return_code=$?
+        if [ ${return_code} -ne 0 ]; then
+            echo "failed to index law with error code ${return_code}"
+            return 1
+        else
+            echo "law tasks were successfully indexed"
+        fi
+    fi
+
+}
+
+setup_analysis "$@"
+```
+
+The `ANALYSIS_STORE` variable is used to specify the output directory for the analysis. Every task creates a subdirectory with its output.
 
 ### law configuration
 
-detailed description in the [configuration section](https://law.readthedocs.io/en/latest/config.html) of the law documentation.
+A detailed description of the configuration of law can be found in the [configuration section](https://law.readthedocs.io/en/latest/config.html) of the law documentation.
+
+The important part is the `[modules]` section, where all the modules that you want to use in your analysis are listed.
 
 ```bash
 [modules]
@@ -42,50 +106,47 @@ pocket_coffea.law_tasks.tasks.plotting
 # custom tasks
 custom_tasks.tasks
 ```
-
-### setup.sh
-
+You can also add custom tasks here, which must be accessible via `PYTHONPATH`. So you should add the following to your `setup.sh`:
 ```bash
-# setup PATHs and configurations for law
-
-action() {
-    # get important paths
-    orig="${PWD}"
-    this_file="$( [ ! -z "${ZSH_VERSION}" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
-    this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
-    cd "${orig}"
-
-    # add directory to pythonpath, so modules can be imported
-    export PYTHONPATH="${this_dir}:${PYTHONPATH}"
-
-    # === law ===
-    export LAW_CONFIG_FILE="${this_dir}/law.cfg"
-    export LAW_HOME="${this_dir}/.law"
-
-    # source law's bash completion script
-    if which law &> /dev/null; then
-        source "$( law completion )" ""
-
-        # index law and check if it was successful
-        law index -q
-        return_code=$?
-        if [ ${return_code} -ne 0 ]; then
-            echo "failed to index law with error code ${return_code}"
-            return 1
-        else
-            echo "law tasks were successfully indexed"
-        fi
-
-    fi
-
-}
-
-action "$@"
+export PYTHONPATH="${this_dir}:${PYTHONPATH}"
 ```
 
 ## Running law tasks
 
+### Getting an Overview
+You can get an overview of all available tasks if you index law in verbose mode:
 ```bash
-law run Plotting --cfg config.py --print-status -1
+law index -v
+```
+
+Tasks have different parameters which control the behavior of the task. The available parameters will be listed if you press `TAB` twice after the task name in the command line.
+```bash
+law run CreateDatasets <TAB><TAB>
+```
+To get an extensive list with descriptions of all parameters you can use the `--help` flag:
+```bash
+law run CreateDatasets --help
+```
+
+Tasks depend on each other, so you can use the `--print-deps <DEPTH>` flag to get an overview of the dependencies of a task, where `<DEPTH>` is an integer that specifies the depth of the dependency tree (-1 displays all dependencies).
+```bash
+law run Plotter --print-deps -1
+```
+This just prints the dependencies. To check which tasks have already been executed and which are still missing you can use the `--print-status <DEPTH>` flag.
+```bash
+law run Plotter --print-status -1
+```
+
+### Executing Tasks
+To execute a task you simply use `law run` followed by the task name and the parameters. Some parameters have defaults, so you don't have to specify them. If you want to overwrite a default parameter you can do this by specifying the parameter with the new value.
+
+Let's assume you have your configuration file in a folder `config/config.py`, you want to run on lxplus with the dask executor and you want to scale out to 50 workers. In the plots you dont want to plot the data and you want the y-axis to be logarithmic. You can run the plotting task like this:
+```bash
+law run Plotting --cfg config/config.py --version version01 --executor dask@lxplus --scaleout 50 --blind True --log-scale 
+```
+The version parameter is used to create a new directory in the output directory to for example separate different configurations. The parameters `--blind` and `--log-scale` are both boolean parameters, so to set them to `True` you can just specify them without a value.
+
+If a task has already been executed and you want to rerun it you can use the `--remove-output <DEPTH>` flag, where `<DEPTH>` can be an integer or a tuple. The first integer specifies the depth of the dependency tree. For the second value you can choose between `d` (dry), `i` (interactive) and `a` (all). The third value is a boolean that specifies if the task should be executed after the removal (1) or not (0).
+```bash
 law run Plotting --cfg config.py --remove-output 0,i,1
 ```

--- a/pocket_coffea/law_tasks/configuration/general.py
+++ b/pocket_coffea/law_tasks/configuration/general.py
@@ -95,7 +95,7 @@ class runnerconfig(luigi.Config):
 
 
 class plottingconfig(luigi.Config):
-    plot_dir = luigi.Parameter(default="plots", description="Output folder for plots")
+    plot_dir = luigi.Parameter(default=law.NO_STR, description="Output folder for plots")
     plot_verbose = luigi.IntParameter(
         default=0, description="verbosity level for PlotManager (default: 0)"
     )

--- a/pocket_coffea/law_tasks/tasks/datasets.py
+++ b/pocket_coffea/law_tasks/tasks/datasets.py
@@ -85,8 +85,8 @@ from pocket_coffea.utils.dataset import build_datasets
 class CreateDatasets(BaseTask):
     """Create dataset json files"""
 
-    # datasets are independent of the version
-    version = None
+    # # datasets are independent of the version
+    # version = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pocket_coffea/law_tasks/tasks/plotting.py
+++ b/pocket_coffea/law_tasks/tasks/plotting.py
@@ -82,6 +82,8 @@ class Plotter(PlotterBase):
     def output(self):
         blind_str = "blind" if self.blind else "data-mc"
         yscale_str = "log" if self.log_scale else "lin"
+        if self.plot_dir != law.NO_STR:
+            return self.local_file_target(self.plot_dir, blind_str, yscale_str, ".plots_done")
         return self.local_file_target(blind_str, yscale_str, ".plots_done")
 
     def run(self):
@@ -100,6 +102,8 @@ class PlotSystematics(PlotterBase):
     def output(self):
         syst_str = "systematics_ratio" if self.ratio else "systematics"
         yscale_str = "log" if self.log_scale else "lin"
+        if self.plot_dir != law.NO_STR:
+            return self.local_file_target(self.plot_dir, syst_str, yscale_str, ".plots_done")
         return self.local_file_target(syst_str, yscale_str, ".plots_done")
 
     def run(self):


### PR DESCRIPTION
# Documentation of law Tasks Updated

The law section of the PocketCoffea documentation is updated to include:
- a short introduction into what law does and which tasks are available
- a guide how to setup the analysis, which files are needed with example files
- how to get an overview of the tasks status/dependencies
- how to execute tasks with some basic, useful commands

# Minor changes 
A few minor changes are made to the output paths of plotting and dataset creation tasks
- plotting: the default plot directory is now empty (which was basically a redundancy), i.e. `$ANALYSIS_STORE/Plotter/plot` &rarr; `$ANALYSIS_STORE/Plotter/`
- dataset creation: the json output of the dataset creation is now stored per version (e.g. changes in dataset definition can be separated by version parameter)

---

I hope the updated documentation makes it easy to get started with law.
Feedback on what might be missing in the documentation is most welcome.