### PR TITLE
Integrate Authenticated Session for XSec Data Retrieval

### DIFF
--- a/pocket_coffea/scripts/dataset/dataset_query.py
+++ b/pocket_coffea/scripts/dataset/dataset_query.py
@@ -16,6 +16,7 @@ from rich.tree import Tree
 import re
 from pocket_coffea.utils import rucio as rucio_utils
 import requests
+import tsgauth
 #from pocket_coffea.parameters.xsection import xsection
 def print_dataset_query(query, dataset_list, console, selected=[]):
     table = Table(title=f"Query: [bold red]{query}")
@@ -296,17 +297,25 @@ Some basic commands:
         parts = dataset_name.split('/')
         if len(parts) > 0:
             parts =  parts[1]
-        url = 'https://xsdb-temp.app.cern.ch/api/search'
-        response = requests.post(url, json={'process_name': parts})
-        if response.status_code == 200:
+        search_payload = {
+        "search": {"process_name": parts}
+        }
+        auth = tsgauth.oidcauth.KerbSessionAuth(use_auth_file=True)
+        session = requests.Session()
+        session.get("https://xsecdb-xsdb-official.app.cern.ch/", **auth.authparams())
+    
+        url = 'https://xsecdb-xsdb-official.app.cern.ch/api/search'
+        response = session.post(url, data=json.dumps(search_payload))
+        data = response.json()
+        try:
             data = response.json()
             if isinstance(data, list) and len(data) > 0:
                 return float(data[0]['cross_section'])
             else:
-                raise ValueError(f"No data found for process_name '{parts}'")
-        else:
-            raise ConnectionError(f"Failed to fetch data for process_name '{parts}'. Status code: {response.status_code}")
-
+                raise ValueError(f"No data found for matrix_generator '{parts}'")
+        except json.decoder.JSONDecodeError:
+            raise ValueError("Failed to decode JSON response")
+        
     def do_select(self, selection=None, metadata=None):
         """Selected the datasets from the list of query results. Input a list of indices
         also with range 4-6 or "all"."""


### PR DESCRIPTION
Description:

- This PR enhances the `extract_xsec_from_dataset_name` function to use an authenticated session for retrieving cross-section data from the [xsdb website](https://xsecdb-xsdb-official.app.cern.ch/) 
- This directly comes from [tsgauth](https://gitlab.cern.ch/cms-tsg/common/tsgauth) library to create a session with the necessary authentication.

Testing:

- Verified the function with valid test datasets in `dataset-discovery-cli`.

Additional Requirements:
- Ensure tsgauth library is installed and configured correctly. `pip install tsgauth`
- The function now requires access to the authentication file.
- in lxplus, automatically verified but for external machines, requires kerberos setup:
   - `kinit -f username@CERN.CH`
   - `username@CERN.CH's` Password: <enter your password>
   - More details on how to setup kerberos is [here](https://linux.web.cern.ch/docs/kerberos-access/)
   - Usually remains valid for 1 day, one can check by `klist` in external machines

Disclaimer:
- The user will be prompted by 2FA code at the beginning. The 2FA is stored in `~/.tsgauth` directory of the user and remains valid for 8 hours. 
- **Make sure to keep it safe! Sharing the authentication json to others means others have access to all CERN managed websites with your credentials.**
