### PR TITLE
fix: automatically remove _Disk from sitename when filtering

### DIFF
--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -206,7 +206,9 @@ def get_dataset_files_replicas(
             possible_sites = list(rses.keys())
             if blocklist_sites:
                 possible_sites = list(
-                    filter(lambda key: key not in blocklist_sites, possible_sites)
+                    filter(lambda key: (
+                        (key not in blocklist_sites) and (key.replace("_Disk","") not in blocklist_sites)
+                        ),  possible_sites)
                 )
 
             if len(possible_sites) == 0 and not partial_allowed and not include_redirector:


### PR DESCRIPTION
The PR fixes the confusion after blocksites list. Often users don't put the suffix `_Disk` while filtering for some sites. 
Now that is checked automatically. 