### PR TITLE
Improved scripts

### DIFF
--- a/pocket_coffea/executors/executors_cern_swan.py
+++ b/pocket_coffea/executors/executors_cern_swan.py
@@ -19,7 +19,7 @@ class PackageChecker(WorkerPlugin):
             if spec is None:
                 raise ImportError(f"Package {self.package_name} not found")
         except ImportError:
-            worker.close(timeout=0, executor_wait=False, nanny=True, reason'eos-not-ready')
+            worker.close(timeout=0, executor_wait=False, nanny=True, reason='eos-not-ready')
             
 
 class DaskExecutorFactory(ExecutorFactoryABC):

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -9,6 +9,7 @@ general:
   voms-proxy: null
   ignore-grid-certificate: false
   group-samples: null
+  starting-time: null
 
 dask@lxplus:
   scaleout: 10

--- a/pocket_coffea/parameters/histograms.py
+++ b/pocket_coffea/parameters/histograms.py
@@ -609,6 +609,8 @@ def jet_hists(coll="JetGood", pos=None, fields=None, name=None, axis_settings=No
     return _get_default_hist(name, "jet", coll, pos, fields, axis_settings, **kwargs)
 
 def jet_taggers_hists(coll="JetGood", pos=None, fields=None, name=None, axis_settings=None, **kwargs):
+    if name == None:
+        name = coll
     out = {}
     for field in taggers_fields["jet"]:
         if fields == None or field in fields:
@@ -634,6 +636,8 @@ def jet_taggers_hists(coll="JetGood", pos=None, fields=None, name=None, axis_set
     return out
 
 def fatjet_taggers_hists(coll="FatJetGood", pos=None, fields=None, name=None, axis_settings=None, **kwargs):
+    if name == None:
+        name = coll
     out = {}
     for field in taggers_fields["fatjet"]:
         if fields == None or field in fields:

--- a/pocket_coffea/scripts/hadd_skimmed_files.py
+++ b/pocket_coffea/scripts/hadd_skimmed_files.py
@@ -116,6 +116,7 @@ def hadd_skimmed_files(files_list, outputdir, only_datasets, files, events, scal
         metadata["size"] = int(skim_efficiency * int(df["datasets_metadata"]["by_dataset"][s]["size"])) # Compute the (approximate) size of the skimmed dataset
         metadata["nevents"] = sum(df["nskimmed_events"][s])
         metadata["skim_efficiency"] = skim_efficiency
+        metadata["isSkim"] = True
         dataset_definition[s] = {"metadata": metadata, "files": list(d['files'].keys())}
 
     json.dump(dataset_definition, open("skimmed_dataset_definition.json", "w"), indent=2)

--- a/pocket_coffea/scripts/hadd_skimmed_files.py
+++ b/pocket_coffea/scripts/hadd_skimmed_files.py
@@ -1,12 +1,26 @@
 #!/usr/bin/env python
 import os
 from multiprocessing import Pool
+from functools import partial
 import argparse
 from collections import defaultdict
 from coffea.util import load
 import subprocess
 import json
 import click
+
+def do_hadd(group, overwrite=False):
+    try:
+        print("Running: ", group[0])
+        if overwrite:
+            subprocess.run(["hadd", "-f", group[0], *group[1]], check=True)
+        else:
+            subprocess.run(["hadd", group[0], *group[1]], check=True)
+        return group[0], 0
+    except subprocess.CalledProcessError as e:
+        print("Error producing group: ", group[0])
+        print(e.stderr)
+        return group[0], 1
 
 @click.command()
 @click.option(
@@ -51,7 +65,7 @@ def hadd_skimmed_files(files_list, outputdir, only_datasets, files, events, scal
         group = []
         ngroup = 1
         for file, nevents in zip(
-            df["skimmed_files"][dataset], df["nskimmed_files"][dataset]
+            df["skimmed_files"][dataset], df["nskimmed_events"][dataset]
         ):
             if (files and (nfiles + 1) > files) or (
                 events and (nevents_tot + nevents) > events
@@ -77,23 +91,14 @@ def hadd_skimmed_files(files_list, outputdir, only_datasets, files, events, scal
     print(f"We will hadd {len(workload)} groups of files.")
     print("Samples:", groups_metadata.keys())
 
-    def do_hadd(group):
-        try:
-            print("Running: ", group[0])
-            if overwrite:
-                subprocess.run(["hadd", "-f", group[0], *group[1]], check=True)
-            else:
-                subprocess.run(["hadd", group[0], *group[1]], check=True)
-            return group[0], 0
-        except subprocess.CalledProcessError as e:
-            print("Error producing group: ", group[0])
-            print(e.stderr)
-            return group[0], 1
-
-
     if not dry:
         p = Pool(scaleout)
-        results = p.map(do_hadd, workload)
+        # Create one output folder for each dataset
+        for outfile, group in workload:
+            basedir = os.path.dirname(outfile)
+            if not os.path.exists(basedir):
+                os.makedirs(basedir)
+        results = p.map(partial(do_hadd, overwrite=overwrite), workload)
 
         print("\n\n\n")
         for group, r in results:
@@ -103,9 +108,15 @@ def hadd_skimmed_files(files_list, outputdir, only_datasets, files, events, scal
     json.dump(groups_metadata, open("hadd.json", "w"), indent=2)
 
     # Now saving the dataset definition file
-    dataset_definition = {
-        s: {"files": list(d['files'].keys())} for s, d in groups_metadata.items()
-    }
+    dataset_metadata = df["datasets_metadata"]["by_dataset"]
+    dataset_definition = {}
+    for s, d in groups_metadata.items():
+        metadata = dataset_metadata[s]
+        skim_efficiency = df["cutflow"]["skim"][s] / df["cutflow"]["initial"][s]
+        metadata["size"] = int(skim_efficiency * int(df["datasets_metadata"]["by_dataset"][s]["size"])) # Compute the (approximate) size of the skimmed dataset
+        metadata["nevents"] = sum(df["nskimmed_events"][s])
+        metadata["skim_efficiency"] = skim_efficiency
+        dataset_definition[s] = {"metadata": metadata, "files": list(d['files'].keys())}
 
     json.dump(dataset_definition, open("skimmed_dataset_definition.json", "w"), indent=2)
 

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -16,6 +16,7 @@ from coffea.processor import Runner
 from pocket_coffea.utils.configurator import Configurator
 from pocket_coffea.utils.utils import load_config, path_import, adapt_chunksize
 from pocket_coffea.utils.logging import setup_logging
+from pocket_coffea.utils.time import wait_until
 from pocket_coffea.parameters import defaults as parameters_utils
 from pocket_coffea.executors import executors_base
 from pocket_coffea.utils.benchmarking import print_processing_stats
@@ -149,7 +150,12 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
 
     if "parsl" in executor_name:
         logging.getLogger().handlers[0].setLevel("ERROR")
-        
+
+    # Wait until the starting time, if provided
+    if run_options["starting-time"] is not None:
+        logging.info(f"Waiting until {run_options['starting-time']} to start processing")
+        wait_until(run_options["starting-time"])
+
     # Load the executor class from the lib and instantiate it
     executor_factory = executors_lib.get_executor_factory(executor_name, run_options=run_options, outputdir=outputdir)
     # Check the type of the executor_factory

--- a/pocket_coffea/utils/time.py
+++ b/pocket_coffea/utils/time.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from time import sleep
+
+def wait_until(time):
+    '''Wait until the given time'''
+    if type(time) == str:
+        date_format = "%d-%m-%Y %H:%M:%S"
+        time = datetime.strptime(time, date_format)
+    elif type(time) == datetime:
+        pass
+    else:
+        raise TypeError("The time argument must be a string or a datetime object.")        
+    while datetime.now() < time:
+        sleep(1)
+        pass


### PR DESCRIPTION
- Solved https://github.com/PocketCoffea/PocketCoffea/issues/258: fixed missing default for histograms name.
- Solved https://github.com/PocketCoffea/PocketCoffea/issues/259: avoid concurrent read/writes to `.sites_map.json` using multiprocessing locks.
- Enhancement in `runner.py`: schedule job submission at a given time specified in the run options.
- Update `hadd_skimmed_files.py`: save complete metadata of skimmed datasets with size, number of events and skimmed efficiency. Save the `isSkim` metadata to flag that the dataset is a skim.