### PR TITLE
blind specific histogram bins

### DIFF
--- a/pocket_coffea/parameters/plotting_style.yaml
+++ b/pocket_coffea/parameters/plotting_style.yaml
@@ -3,6 +3,7 @@ plotting_style:
     collapse_datasets: true     # Plot all the datasets with the same sample as a single shape
     fontsize: 22
     fontsize_legend_ratio: 12
+    blind_threshold: -1
 
 
     opts_figure:


### PR DESCRIPTION
I just opened this PR for the purpose of a discussion (addressing #250 ).
The changes are not yet ready to be merged.

i implemented a simple S/sqrt(B) threshold to blind histogram bins that are above the blind_threshold.

So far there is no good method to know which processes are considered signal or background. i used the `signal_samples` parameter, which however also plots the signal processes as lines.
I think this implementation would benefit from a `Process` class (see #236).