### PR TITLE
Minor-update on plotting and law tasks

### DIFF
--- a/pocket_coffea/law_tasks/tasks/datasets.py
+++ b/pocket_coffea/law_tasks/tasks/datasets.py
@@ -123,6 +123,7 @@ class CreateDatasets(BaseTask):
         self.merged_datasets = modify_dataset_output_path(
             dataset_definition=self.merged_datasets,
             dataset_configuration=self.dataset_config,
+            # output_path=self.local_path(), # ! this would overwrite config.py
         )
 
     def output(self):

--- a/pocket_coffea/law_tasks/utils.py
+++ b/pocket_coffea/law_tasks/utils.py
@@ -431,9 +431,8 @@ def load_plotting_style(params_file: FileName, custom_plot_style: FileName = Non
     """
     parameters = OmegaConf.load(params_file)
     if os.path.isfile(custom_plot_style):
-        parameters = parameters_utils.merge_parameters_from_files(
-            parameters, custom_plot_style, update=True
-        )
+        # get the default parameters and overwrite them with the custom ones
+        parameters = parameters_utils.get_defaults_and_compose(custom_plot_style)
     elif (custom_plot_style is not None) and (custom_plot_style != law.NO_STR):
         warnings.warn(
             f"custom plotting style file {custom_plot_style} not found."

--- a/pocket_coffea/parameters/defaults.py
+++ b/pocket_coffea/parameters/defaults.py
@@ -76,7 +76,7 @@ def get_default_run_options():
 
 def get_defaults_and_compose(*files: List[str]):
     default_params = get_default_parameters()
-    return merge_parameters_from_files(default_params, files)
+    return merge_parameters_from_files(default_params, *files)
 
 
 def merge_parameters(main_config: OmegaConf, *configs: List[OmegaConf], update=True):


### PR DESCRIPTION
some minor updates on the plotting task

`parameters/defaults.py`: syntax error fixed

`law_tasks/utils.py`: if a custom_plot_style file is passed to the plotting task, it would not take into account all changes, e.g. if `samples_groups` in the new custom_plot_style file had fewer entries, then the merging with `update=True` leads to the old entries still being in the yaml file
```yml
plotting_style:
  samples_groups:
    group1:
      - sample1
      - sample2
    # group2:
    #  -sample3
    #  -sample4
```
group2 is commented out in the custom_plot_style but kept in the plotting since, it is in the original plotting.yaml and only updated

`law_tasks/tasks/datasets.py`: the output path of the datasets are set in the configurator, cannot be changed by law task --> fixed