### PR TITLE
Run grouping by sample

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -134,15 +134,17 @@ The default options for the running options and different type of executors are 
 
 For example:
 ```yaml
-general: 
+general:
   scaleout: 1
-  chunksize: 100000
+  chunksize: 150000
   limit-files: null
   limit-chunks: null
   retries: 20
   tree-reduction: 20
   skip-bad-files: false
   voms-proxy: null
+  ignore-grid-certificate: false
+  group-samples: null
 
 dask@lxplus:
   scaleout: 10
@@ -189,6 +191,47 @@ $> pocket-coffea run  --cfg analysis_config.py -o output --executor dask@lxplus 
               --chunksize 150000 --queue espresso
 ```
 
+
+### Process datasets separately and group samples
+By default, the `pocket-coffea run` command will run all the datasets together in one shot and a single output `output_all.coffea` is saved.
+In case one wants to save intermediate outputs, it is possible to run with the `--process-separately` option, where each dataset
+is processed separately and an independent output `output_{dataset}.coffea` is saved for each dataset.
+
+In case several datasets need to be processed with the `--process-separately` option, there is the additional possibility to group datasets
+belonging to the same sample, process them together and save an output `output_{group}.coffea` for each group.
+To group samples during processing it is sufficient to add an extra entry to the custom `run_options.yaml` file passed to `pocket-coffea run`,
+defining the dictionary `group-samples`. Each key in this dictionary corresponds to the group name, and the values of the dictionary are lists
+of samples.
+
+As an example, by adding the following snippet to the `run_options.yaml` file:
+
+```yaml
+group-samples:
+  signal:
+    - "ttHTobb"
+    - "ttHTobb_ttToSemiLep"
+  TTToSemiLeptonic:
+    - "TTToSemiLeptonic"
+  TTbbSemiLeptonic:
+    - "TTbbSemiLeptonic"
+  "TTTo2L2Nu_SingleTop":
+    - "TTTo2L2Nu"
+    - "SingleTop"
+  VJets:
+    - "WJetsToLNu_HT"
+    - "DYJetsToLL"
+  VV_TTV:
+    - "VV"
+    - "TTV"
+  DATA:
+    - "DATA_SingleEle"
+    - "DATA_SingleMuon"
+```
+and running the analysis with the command `pocket-coffea run --cfg config.py -ro run_options.yaml --process-separately`, will result in running
+the analysis processor sequentially for 7 times, saving 7 independent outputs: `output_signal.coffea`, `output_TTToSemiLeptonic.coffea`, `output_TTbbSemiLeptonic.coffea`,
+`output_TTTo2L2Nu_SingleTop.coffea`, `output_VJets.coffea`, `output_VV_TTV.coffea` and `output_DATA.coffea`.
+For example, the output file `output_signal.coffea` file will contain the output obtained by processing the datasets of the samples `ttHTobb` and `ttHTobb_ttToSemiLep`,
+for all the data-taking years specified in the `datasets["filter"]["year"]` dictionary.
 
 ### Customize the executor software environment
 The software environment where the executor runs the analysis is defined by the python environment where the analysis is

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -8,6 +8,7 @@ general:
   skip-bad-files: false
   voms-proxy: null
   ignore-grid-certificate: false
+  group-samples: null
 
 dask@lxplus:
   scaleout: 10

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -14,7 +14,7 @@ from coffea import processor
 from coffea.processor import Runner
 
 from pocket_coffea.utils.configurator import Configurator
-from pocket_coffea.utils.utils import load_config, path_import
+from pocket_coffea.utils.utils import load_config, path_import, adapt_chunksize
 from pocket_coffea.utils.logging import setup_logging
 from pocket_coffea.parameters import defaults as parameters_utils
 from pocket_coffea.executors import executors_base
@@ -178,7 +178,14 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
         
     if not process_separately:
         # Running on all datasets at once
