### PR TITLE
Improvements in plotting + various

### DIFF
--- a/docs/analysis_example.md
+++ b/docs/analysis_example.md
@@ -107,7 +107,7 @@ see [Datasets handling](./datasets.md)
 
 The steps are the following:
 
-1) Create a json file that contains the required datasets, `dataset_definitions.json`. Each entry of the dictionary
+1) Create a json file that contains the required datasets, `datasets_definitions.json`. Each entry of the dictionary
 corresponds to a dataset. Datasets include a list of DAS keys, the output json dataset path and the metadata. In
 addition a label `sample` is specified to assign a the "type" of events contained in the dataset (e.g. group QCD datasets from different
 HT bins in a single sample).
@@ -206,7 +206,7 @@ our Drell-Yan and SingleMuon datasets should be the following:
 # if you are using singularity, create the ticket outside of it.
 voms-proxy-init -voms cms -rfc --valid 168:0
 
-pocket-coffea build-dataset --cfg datasets/dataset_definitions.json -o
+pocket-coffea build-datasets --cfg datasets/datasets_definitions.json -o
 
 # if you are running at CERN it is useful to restrict the data sources to Tiers closer to CERN
 pocket-coffea build-datasets --cfg datasets/datasets_definitions.json -o -rs 'T[123]_(FR|IT|BE|CH|DE)_\w+'

--- a/docs/analysis_example.md
+++ b/docs/analysis_example.md
@@ -32,7 +32,7 @@ If you want to test it on lxplus just use the singularity image:
 apptainer shell  -B /afs -B /cvmfs/cms.cern.ch -B /tmp  -B /eos/cms/  \
                  -B /etc/sysconfig/ngbauth-submit  \
                  -B ${XDG_RUNTIME_DIR}  --env KRB5CCNAME=${XDG_RUNTIME_DIR}/krb5cc
-                 /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-cc7-stable
+                 /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-el9-stable
 ```
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ The apptainer environment is activated on **lxplus** with the following command:
 apptainer shell -B /afs -B /cvmfs/cms.cern.ch \
                 -B /tmp  -B /eos/cms/  -B /etc/sysconfig/ngbauth-submit \
                 -B ${XDG_RUNTIME_DIR}  --env KRB5CCNAME="FILE:${XDG_RUNTIME_DIR}/krb5cc" 
-    /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-cc7-stable
+    /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-el9-stable
 ```
 
 N.B.: The command to start the apptainer image has changed when lxplus moved to the el9 machines by default. The
@@ -45,7 +45,7 @@ difference is about the handling of the kerberos ticket necessary to access to t
 shell command above setups correctly the environment.
 
 The last part of the command contains the image version on unpacked:
-**cms-analysis/general/pocketcoffea:lxplus-cc7-stable**. The stable version is the recommended one to stay up-to-date
+**cms-analysis/general/pocketcoffea:lxplus-el9-stable**. The stable version is the recommended one to stay up-to-date
 with the development without the rought edges of the main branch. 
 
 Once inside the environment no installation is needed. The PocketCoffea scripts are globally available and the user's
@@ -87,7 +87,7 @@ If the user needs to modify locally the central PocketCoffea code, the apptainer
 apptainer shell --bind /afs -B /cvmfs/cms.cern.ch \
          --bind /tmp  --bind /eos/cms/ -B /etc/sysconfig/ngbauth-submit \
          -B ${XDG_RUNTIME_DIR}  --env KRB5CCNAME="FILE:${XDG_RUNTIME_DIR}/krb5cc"  \
-         /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-cc7-stable
+         /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-el9-stable
 
 # Clone locally the PocketCoffea repo
 git clone git@github.com:PocketCoffea/PocketCoffea.git
@@ -109,7 +109,7 @@ The next time the user enters in the apptainer the virtual environment needs to 
 apptainer shell  -B /afs -B /cvmfs/cms.cern.ch -B /tmp  -B /eos/cms/  \
                  -B /etc/sysconfig/ngbauth-submit  \
                  -B ${XDG_RUNTIME_DIR}  --env KRB5CCNAME="FILE:${XDG_RUNTIME_DIR}/krb5cc" 
