### PR TITLE
Parton shower and QCD scale weights

### DIFF
--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -471,3 +471,29 @@ def sf_pileup_reweight(params, events, year):
     sfdown = puWeightsJSON[puName].evaluate(nPu, 'down')
 
     return sf, sfup, sfdown
+
+def sf_isr(events):
+    '''Up and down variations for the ISR parton shower weights.
+    In order to properly store the weights, a dummy weight of 1 is stored
+    as central value for the ISR correction.
+    Conventions for the PS weights are:
+    [0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;
+    '''
+    isr_up = events.PSWeight[:,2]
+    isr_down = events.PSWeight[:,0]
+    nom = ak.ones_like(isr_up)
+
+    return nom, isr_up, isr_down
+
+def sf_fsr(events):
+    '''Up and down variations for the FSR parton shower weights.
+    In order to properly store the weights, a dummy weight of 1 is stored
+    as central value for the FSR correction.
+    Convention for the PS weights are:
+    [0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;
+    '''
+    fsr_up = events.PSWeight[:,3]
+    fsr_down = events.PSWeight[:,1]
+    nom = ak.ones_like(fsr_up)
+
+    return nom, fsr_up, fsr_down

--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -489,7 +489,7 @@ def sf_fsr(events):
     '''Up and down variations for the FSR parton shower weights.
     In order to properly store the weights, a dummy weight of 1 is stored
     as central value for the FSR correction.
-    Convention for the PS weights are:
+    Conventions for the PS weights are:
     [0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;
     '''
     fsr_up = events.PSWeight[:,3]

--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -472,7 +472,7 @@ def sf_pileup_reweight(params, events, year):
 
     return sf, sfup, sfdown
 
-def sf_isr(events):
+def sf_partonshower_isr(events):
     '''Up and down variations for the ISR parton shower weights.
     In order to properly store the weights, a dummy weight of 1 is stored
     as central value for the ISR correction.
@@ -485,7 +485,7 @@ def sf_isr(events):
 
     return nom, isr_up, isr_down
 
-def sf_fsr(events):
+def sf_partonshower_fsr(events):
     '''Up and down variations for the FSR parton shower weights.
     In order to properly store the weights, a dummy weight of 1 is stored
     as central value for the FSR correction.

--- a/pocket_coffea/lib/weights/common/common.py
+++ b/pocket_coffea/lib/weights/common/common.py
@@ -13,6 +13,8 @@ from pocket_coffea.lib.scale_factors import (
     sf_jet_puId,
     sf_L1prefiring,
     sf_pileup_reweight,
+    sf_isr,
+    sf_fsr
 )
 
 
@@ -96,6 +98,21 @@ SF_L1prefiring = WeightLambda.wrap_func(
     name="sf_L1prefiring",
     function=lambda params, metadata, events, size, shape_variations:
         sf_L1prefiring(events),
+    has_variations=True
+    )
+
+
+SF_PSWeight_isr = WeightLambda.wrap_func(
+    name="sf_psweight_isr",
+    function=lambda params, metadata, events, size, shape_variations:
+        sf_isr(events),
+    has_variations=True
+    )
+
+SF_PSWeight_fsr = WeightLambda.wrap_func(
+    name="sf_psweight_fsr",
+    function=lambda params, metadata, events, size, shape_variations:
+        sf_fsr(events),
     has_variations=True
     )
 
@@ -295,6 +312,8 @@ common_weights = [
     SF_ctag,
     SF_ctag_calib,
     SF_jet_puId,
+    SF_PSWeight_isr,
+    SF_PSWeight_fsr
 ]
 
 

--- a/pocket_coffea/lib/weights/common/common.py
+++ b/pocket_coffea/lib/weights/common/common.py
@@ -13,8 +13,8 @@ from pocket_coffea.lib.scale_factors import (
     sf_jet_puId,
     sf_L1prefiring,
     sf_pileup_reweight,
-    sf_isr,
-    sf_fsr
+    sf_partonshower_isr,
+    sf_partonshower_fsr
 )
 
 