-        logging.info(f"Working on samples: {list(filesets_to_run.keys())}")
+        logging.info(f"Working on datasets: {list(filesets_to_run.keys())}")
+
+        n_events_tot = sum([int(files["metadata"]["nevents"]) for files in filesets_to_run.values()])
+        logging.info("Total number of events: %d", n_events_tot)
+
+        adapted_chunksize = adapt_chunksize(n_events_tot, run_options)
+        if adapted_chunksize != run_options["chunksize"]:
+            logging.info(f"Reducing chunksize from {run_options['chunksize']} to {adapted_chunksize} for dataset(s) {group_name}")
 
         run = Runner(
             executor=executor,
@@ -196,23 +203,42 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
         print_processing_stats(output, start_time, run_options["scaleout"])
 
     else:
+        if run_options["group-samples"] is not None:
+            logging.info(f"Grouping samples during processing")
+            logging.info(f"Grouping samples configuration: {run_options['group-samples']}")
+            # Group samples together during processing with a list specified in the run_options
+            # Once a dataset is grouped, it is removed from the list of datasets to be processed to avoid double processing
+            filesets_groups = {}
+            filesets_to_group = filesets_to_run.copy()
+            for group, samples_to_group in run_options["group-samples"].items():
+                fileset_ = {}
+                for dataset, files in filesets_to_run.items():
+                    if files["metadata"]["sample"] in samples_to_group:
+                        fileset_[dataset] = filesets_to_group.pop(dataset)
+                filesets_groups[group] = fileset_
+            # Adding the remaining datasets that were not grouped
+            for dataset, files in filesets_to_group.items():
+                filesets_groups[dataset] = {dataset:files}
+        else:
+            filesets_groups = {dataset:{dataset:files} for dataset, files in filesets_to_run.items()}
+
         # Running separately on each dataset
-        for sample, files in filesets_to_run.items():
-            print(f"Working on sample: {sample}")
-            logging.info(f"Working on sample: {sample}")
-            
-            fileset_ = {sample:files}
-
-            n_events_tot = int(files["metadata"]["nevents"])
-            n_workers_max = n_events_tot / run_options["chunksize"]
-
-            # If the number of available workers exceeds the maximum number of workers for a given sample,
-            # the chunksize is reduced so that all the workers are used to process the given sample
-            if (run_options["scaleout"] > n_workers_max):
-                adapted_chunksize = int(n_events_tot / run_options["scaleout"])
-                logging.info(f"Reducing chunksize from {run_options['chunksize']} to {adapted_chunksize} for sample {sample}")
+        for group_name, fileset_ in filesets_groups.items():
+            datasets = list(fileset_.keys())
+            if len(datasets) == 1:
+                dataset = datasets[0]
+                print(f"Working on dataset: {group_name}")
+                logging.info(f"Working on dataset: {group_name}")
             else:
-                adapted_chunksize = run_options["chunksize"]
+                print(f"Working on group of datasets: {group_name} ({len(datasets)} datasets)")
+                logging.info(f"Working on group of datasets: {group_name} ({len(datasets)} datasets)")
+
+            n_events_tot = sum([int(files["metadata"]["nevents"]) for files in fileset_.values()])
+            logging.info("Total number of events: %d", n_events_tot)
+
+            adapted_chunksize = adapt_chunksize(n_events_tot, run_options)
+            if adapted_chunksize != run_options["chunksize"]:
+                logging.info(f"Reducing chunksize from {run_options['chunksize']} to {adapted_chunksize} for dataset(s) {group_name}")
 
             run = Runner(
                 executor=executor,
@@ -224,8 +250,8 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
             )
             output = run(fileset_, treename="Events",
                          processor_instance=config.processor_instance)
-            print(f"Saving output to {outfile.format(sample)}")
-            save(output, outfile.format(sample))
+            print(f"Saving output to {outfile.format(group_name)}")
+            save(output, outfile.format(group_name))
             print_processing_stats(output, start_time, run_options["scaleout"])
     # Closing the executor if needed
     executor_factory.close()

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -215,7 +215,8 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
                 for dataset, files in filesets_to_run.items():
                     if files["metadata"]["sample"] in samples_to_group:
                         fileset_[dataset] = filesets_to_group.pop(dataset)
-                filesets_groups[group] = fileset_
+                if len(fileset_) > 0:
+                    filesets_groups[group] = fileset_
             # Adding the remaining datasets that were not grouped
             for dataset, files in filesets_to_group.items():
                 filesets_groups[dataset] = {dataset:files}

--- a/pocket_coffea/utils/utils.py
+++ b/pocket_coffea/utils/utils.py
@@ -50,6 +50,16 @@ def load_config(cfg, do_load=True, save_config=True, outputdir=None):
         raise("The configuration module attribute `cfg` is not of type Configurator. Please check yuor configuration!")
     return config
 
+def adapt_chunksize(nevents, run_options):
+    '''Helper function to adjust the chunksize so that each worker has at least a chunk to process.
+    If the number of available workers exceeds the maximum number of workers for a given dataset,
+    the chunksize is reduced so that all the available workers are used to process the given dataset.'''
+    n_workers_max = nevents / run_options["chunksize"]
+    if (run_options["scaleout"] > n_workers_max):
+        adapted_chunksize = int(nevents / run_options["scaleout"])
+    else:
+        adapted_chunksize = run_options["chunksize"]
+    return adapted_chunksize
 
 # Function taken from HiggsDNA
 # https://gitlab.cern.ch/HiggsDNA-project/HiggsDNA/-/blob/master/higgs_dna/utils/dumping_utils.py


### PR DESCRIPTION
A new feature to improve the `--process-separately` running option is implemented.
The user can specify a dictionary of grouped samples in the custom `run_options.yaml` to specify which samples have to be grouped together during processing.

In case several datasets need to be processed with the `--process-separately` option, there is now the additional possibility to group datasets belonging to the same sample, process them together and save an output `output_{group}.coffea` for each group.
To group samples during processing it is sufficient to add an extra entry to the custom `run_options.yaml` file passed to `pocket-coffea run`, defining the dictionary `group-samples`. Each key in this dictionary corresponds to the group name, and the values of the dictionary are lists of samples.

As an example, by adding the following snippet to the `run_options.yaml` file:

```yaml
group-samples:
  signal:
    - "ttHTobb"
    - "ttHTobb_ttToSemiLep"
  TTToSemiLeptonic:
    - "TTToSemiLeptonic"
  TTbbSemiLeptonic:
    - "TTbbSemiLeptonic"
  "TTTo2L2Nu_SingleTop":
    - "TTTo2L2Nu"
    - "SingleTop"
  VJets:
    - "WJetsToLNu_HT"
    - "DYJetsToLL"
  VV_TTV:
    - "VV"
    - "TTV"
  DATA:
    - "DATA_SingleEle"
    - "DATA_SingleMuon"
```
and running the analysis with the command `pocket-coffea run --cfg config.py -ro run_options.yaml --process-separately`, will result in running the analysis processor sequentially for 7 times, saving 7 independent outputs: `output_signal.coffea`, `output_TTToSemiLeptonic.coffea`, `output_TTbbSemiLeptonic.coffea`, `output_TTTo2L2Nu_SingleTop.coffea`, `output_VJets.coffea`, `output_VV_TTV.coffea` and `output_DATA.coffea`.
For example, the output file `output_signal.coffea` file will contain the output obtained by processing the datasets of the samples `ttHTobb` and `ttHTobb_ttToSemiLep`, for all the data-taking years specified in the `datasets["filter"]["year"]` dictionary.

**Possible future enhancement:** an option to group or split datasets by data-taking year during processing could be implemented.