-                 /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-cc7-stable
+                 /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-el9-stable
 
 # Activate the virtual environment
 cd PocketCoffea

--- a/docs/plots.md
+++ b/docs/plots.md
@@ -114,6 +114,21 @@ histogram is rescaled by the number specified.
 The `print_info` options would print a text on the plots for category
 name and the year (era period).
 
+In addition, all the default parameters related to the formatting of figures,
+such as `opts_figure`, `opts_data`, `opts_mc`, `opts_sig`, `opts_syst`, `opts_unc` and
+`opts_ylim`, can be overridden by passing custom parameters. For example, to set custom
+limits on the y-axis of logarithmic plots, one can include this dictionary in the
+`.yaml` file passed as the `-op` argument:
+```
+plotting_style:
+
+    opts_ylim:
+        datamc:
+            ylim_log:
+                lo: 0.01
+                hi: 1000000
+```
+
 ## Produce shape comparison plots
 
 Oftentimes one wants to compare shapes of various MC samples, not the

--- a/docs/running.md
+++ b/docs/running.md
@@ -84,7 +84,7 @@ Options:
   -lc, --limit-chunks INTEGER     Limit number of chunks
   -e, --executor TEXT             Overwrite executor from config (to be used
                                   only with the --test options)
-  -s, --scaleout INTEGER          Overwrite scalout config
+  -s, --scaleout INTEGER          Overwrite scaleout config
   -c, --chunksize INTEGER         Overwrite chunksize config
   -q, --queue TEXT                Overwrite queue config
   -ll, --loglevel TEXT            Console logging level