@@ -103,16 +103,16 @@ SF_L1prefiring = WeightLambda.wrap_func(
 
 
 SF_PSWeight_isr = WeightLambda.wrap_func(
-    name="sf_psweight_isr",
+    name="sf_partonshower_isr",
     function=lambda params, metadata, events, size, shape_variations:
-        sf_isr(events),
+        sf_partonshower_isr(events),
     has_variations=True
     )
 
 SF_PSWeight_fsr = WeightLambda.wrap_func(
-    name="sf_psweight_fsr",
+    name="sf_partonshower_fsr",
     function=lambda params, metadata, events, size, shape_variations:
-        sf_fsr(events),
+        sf_partonshower_fsr(events),
     has_variations=True
     )
 

--- a/pocket_coffea/lib/weights/common/weights_run2_UL.py
+++ b/pocket_coffea/lib/weights/common/weights_run2_UL.py
@@ -85,9 +85,51 @@ def sf_ele_trigger(params, events, year, variations=["nominal"]):
     return sf_dict
 
 
-########################################################################
-# More complicated WeightWrapper defining dynamic variations depending
-# on the data taking period
+def sf_renscale(events):
+    '''Up and down variations for the renormalization scale weights.
+    The up variation of the renormalization scale weight is defined as the ratio of the weight
+    with renormalization scale increased by a factor of 2 to the nominal weight ([7]/[4]).
+    The down variation of the renormalization scale weight is defined as the ratio of the weight
+    with renormalization scale decreased by a factor of 2 to the nominal weight ([1]/[4]).
+    Conventions for the LHEScaleWeight (valid for NanoAODv9) are:
+    LHE scale variation weights (w_var / w_nominal);
+    [0] is renscfact=0.5d0 facscfact=0.5d0 ;
+    [1] is renscfact=0.5d0 facscfact=1d0 ;
+    [2] is renscfact=0.5d0 facscfact=2d0 ;
+    [3] is renscfact=1d0 facscfact=0.5d0 ;
+    [4] is renscfact=1d0 facscfact=1d0 ;
+    [5] is renscfact=1d0 facscfact=2d0 ;
+    [6] is renscfact=2d0 facscfact=0.5d0 ;
+    [7] is renscfact=2d0 facscfact=1d0 ;
+    [8] is renscfact=2d0 facscfact=2d0'''
+    sf_up = events.LHEScaleWeight[:,7]/events.LHEScaleWeight[:,4]
+    sf_down = events.LHEScaleWeight[:,1]/events.LHEScaleWeight[:,4]
+    nom = ak.ones_like(sf_up)
+
+    return nom, sf_up, sf_down
+
+def sf_facscale(events):
+    '''Up and down variations for the factorization scale weights.
+    The up variation of the factorization scale weight is defined as the ratio of the weight
+    with factorization scale increased by a factor of 2 to the nominal weight ([5]/[4]).
+    The down variation of the factorization scale weight is defined as the ratio of the weight
+    with factorization scale decreased by a factor of 2 to the nominal weight ([3]/[4]).
+    Conventions for the LHEScaleWeight (valid for NanoAODv9) are:
+    LHE scale variation weights (w_var / w_nominal);
+    [0] is renscfact=0.5d0 facscfact=0.5d0 ;
+    [1] is renscfact=0.5d0 facscfact=1d0 ;
+    [2] is renscfact=0.5d0 facscfact=2d0 ;
+    [3] is renscfact=1d0 facscfact=0.5d0 ;
+    [4] is renscfact=1d0 facscfact=1d0 ;
+    [5] is renscfact=1d0 facscfact=2d0 ;
+    [6] is renscfact=2d0 facscfact=0.5d0 ;
+    [7] is renscfact=2d0 facscfact=1d0 ;
+    [8] is renscfact=2d0 facscfact=2d0'''
+    sf_up = events.LHEScaleWeight[:,5]/events.LHEScaleWeight[:,4]
+    sf_down = events.LHEScaleWeight[:,3]/events.LHEScaleWeight[:,4]
+    nom = ak.ones_like(sf_up)
+
+    return nom, sf_up, sf_down
 
 
 class SF_ele_trigger(WeightWrapper):
@@ -125,3 +167,17 @@ class SF_ele_trigger(WeightWrapper):
                 self._params, events, self._metadata["year"], variations=["nominal"]
             )
             return WeightData(name=self.name, nominal=out["nominal"][0])
+
+SF_QCD_renscale = WeightLambda.wrap_func(
+    name="sf_qcd_renscale",
+    function=lambda params, metadata, events, size, shape_variations:
+        sf_renscale(events),
+    has_variations=True
+    )
+
+SF_QCD_facscale = WeightLambda.wrap_func(
+    name="sf_qcd_facscale",
+    function=lambda params, metadata, events, size, shape_variations:
+        sf_facscale(events),
+    has_variations=True
+    )

