### PR TITLE
remove isMC check when creating weights_config

### DIFF
--- a/pocket_coffea/utils/configurator.py
+++ b/pocket_coffea/utils/configurator.py
@@ -158,7 +158,6 @@ class Configurator:
                 "is_split_bycat": False,
             }
             for s in self.samples
-            if self.samples_metadata[s]["isMC"]
         }
         ## Defining the available weight strings
         ## If the users hasn't passed a list of WeightWrapper classes, the configurator


### PR DESCRIPTION
In my analysis I have to add weights to morph data and I think that this change doesn't affect the general weight configuration