@@ -133,7 +133,7 @@ The default options for the running options and different type of executors are 
 For example:
 ```yaml
 general: 
-  scalout: 1
+  scaleout: 1
   chunksize: 100000
   limit-files: null
   limit-chunks: null

--- a/docs/running.md
+++ b/docs/running.md
@@ -147,7 +147,7 @@ dask@lxplus:
   cores-per-worker: 1
   mem-per-worker: "2GB"
   disk-per-worker: "2GB"
-  worker-image: /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-cc7-stable
+  worker-image: /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-el9-stable
   death-timeout: "3600"
   queue: "microcentury"
   adaptive: false

--- a/pocket_coffea/executors/executors_DESY_NAF.py
+++ b/pocket_coffea/executors/executors_DESY_NAF.py
@@ -88,7 +88,7 @@ class ParslCondorExecutorFactory(ExecutorFactoryABC):
 
     def customized_args(self):
         args = super().customized_args()
-        # in the futures executor Nworkers == N scalout
+        # in the futures executor Nworkers == N scaleout
         # ~ args["treereduction"] = self.run_options.get("tree-reduction", None)
         # ~ args["skip-bad-files"] = self.run_options.get("skip-bad-files", None)
         return args

--- a/pocket_coffea/executors/executors_RWTH.py
+++ b/pocket_coffea/executors/executors_RWTH.py
@@ -96,7 +96,7 @@ class ParslCondorExecutorFactory(ExecutorFactoryABC):
 
     def customized_args(self):
         args = super().customized_args()
-        # in the futures executor Nworkers == N scalout
+        # in the futures executor Nworkers == N scaleout
         #args["treereduction"] = self.run_options["tree-reduction"]
         return args
 
@@ -186,7 +186,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
 
     def customized_args(self):
         args = super().customized_args()
-        # in the futures executor Nworkers == N scalout
+        # in the futures executor Nworkers == N scaleout
         args["client"] = self.dask_client
         args["treereduction"] = self.run_options["tree-reduction"]
         args["retries"] = self.run_options["retries"]

--- a/pocket_coffea/executors/executors_T3_CH_PSI.py
+++ b/pocket_coffea/executors/executors_T3_CH_PSI.py
@@ -61,8 +61,8 @@ class DaskExecutorFactory(ExecutorFactoryABC):
         print(">>> Creating a SLURM cluster")
         self.dask_cluster = SLURMCluster(
                 queue=self.run_options['queue'],
-                cores=self.run_options['cores-per-worker'],
-                processes=self.run_options['cores-per-worker'],
+                cores=self.run_options.get('cores-per-worker', 1),
+                processes=self.run_options.get('cores-per-worker', 1),
                 memory=self.run_options['mem-per-worker'],
                 walltime=self.run_options["walltime"],
                 job_script_prologue=self.get_worker_env(),

--- a/pocket_coffea/executors/executors_T3_CH_PSI.py
+++ b/pocket_coffea/executors/executors_T3_CH_PSI.py
@@ -93,7 +93,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
 
     def customized_args(self):
         args = super().customized_args()
-        # in the futures executor Nworkers == N scalout
+        # in the futures executor Nworkers == N scaleout
         args["client"] = self.dask_client
         args["treereduction"] = self.run_options["tree-reduction"]
         args["retries"] = self.run_options["retries"]

--- a/pocket_coffea/executors/executors_base.py
+++ b/pocket_coffea/executors/executors_base.py
@@ -64,7 +64,7 @@ class FuturesExecutorFactory(ExecutorFactoryABC):
 
     def customized_args(self):
         args = super().customized_args()
-        # in the futures executor Nworkers == N scalout
+        # in the futures executor Nworkers == N scaleout
         args["workers"] = self.run_options["scaleout"]
         return args
 

--- a/pocket_coffea/executors/executors_lxplus.py
+++ b/pocket_coffea/executors/executors_lxplus.py
@@ -110,7 +110,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
 
     def customized_args(self):
         args = super().customized_args()
-        # in the futures executor Nworkers == N scalout
+        # in the futures executor Nworkers == N scaleout
         args["client"] = self.dask_client
         args["treereduction"] = self.run_options["tree-reduction"]
         args["retries"] = self.run_options["retries"]

--- a/pocket_coffea/executors/executors_purdue_af.py
+++ b/pocket_coffea/executors/executors_purdue_af.py
@@ -137,7 +137,7 @@ class DaskGatewayExecutorFactory(ExecutorFactoryABC):
 
     def customized_args(self):
         args = super().customized_args()
-        # in the futures executor Nworkers == N scalout
+        # in the futures executor Nworkers == N scaleout
         args["client"] = self.dask_client
         args["treereduction"] = self.run_options["tree-reduction"]
         args["retries"] = self.run_options["retries"]

--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -365,7 +365,7 @@ def sf_btag_calib(params, sample, year, njets, jetsHt):
         params.btagSF_calibration[year]["file"]
     )
     corr = cset[params.btagSF_calibration[year]["name"]]
-    w = corr.evaluate(sample, year, ak.to_numpy(njets), ak.to_numpy(jetsHt))
+    w = corr.evaluate(sample, ak.to_numpy(njets), ak.to_numpy(jetsHt))
     return w
 
 

--- a/pocket_coffea/lib/weights/common/common.py
+++ b/pocket_coffea/lib/weights/common/common.py
@@ -1,5 +1,6 @@
 from ..weights import WeightWrapper, WeightLambda, WeightData, WeightDataMultiVariation
 import numpy as np
+import awkward as ak
 
 from pocket_coffea.lib.scale_factors import (
     sf_ele_reco,
@@ -196,7 +197,7 @@ class SF_btag(WeightWrapper):
 
 class SF_btag_calib(WeightWrapper):
     name = "sf_btag_calib"
-    has_variations = True
+    has_variations = False
 
     def __init__(self, params, metadata):
         super().__init__(params, metadata)
@@ -213,12 +214,12 @@ class SF_btag_calib(WeightWrapper):
                             )
         return WeightData(
             name = self.name,
-            nominal = out[0],
-            up = out[1],
-            down = out[2]
+            nominal = out,#[0],
+            #up = out[1],
+            #down = out[2]
             )
 
-    
+
 ########################################
 # Ctag scale factors have weights depending on the shape_variation
 

--- a/pocket_coffea/parameters/plotting_style.yaml
+++ b/pocket_coffea/parameters/plotting_style.yaml
@@ -8,8 +8,6 @@ plotting_style:
     opts_figure:
       datamc:
         figsize: [12,9]
-        ylim_log:
-          lo: 0.01
       datamc_ratio:
         figsize: [12,12]
         gridspec_kw:
@@ -88,6 +86,11 @@ plotting_style:
         linewidth: 0
         step: post
         zorder: 2
+
+    opts_ylim:
+      datamc:
+        ylim_log:
+          lo: 0.01
 
     print_info:
       category: False

--- a/pocket_coffea/parameters/plotting_style.yaml
+++ b/pocket_coffea/parameters/plotting_style.yaml
@@ -8,6 +8,8 @@ plotting_style:
     opts_figure:
       datamc:
         figsize: [12,9]
+        ylim_log:
+          lo: 0.01
       datamc_ratio:
         figsize: [12,12]
         gridspec_kw:

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -33,10 +33,11 @@ import click
 @click.option('--no-ratio', is_flag=True, help='Dont plot the ratio', required=False, default=False)
 @click.option('--no-systematics-ratio', is_flag=True, help='Plot the ratio of the shifts for the systematic uncertainties', required=False, default=False)
 @click.option('--compare', is_flag=True, help='Plot comparison of the samples, instead of data/MC', required=False, default=False)
+@click.option('--index-file', type=str, help='Path of the index file to be copied recursively in the plots directory and its subdirectories', required=False, default=None)
 
 def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfile,
                workers, only_cat, only_syst, exclude_hist, only_hist, split_systematics, partial_unc_band, no_syst,
-               overwrite, log, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare):
+               overwrite, log, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare, index_file):
     '''Plot histograms produced by PocketCoffea processors'''
 
     # Using the `input_dir` argument, read the default config and coffea files (if not set with argparse):
@@ -98,7 +99,8 @@ def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfile,
         log=log,
         density=density,
         verbose=verbose,
-        save=True
+        save=True,
+        index_file=index_file
     )
 
     print("Started plotting.  Please wait...")

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -18,6 +18,7 @@ import click
 @click.option("-i", "--inputfile", type=str, help="Input file", required=False)
 @click.option('-j', '--workers', type=int, default=8, help='Number of parallel workers to use for plotting', required=False)
 @click.option('-oc', '--only-cat', type=str, multiple=True, help='Filter categories with string', required=False)
+@click.option('-oy', '--only-year', type=str, multiple=True, help='Filter datataking years with string', required=False)
 @click.option('-os', '--only-syst', type=str, multiple=True, help='Filter systematics with a list of strings', required=False)
 @click.option('-e', '--exclude-hist', type=str, multiple=True, default=None, help='Exclude histograms with a list of regular expression strings', required=False)
 @click.option('-oh', '--only-hist', type=str, multiple=True, default=None, help='Filter histograms with a list of regular expression strings', required=False)
@@ -36,7 +37,7 @@ import click
 @click.option('--index-file', type=str, help='Path of the index file to be copied recursively in the plots directory and its subdirectories', required=False, default=None)
 
 def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfile,
-               workers, only_cat, only_syst, exclude_hist, only_hist, split_systematics, partial_unc_band, no_syst,
+               workers, only_cat, only_year, only_syst, exclude_hist, only_hist, split_systematics, partial_unc_band, no_syst,
                overwrite, log, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare, index_file):
     '''Plot histograms produced by PocketCoffea processors'''
 
@@ -95,6 +96,7 @@ def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfile,
         plot_dir=outputdir,
         style_cfg=style_cfg,
         only_cat=only_cat,
+        only_year=only_year,
         workers=workers,
         log=log,
         density=density,

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -29,7 +29,7 @@ from pocket_coffea.utils.benchmarking import print_processing_stats
 @click.option("-lf","--limit-files", type=int, help="Limit number of files")
 @click.option("-lc","--limit-chunks", type=int, help="Limit number of chunks", default=None)
 @click.option("-e","--executor", type=str, help="Overwrite executor from config (to be used only with the --test options)", default="iterative")
-@click.option("-s","--scaleout", type=int, help="Overwrite scalout config" )
+@click.option("-s","--scaleout", type=int, help="Overwrite scaleout config" )
 @click.option("-c","--chunksize", type=int, help="Overwrite chunksize config" )
 @click.option("-q","--queue", type=str, help="Overwrite queue config" )
 @click.option("-ll","--loglevel", type=str, help="Console logging level", default="INFO" )

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from multiprocessing import Pool
 from collections import defaultdict
 from functools import partial
+from itertools import product
 from warnings import warn
 
 import math
@@ -163,6 +164,7 @@ class PlotManager:
         style_cfg,
         toplabel=None,
         only_cat=None,
+        only_year=None,
         workers=8,
         log=False,
         density=False,
@@ -174,6 +176,7 @@ class PlotManager:
         self.shape_objects = {}
         self.plot_dir = plot_dir
         self.only_cat = only_cat
+        self.only_year = only_year
         self.workers = workers
         self.log = log
         self.density = density
@@ -190,6 +193,8 @@ class PlotManager:
         for variable in variables:
             vs = {}
             for year, samples in datasets_metadata["by_datataking_period"].items():
+                if self.only_year and year not in self.only_year:
+                    continue
                 hs = {}
                 for sample, datasets in samples.items():
                     hs[sample] = {}
@@ -205,6 +210,8 @@ class PlotManager:
 
         for variable, histoplot in self.hists_to_plot.items():
             for year, h_dict in histoplot.items():
+                if self.only_year and year not in self.only_year:
+                    continue
                 name = '_'.join([variable, year])
                 # If toplabel is overwritten we use that, if not we take the lumi from the year
                 if self.toplabel:
@@ -380,6 +387,11 @@ class Shape:
         self.exclude_samples()
         self.rescale_samples()
         self.load_attributes()
+        # IMPORTANT: the flow bins should be summed before loading the SystManager,
+        # so that the systematic uncertainties are built with the flow bins included in the first and last bins
+        if self.style.flow:
+            self.sum_flow_bins()
+        self.load_syst_manager()
 
     def load_attributes(self):
         '''Loads the attributes from the dictionary of histograms.'''
@@ -406,7 +418,6 @@ class Shape:
                     ],
                     self.get_axis_items(ax.name, is_mc=True),
                 )
-            self.syst_manager = SystManager(self, self.style)
         if not self.is_mc_only:
             assert len(
                 set([self.h_dict[s].ndim for s in self.samples_data])
@@ -445,6 +456,17 @@ class Shape:
                     }
                 }
             )
+
+    def load_syst_manager(self):
+        '''Loads the attributes from the dictionary of histograms.'''
+        if self.verbose>1:
+            print(self.h_dict)
+            print("samples:", self.samples_mc)
+
+        self.is_data_only = len(self.samples_mc) == 0
+
+        if not self.is_data_only:
+            self.syst_manager = SystManager(self, self.style)
 
     @property
     def dense_axes(self):
@@ -645,6 +667,46 @@ class Shape:
                     print("Warning: the rescaling sample is not among the samples in the histograms. Nothing will be rescaled! ")
                     print("\t Rescale requested for:", sample, ";  hists exist:", self.h_dict.keys())
 
+    def sum_flow_bins(self):
+        '''Add the underflow and overflow bins to the first and last bins, respectively.
+        The operation is performed for each sample and for each category for data histograms.
+        It is performed for each sample, category and variation for MC histograms.
+        The underflow and overflow bins are set to zero after summing them to the first and last bins.'''
+        if self.dense_dim > 1:
+            print(f"WARNING: cannot sum flow bins of histogram {self.name} with dimension {self.dense_dim}.")
+            print("The method `sum_flow_bins` will be skipped.")
+            return
+
+        xaxis_name = self.dense_axes[0].name
+
+        for s, h in self.h_dict.items():
+            if s in self.samples_mc:
+                if len(self.categorical_axes_mc) != 2:
+                    raise NotImplementedError(
+                        "The flow option is only implemented for histograms with two categorical axes `cat` and `variation`."
+                    )
+                assert self.categorical_axes_mc[0].name == "cat", "The first categorical axis should be named `cat`."
+                assert self.categorical_axes_mc[1].name == "variation", "The second categorical axis should be named `variation`."
+                for cat, variation in product(self.categorical_axes_mc[0], self.categorical_axes_mc[1]):
+                    self.h_dict[s][{'cat' : cat, 'variation' : variation, xaxis_name : 0}] += self.h_dict[s][{'cat' : cat, 'variation' : variation, xaxis_name : hist.underflow}]
+                    self.h_dict[s][{'cat' : cat, 'variation' : variation, xaxis_name : -1}] += self.h_dict[s][{'cat' : cat, 'variation' : variation, xaxis_name : hist.overflow}]
+                    # Set the underflow and overflow bins to zero after summing them
+                    self.h_dict[s][{'cat' : cat, 'variation' : variation, xaxis_name : hist.underflow}] = [0.0, 0.0]
+                    self.h_dict[s][{'cat' : cat, 'variation' : variation, xaxis_name : hist.overflow}] = [0.0, 0.0]
+
+            elif s in self.samples_data:
+                if len(self.categorical_axes_data) != 1:
+                    raise NotImplementedError(
+                        "The flow option is only implemented for histograms with one categorical axis `cat`."
+                    )
+                assert self.categorical_axes_data[0].name == "cat", "The first categorical axis should be named `cat`."
+                for cat in self.categorical_axes_data[0]:
+                    self.h_dict[s][{'cat' : cat, xaxis_name : 0}] += self.h_dict[s][{'cat' : cat, xaxis_name : hist.underflow}]
+                    self.h_dict[s][{'cat' : cat, xaxis_name : -1}] += self.h_dict[s][{'cat' : cat, xaxis_name : hist.overflow}]
+                    # Set the underflow and overflow bins to zero after summing them
+                    self.h_dict[s][{'cat' : cat, xaxis_name : hist.underflow}] = [0.0, 0.0]
+                    self.h_dict[s][{'cat' : cat, xaxis_name : hist.overflow}] = [0.0, 0.0]
+
     def _get_stacks(self, cat, spliteras=False):
         '''Builds the data and MC stacks, applying a slicing by category.
         The stacks are cached in a dictionary so that they are not recomputed every time.
@@ -755,27 +817,18 @@ class Shape:
         hnum = stacks["data_sum"]
         hden = stacks["mc_nominal_sum"]
 
-        num = hnum.values(flow=self.style.flow)
-        den = hden.values(flow=self.style.flow)
-        num_variances = hnum.variances(flow=self.style.flow)
-        den_variances = hden.variances(flow=self.style.flow)
-
-        # Sum underflow and overflow bins for the numerator and denominator, to restore an array of the same length
-        if self.style.flow:
-            if (len(num) != (len(hnum.values()) + 2)) | (len(den) != (len(hden.values()) + 2)):
-                raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-            num = np.concatenate([[num[0]+num[1]], num[2:-2], [num[-2]+num[-1]]])
-            den = np.concatenate([[den[0]+den[1]], den[2:-2], [den[-2]+den[-1]]])
-            num_variances = np.concatenate([[num_variances[0]+num_variances[1]], num_variances[2:-2], [num_variances[-2]+num_variances[-1]]])
-            den_variances = np.concatenate([[den_variances[0]+den_variances[1]], den_variances[2:-2], [den_variances[-2]+den_variances[-1]]])
+        num = hnum.values()
+        den = hden.values()
+        num_variances = hnum.variances()
+        den_variances = hden.variances()
 
         if self.density:
             num_integral = sum(num * np.array(self.style.opts_axes["xbinwidth"]) )
-            if num_integral>0:
+            if num_integral > 0:
                 num = num * (1./num_integral)
                 num_variances = num_variances * (1./num_integral)**2
             den_integral = sum(den * np.array(self.style.opts_axes["xbinwidth"]) )
-            if den_integral>0:
+            if den_integral > 0:
                 den = den * (1./den_integral)
                 den_variances = den_variances * (1./den_integral)**2
 
@@ -783,7 +836,7 @@ class Shape:
         # Total uncertainy propagation of num / den :
         # ratio_variance = np.power(ratio,2)*( num_variances*np.power(num, -2) + den_variances*np.power(den, -2))
         # Only the uncertainty of num (DATA) propagated:
-        ratio_variance = num_variances*np.power(den, -2)
+        ratio_variance = num_variances * np.power(den, -2)
 
         ratio_uncert = np.abs(poisson_interval(ratio, ratio_variance) - ratio)
         ratio_uncert[np.isnan(ratio_uncert)] = np.inf
@@ -807,15 +860,8 @@ class Shape:
         else:
             hden = stacks['mc_nominal'][ref]
 
-        den = hden.values(flow=self.style.flow)
-        den_variances = hden.variances(flow=self.style.flow)
-
-        # Sum underflow and overflow bins for the denominator, to restore an array of the same length
-        if self.style.flow:
-            if (len(den) != (len(hden.values()) + 2)):
-                raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-            den = np.concatenate([[den[0]+den[1]], den[2:-2], [den[-2]+den[-1]]])
-            den_variances = np.concatenate([[den_variances[0]+den_variances[1]], den_variances[2:-2], [den_variances[-2]+den_variances[-1]]])
+        den = hden.values()
+        den_variances = hden.variances()
 
         if self.density:
             den_integral = sum(den * np.array(self.style.opts_axes["xbinwidth"]) )
@@ -833,14 +879,8 @@ class Shape:
             histograms_list.append(stacks['data_sum'])
         for hnum in histograms_list:
             #print("Process:", hnum.name, type(hnum))
-            num = hnum.values(flow=self.style.flow)
-            num_variances = hnum.variances(flow=self.style.flow)
-
-            if self.style.flow:
-                if (len(num) != (len(hnum.values()) + 2)):
-                    raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-                num = np.concatenate([[num[0]+num[1]], num[2:-2], [num[-2]+num[-1]]])
-                num_variances = np.concatenate([[num_variances[0]+num_variances[1]], num_variances[2:-2], [num_variances[-2]+num_variances[-1]]])
+            num = hnum.values()
+            num_variances = hnum.variances()
 
             if self.density:
                 num_integral = sum(num * np.array(self.style.opts_axes["xbinwidth"]) )
@@ -925,8 +965,8 @@ class Shape:
             if arg_log == 0:
                 arg_log = 100
             exp = math.floor(math.log(arg_log, 10))
-            y_lim_hi = self.style.opts_figure["datamc"]["ylim_log"].get("hi", 10 ** (exp*1.75))
-            self.ax.set_ylim((self.style.opts_figure["datamc"]["ylim_log"]["lo"], y_lim_hi))
+            y_lim_hi = self.style.opts_ylim["datamc"]["ylim_log"].get("hi", 10 ** (exp*1.75))
+            self.ax.set_ylim((self.style.opts_ylim["datamc"]["ylim_log"]["lo"], y_lim_hi))
         else:
             if self.is_data_only:
                 reference_shape = stacks["data_sum"].values()
@@ -1045,20 +1085,6 @@ class Shape:
             if not hasattr(self, "ax"):
                 self.define_figure(ratio=False)
         y = stacks["data_sum"].values()
-        # Add underflow and overflow bins to the first and last bin, respectively
-        if self.style.flow:
-            has_underflow = True
-            has_overflow = True
-            try: stacks["data_sum"][hist.underflow]
-            except: has_underflow = False
-            try: stacks["data_sum"][hist.overflow]
-            except: has_overflow = False
-            if not all([has_underflow, has_overflow]):
-                raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-            y_underflow = stacks["data_sum"][hist.underflow].value
-            y_overflow = stacks["data_sum"][hist.overflow].value
-            y[0] += y_underflow
-            y[-1] += y_overflow
 
         # Blinding data for certain variables (if defined in plotting config)
         if self.style.has_blind_hists and cat in self.style.blind_hists.categories:
@@ -1183,7 +1209,7 @@ class Shape:
 
             # If the histogram is in density mode, the systematic uncertainty has to be normalized to the integral of the MC stack
             if self.density:
-                mc_integral = sum(self._get_stacks(cat)["mc_nominal_sum"].values(flow=self.style.flow)) * np.array(self.style.opts_axes["xbinwidth"])
+                mc_integral = sum(self._get_stacks(cat)["mc_nominal_sum"].values()) * np.array(self.style.opts_axes["xbinwidth"])
                 up = up / mc_integral
                 down = down / mc_integral
 
@@ -1450,18 +1476,6 @@ class SystUnc:
             # Full nominal MC including all MC samples
             self.h_mc_nominal = stacks["mc_nominal_sum"]
             self.nominal, self.bins = stacks["mc_nominal_sum"].to_numpy()
-            # Add underflow and overflow bins to the first and last bin, respectively
-            if self.style.flow:
-                has_underflow = True
-                has_overflow = True
-                try: stacks["mc_nominal_sum"][hist.underflow]
-                except: has_underflow = False
-                try: stacks["mc_nominal_sum"][hist.overflow]
-                except: has_overflow = False
-                if not all([has_underflow, has_overflow]):
-                    raise NotImplementedError("Both underflow and overflow bins have to be defined. Please set `overflow=True` and `underflow=True` in the constructor of the Axis object, in your configuration.")
-                self.nominal[0] += stacks["mc_nominal_sum"][hist.underflow].value
-                self.nominal[-1] += stacks["mc_nominal_sum"][hist.overflow].value
         elif syst_list:
             self.syst_list = syst_list
             assert (
@@ -1470,6 +1484,7 @@ class SystUnc:
             assert not (
                 (self._n_empty == 1) & (self.nsyst == 1)
             ), "Attempting to intialize a `SystUnc` instance with an empty systematic uncertainty."
+            # Get nominal yields from the first systematic uncertainty in the list
             _syst = self.syst_list[0]
             self.h_mc_nominal = _syst.h_mc_nominal
             self.nominal = _syst.nominal
@@ -1546,12 +1561,6 @@ class SystUnc:
         '''Method used in the constructor to instanstiate a SystUnc object from
         a list of SystUnc objects. The sytematic uncertainties in self.syst_list,
         are summed in quadrature to define a new SystUnc object.'''
-        if not self._is_empty:
-            index_non_empty = [i for i, s in enumerate(self.syst_list) if not s._is_empty][0]
-        else:
-            raise Exception(' '.join([f"The systematic uncertainty `{self.name}` is empty.",
-                                    "Please check the histogram definition. If a histogram is expected to be empty in a given category, the category can be excluded with the option `only_cat`."]))
-        self.nominal = self.syst_list[index_non_empty].nominal
         for syst in self.syst_list:
             if not ((self._is_empty) | (syst._is_empty)):
                 assert all(
@@ -1652,7 +1661,7 @@ class SystUnc:
             exp = math.floor(math.log(self.nominal.max(), 10)) + 3
             y_lim_hi = self.style.opts_figure["systematics"]["ylim_log"].get("hi", 10**exp)
             self.ax.set_ylim(
-                (self.style.opts_figure["datamc"]["ylim_log"]["lo"], y_lim_hi)
+                (self.style.opts_ylim["datamc"]["ylim_log"]["lo"], y_lim_hi)
             )
         else:
             self.ax.set_ylim((0, 1.5 * self.nominal.max()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ omegaconf
 law
 click>=8.0.4
 correctionlib>=2.6.1
-setuptools>=70.3.0
-setuptools-scm>=8.1.0
+setuptools==70.3.0
+setuptools-scm==8.1.0


### PR DESCRIPTION
A series of improvements are implemented with this PR, in particular for the plotting utils.
The new features include:

- Fix faulty flow bins: now the flow bins are summed to the first and last bins of the histogram in the constructor of the `Shape` object, then the systematic uncertainty are created including the flow bins.
- New options for the `make_plots.py` script: `--only-year` to process only certain data-taking years and `--index-file` to save recursively an index file (e.g. `index.php`) in the plots folders.
- Customizable ylim for log plots: set low and high limit via parameters. Smart defaults for ylim in `parameters/plotting_style.yaml`.
- Update `plot_shapes_comparison()` function to comply with the latest metadata schema.
- Update common b-tag SF calibration weight: remove data-taking year from correctionlib map. The processor is expecting one correctionlib map for each data-taking year.
- Set default `cores-per-worker` to 1 in T3 PSI executor.
- Fixed typos in docs.
- Pin versions of `setuptools` and `setuptools-scm` due to conflicts between PocketCoffea and latest versions of these packages.