--- a/pocket_coffea/lib/weights/common/weights_run2_UL.py
+++ b/pocket_coffea/lib/weights/common/weights_run2_UL.py
@@ -85,7 +85,7 @@ def sf_ele_trigger(params, events, year, variations=["nominal"]):
     return sf_dict
 
 
-def sf_renscale(events):
+def sf_qcd_renorm_scale(events):
     '''Up and down variations for the renormalization scale weights.
     The up variation of the renormalization scale weight is defined as the ratio of the weight
     with renormalization scale increased by a factor of 2 to the nominal weight ([7]/[4]).
@@ -108,7 +108,7 @@ def sf_renscale(events):
 
     return nom, sf_up, sf_down
 
-def sf_facscale(events):
+def sf_qcd_factor_scale(events):
     '''Up and down variations for the factorization scale weights.
     The up variation of the factorization scale weight is defined as the ratio of the weight
     with factorization scale increased by a factor of 2 to the nominal weight ([5]/[4]).
@@ -168,16 +168,16 @@ class SF_ele_trigger(WeightWrapper):
             )
             return WeightData(name=self.name, nominal=out["nominal"][0])
 
-SF_QCD_renscale = WeightLambda.wrap_func(
-    name="sf_qcd_renscale",
+SF_QCD_renorm_scale = WeightLambda.wrap_func(
+    name="sf_qcd_renorm_scale",
     function=lambda params, metadata, events, size, shape_variations:
-        sf_renscale(events),
+        sf_qcd_renorm_scale(events),
     has_variations=True
     )
 
-SF_QCD_facscale = WeightLambda.wrap_func(
-    name="sf_qcd_facscale",
+SF_QCD_factor_scale = WeightLambda.wrap_func(
+    name="sf_qcd_factor_scale",
     function=lambda params, metadata, events, size, shape_variations:
-        sf_facscale(events),
+        sf_qcd_factor_scale(events),
     has_variations=True
     )

--- a/pocket_coffea/utils/configurator.py
+++ b/pocket_coffea/utils/configurator.py
@@ -426,6 +426,18 @@ class Configurator:
                             self.weights_config[sample]["bycategory"][cat].append(w)
                             self.weights_config[sample]["is_split_bycat"] = True
 
+                if "inclusive" not in s_wcfg and "bycategory" not in s_wcfg:
+                    print(f"None of the `inclusive` or `bycategory` keys found in the weights configuration for sample {sample}.\n")
+                    print(
+                        """The dictionary structure should be like:\n
+                        'bysample': {
+                            'sample_name': {
+                                'inclusive': ['weight1', 'weight2'],
+                                'bycategory': {'cat1': ['weight1', 'weight2']}
+                        }\n"""
+                    )
+                    raise Exception("Wrong weight configuration")
+
     def load_variations_config(self, wcfg, variation_type):
         '''This function loads the variations definition and prepares a list of
         weights to be applied for each sample and category'''


### PR DESCRIPTION
The generator level weights to account for the variation of the QCD scale both in the hard process and in the parton shower (PS) are implemented. In particular, the following weights are implemented:
- PS weight to vary up/down the QCD renormalization scale in the initial-state-radiation (ISR) parton shower
- PS weight to vary up/down the QCD renormalization scale in the final-state-radiation (FSR) parton shower
- Weight to vary up/down the QCD renormalization scale ($\mu_R$) in the hard process
- Weight to vary up/down the QCD factorization scale ($\mu_f$) in the hard process

The weights are taken from the generator-level variables `PSWeight` and `LHEScaleWeight`.

Since the implementation of the PS weights is compatible both with NanoAODv9 and NanoAODv12, it is included in the common weights in PocketCoffea.
Instead, since the implementation of the QCD renormalization and factorization scale weights is specific to NanoAODv9, it is included in the common weights for Run2.

In addition, there is a small patch to the `Configurator` in order to catch the exception when the user is using the weight `bysample` but does not specify either of the `inclusive` or `bycategory` keys.

Reference for PS uncertainties:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopSystematics#Parton_shower_uncertainties

Reference for QCD scale uncertainties:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopSystematics#Factorization_and_renormalizatio