### PR TITLE
Priority sorting in `build-dataset` and `dataset-discovery-cli`

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -18,26 +18,36 @@ To build the JSON dataset, run the script `build_dataset.py`:
 /____/\_,_/_/_/\_,_/____/\_,_/\__/\_,_/___/\__/\__/ 
                                                    
 
-usage: build_datasets.py [-h] [--cfg CFG] [-k KEYS [KEYS ...]] [-d] [-o] [-c] [-s] [-l LOCAL_PREFIX] [-ws WHITELIST_SITES [WHITELIST_SITES ...]] [-bs BLACKLIST_SITES [BLACKLIST_SITES ...]] [-rs REGEX_SITES]
+usage: build_datasets [--help] [--cfg CFG] [-k KEYS [KEYS ...]] [-d] [-o] [-c] [-s] [-l LOCAL_PREFIX] 
+			[-ws WHITELIST_SITE -ws WHITELIST_SITE ...] [-bs BLACKLIST_SITE -bs BLACKLIST_SITES ...] [-ps PRIORITYLIST_SITE -ps PRIORITYLIST_SITES ...] 
+			[-rs REGEX_SITES] [-sort SORTING] [-ir] [-p 8]
 
-Build dataset fileset in json format
+  Build dataset fileset in json format
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --cfg CFG             Config file with parameters specific to the current run
-  -k KEYS [KEYS ...], --keys KEYS [KEYS ...]
-                        Dataset keys to select
-  -o, --overwrite       Overwrite existing file definition json
-  -c, --check           Check file existance in the local prefix
-  -s, --split-by-year   Split output files by year
-  -l LOCAL_PREFIX, --local-prefix LOCAL_PREFIX
-                        Local prefix
-  -ws WHITELIST_SITES [WHITELIST_SITES ...], --whitelist-sites WHITELIST_SITES [WHITELIST_SITES ...]
-                        List of sites in the whitelist
-  -bs BLACKLIST_SITES [BLACKLIST_SITES ...], --blacklist-sites BLACKLIST_SITES [BLACKLIST_SITES ...]
-                        List of sites in the blacklist
-  -rs REGEX_SITES, --regex-sites REGEX_SITES
-                        Regex to filter sites
+Options:
+  --cfg TEXT                      Config file with parameters specific to the
+                                  current run  [required]
+  -k, --keys TEXT                 Keys of the datasets to be created. If None,
+                                  the keys are read from the datasets
+                                  definition file.
+  -d, --download                  Download datasets from DAS
+  -o, --overwrite                 Overwrite existing .json datasets
+  -c, --check                     Check existence of the datasets
+  -s, --split-by-year             Split datasets by year
+  -l, --local-prefix TEXT
+  -ws, --allowlist-sites TEXT     List of sites in whitelist
+  -bs, --blocklist-sites TEXT     List of sites in blacklist
+  -ps, --prioritylist-sites TEXT  List of priorities to sort sites (requires
+                                  sort: priority)
+  -rs, --regex-sites TEXT         example: -rs
+                                  'T[123]_(FR|IT|DE|BE|CH|UK)_\w+' to serve
+                                  data from sites in Europe.
+  -sort, --sort-replicas TEXT     Sort replicas (default: geoip).
+  -ir, --include-redirector       Use the redirector path if no site is
+                                  available after the specified whitelist,
+                                  blacklist and regexes are applied for sites.
+  -p, --parallelize INTEGER
+  -h, --help                      Show this message and exit.
 
 ```
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -112,26 +112,30 @@ usage: build_datasets [--help] [--cfg CFG] [-k KEYS [KEYS ...]] [-d] [-o] [-c] [
   Build dataset fileset in json format
 
 Options:
-  --cfg TEXT                   Config file with parameters specific to the
-                               current run  [required]
-  -k, --keys TEXT              Keys of the datasets to be created. If None,
-                               the keys are read from the datasets definition
-                               file.
-  -d, --download               Download datasets from DAS
-  -o, --overwrite              Overwrite existing .json datasets
-  -c, --check                  Check existence of the datasets
-  -s, --split-by-year          Split datasets by year
+  --cfg TEXT                      Config file with parameters specific to the
+                                  current run  [required]
+  -k, --keys TEXT                 Keys of the datasets to be created. If None,
+                                  the keys are read from the datasets
+                                  definition file.
+  -d, --download                  Download datasets from DAS
+  -o, --overwrite                 Overwrite existing .json datasets
+  -c, --check                     Check existence of the datasets
+  -s, --split-by-year             Split datasets by year
   -l, --local-prefix TEXT
-  -ws, --allowlist-sites TEXT  List of sites in whitelist
-  -bs, --blocklist-sites TEXT  List of sites in blacklist
-  -rs, --regex-sites TEXT      example: -rs 'T[123]_(FR|IT|DE|BE|CH|UK)_\w+'
-                               to serve data from sites in Europe.
-  -sort, --sort-replicas TEXT  Sort replicas (default: geoip).
-  -ir, --include-redirector    Use the redirector path if no site is available
-                               after the specified whitelist, blacklist and
-                               regexes are applied for sites.
+  -ws, --allowlist-sites TEXT     List of sites in whitelist
+  -bs, --blocklist-sites TEXT     List of sites in blacklist
+  -ps, --prioritylist-sites TEXT  List of priorities to sort sites (requires
+                                  sort: priority)
+  -rs, --regex-sites TEXT         example: -rs
+                                  'T[123]_(FR|IT|DE|BE|CH|UK)_\w+' to serve
+                                  data from sites in Europe.
+  -sort, --sort-replicas TEXT     Sort replicas (default: geoip).
+  -ir, --include-redirector       Use the redirector path if no site is
+                                  available after the specified whitelist,
+                                  blacklist and regexes are applied for sites.
   -p, --parallelize INTEGER
-  -h, --help                   Show this message and exit.
+  -h, --help                      Show this message and exit.
+
 ```
 
 The **DBS** and **Rucio** services are used to get information about the requested CMS datasets.

--- a/pocket_coffea/law_tasks/tasks/datasets.py
+++ b/pocket_coffea/law_tasks/tasks/datasets.py
@@ -154,6 +154,7 @@ class CreateDatasets(BaseTask):
             local_prefix=self.local_prefix,
             allowlist_sites=self.allowlist_sites,
             blocklist_sites=self.blocklist_sites,
+            prioritylist_sites=self.prioritylist_sites,
             regex_sites=self.regex_sites,
             parallelize=self.parallelize,
             include_redirector=self.include_redirector,

--- a/pocket_coffea/scripts/dataset/build_datasets.py
+++ b/pocket_coffea/scripts/dataset/build_datasets.py
@@ -59,6 +59,13 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     help="List of sites in blacklist"
 )
 @click.option(
+    "-ps",
+    "--prioritylist-sites",
+    type=str,
+    multiple=True,
+    help="List of priorities to sort sites (requires sort: priority)"
+)
+@click.option(
     "-rs", "--regex-sites", type=str,
     help="example: -rs 'T[123]_(FR|IT|DE|BE|CH|UK)_\w+' to serve data from sites in Europe."
 )
@@ -88,6 +95,7 @@ def build_datasets(
     allowlist_sites,
     include_redirector,
     blocklist_sites,
+    prioritylist_sites,
     regex_sites,
     sort_replicas,
     parallelize,
@@ -98,6 +106,8 @@ def build_datasets(
         allowlist_sites = allowlist_sites[0].split(",")
     if len(blocklist_sites)>0 and "," in blocklist_sites[0]:
         blocklist_sites = blocklist_sites[0].split(",")
+    if len(prioritylist_sites)>0 and "," in prioritylist_sites[0]:
+        prioritylist_sites = prioritylist_sites[0].split(",")
 
     print("Building datasets...")
     print("[green]Allowlist sites:[/]")

--- a/pocket_coffea/scripts/dataset/dataset_query.py
+++ b/pocket_coffea/scripts/dataset/dataset_query.py
@@ -236,7 +236,7 @@ Some basic commands:
             )
         else:
             print("First [bold red]query (Q)[/] for a dataset")
-    
+
     def generate_default_metadata(self, dataset):
         year = self.extract_year_from_dataset_name(dataset)
         isMC = self.is_mc_dataset(dataset)
@@ -558,6 +558,7 @@ Some basic commands:
             print(f"- {s}")
 
     def do_prioritylist_sites(self, sites=None):
+        """Choose prioritised sites by which to order replicas independent of location and availability."""
         if sites is None:
             sites = Prompt.ask(
                 "[yellow]List to order the available sites by (space-separated list, overwrites previous priority)"
@@ -630,6 +631,7 @@ Some basic commands:
 
     def do_set_replicas_sorting(self, sort: str = None):
         """Set the sorting mode for the replicas.
+
         If `sort` is None, it will ask the user for the sorting mode.
         If user input is empty, the sorting mode will not be changed.
 
@@ -723,19 +725,17 @@ Some basic commands:
             self.final_output = None
             print(f"[green]Selected datasets list emptied![/]")
 
-
     # Define a empty-list function
     def do_clear(self):
         if Confirm.ask("[red]Do you want to empty your selected samples list?[/]", default=False):
-          self.selected_datasets = []
-          self.selected_datasets_metadata = []
-          self.replica_results = defaultdict(list)
-          self.replica_results_metadata = {}
-          self.replica_results_bysite = {}
-          self.final_output = None
-          print(f"[green]Selected datasets list emptied![/]")
+            self.selected_datasets = []
+            self.selected_datasets_metadata = []
+            self.replica_results = defaultdict(list)
+            self.replica_results_metadata = {}
+            self.replica_results_bysite = {}
+            self.final_output = None
+            print(f"[green]Selected datasets list emptied![/]")
 
-        
     def load_dataset_definition(
         self,
         dataset_definition,
@@ -786,11 +786,9 @@ Some basic commands:
         self.do_list_selected()
         return out_replicas
 
-
-    
-
 # This is the main function that will be called by the CLI
-      
+
+
 @click.command()
 @click.option("--dataset-definition", help="Dataset definition file", type=str, required=False)
 @click.option("--output", help="Output name for dataset discovery output (no fileset preprocessing)", type=str, required=False, default="output_dataset.json")
@@ -802,7 +800,7 @@ Some basic commands:
 @click.option("--query-results-strategy", help="Mode for query results selection: [all|manual]", type=str, default="all")
 @click.option("--replicas-strategy", help="Mode for selecting replicas for datasets: [manual|round-robin|first|choose]", default="round-robin", required=False)
 def dataset_discovery_cli(dataset_definition, output, fileset_output, allow_sites, block_sites, priority_sites, regex_sites, query_results_strategy, replicas_strategy):
-    '''CLI for interactive dataset discovery'''
+    """CLI for interactive dataset discovery."""
     cli = DataDiscoveryCLI()
 
     if allow_sites:
@@ -828,5 +826,6 @@ def dataset_discovery_cli(dataset_definition, output, fileset_output, allow_site
 
     cli.start_cli()
 
+
 if __name__ == "__main__":
-    dataset_query_cli()
+    dataset_discovery_cli()

--- a/pocket_coffea/utils/dataset.py
+++ b/pocket_coffea/utils/dataset.py
@@ -25,6 +25,7 @@ def do_dataset(
     allowlist_sites,
     include_redirector,
     blocklist_sites,
+    prioritylist_sites,
     regex_sites,
     sort_replicas: str = "geoip",
     **kwargs,
@@ -46,6 +47,7 @@ def do_dataset(
                 "allowlist_sites": allowlist_sites,
                 "include_redirector": include_redirector,
                 "blocklist_sites": blocklist_sites,
+                "prioritylist_sites": prioritylist_sites,
                 "regex_sites": regex_sites,
             },
             sort_replicas=sort_replicas,
@@ -54,7 +56,6 @@ def do_dataset(
         raise Exception(f"Error getting info about dataset: {key}")
 
     return dataset
-
 
 
 def build_datasets(
@@ -68,6 +69,7 @@ def build_datasets(
     allowlist_sites=None,
     include_redirector=False,
     blocklist_sites=None,
+    prioritylist_sites=None,
     regex_sites=None,
     sort_replicas="geoip",
     parallelize=4,
@@ -87,6 +89,7 @@ def build_datasets(
         "allowlist_sites": allowlist_sites,
         "include_redirector": include_redirector,
         "blocklist_sites": blocklist_sites,
+        "prioritylist_sites": prioritylist_sites,
         "regex_sites": regex_sites,
         "parallelize": parallelize,
         "sort_replicas": sort_replicas,
@@ -118,8 +121,8 @@ class Sample:
         sort_replicas: str = "geoip",
         **kwargs,
     ):
-        '''
-        Class representing a single analysis sample.
+        """Represent a single analysis sample.
+
         - The name is the unique key of the sample in the dataset file.
         - The DAS name is the unique identifier of the sample in CMS
         - The sample represent the type of events: DATA/Wjets/ttHbb/ttBB. It is used to group the same type of events
@@ -127,8 +130,8 @@ class Sample:
          -- year
          -- isMC: true/false
          -- era: A/B/C/D (only for data)
-        - sites_cfg is a dictionary contaning allowlist, blocklist and regex to filter the SITES
-        '''
+        - sites_cfg is a dictionary contaning allowlist, blocklist, prioritylist and regex to filter the SITES
+        """
         self.name = name
         self.das_names = das_names
         self.metadata = {}
@@ -273,6 +276,7 @@ class Dataset:
             else {
                 "allowlist_sites": None,
                 "blocklist_sites": None,
+                "prioritylist_sites": None,
                 "regex_sites": None,
             }
         )

--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -124,6 +124,7 @@ def get_dataset_files_replicas(
     allowlist_sites=None,
     include_redirector=False,
     blocklist_sites=None,
+    prioritylist_sites=None,
     regex_sites=None,
     mode="full",
     partial_allowed=False,
@@ -138,6 +139,7 @@ def get_dataset_files_replicas(
     The sites can be filtered in 3 different ways:
     - `allowlist_sites`: list of sites to select from. If the file is not found there, raise an Exception.
     - `blocklist_sites`: list of sites to avoid. If the file has no left site, raise an Exception
+    - `prioritylist_sites`: list of priorised sites. Sorts these sites to front if available and sort is 'priority'
     - `regex_sites`: regex expression to restrict the list of sites.
 
     The fileset returned by the function is controlled by the `mode` parameter:
@@ -152,6 +154,7 @@ def get_dataset_files_replicas(
         dataset: str
         allowlist_sites: list
         blocklist_sites: list
+        prioritylist_sites: list
         regex_sites: list
         mode:  str, default "full"
         client: rucio Client, optional
@@ -183,7 +186,7 @@ def get_dataset_files_replicas(
     for filedata in client.list_replicas(
         [{"scope": scope, "name": dataset}],
         client_location=detect_client_location(),
-        sort=sort,
+        sort=sort if sort in ["geoip", "custom_table", "random"] else None,
     ):
         outfile = []
         outsite = []
@@ -274,10 +277,16 @@ def get_dataset_files_replicas(
                 print("\t WARNING! The file was NOT found at any of the allowed sites. Setting its prefix to INFN! \n ", outfile)
                 found = True
 
-                    
         if not found and not partial_allowed:
             raise Exception(f"No SITE available for file: \n {filedata['name']}")
         else:
+            # Sort by prioritylist if applicable
+            if prioritylist_sites and sort.lower() == "priority":
+                for priority in prioritylist_sites[::-1]:
+                    if priority in outsite:
+                        original_idx = outsite.index(priority)
+                        outsite.insert(0, outsite.pop(original_idx))
+                        outfile.insert(0, outfile.pop(original_idx))
             if mode == "full":
                 outfiles.append(outfile)
                 outsites.append(outsite)

--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -9,7 +9,6 @@ from rucio.client import Client
 from rucio.common.client import detect_client_location
 from pocket_coffea.utils.network import get_proxy_path
 
-
 # Rucio needs the default configuration --> taken from CMS cvmfs defaults
 if "RUCIO_HOME" not in os.environ:
     os.environ["RUCIO_HOME"] = "/cvmfs/cms.cern.ch/rucio/current"
@@ -116,8 +115,9 @@ def _get_pfn_for_site(path, rules):
     else:
         # not adding any slash as the path usually starts with it
         if path.startswith("/"):
-             path = path[1:]
+            path = path[1:]
         return rules + "/" + path
+
 
 def get_dataset_files_replicas(
     dataset,
@@ -132,9 +132,7 @@ def get_dataset_files_replicas(
     scope="cms",
     sort: str = "geoip",
 ):
-    """
-    This function queries the Rucio server to get information about the location
-    of all the replicas of the files in a CMS dataset.
+    """Query the Rucio server to get information about the location of all the replicas of the files in a CMS dataset.
 
     The sites can be filtered in 3 different ways:
     - `allowlist_sites`: list of sites to select from. If the file is not found there, raise an Exception.
@@ -150,7 +148,6 @@ def get_dataset_files_replicas(
 
     Parameters
     ----------
-
         dataset: str
         allowlist_sites: list
         blocklist_sites: list
@@ -214,14 +211,14 @@ def get_dataset_files_replicas(
                     )
                     outsite.append(site)
                     found = True
-                    
+
         else:
             possible_sites = list(rses.keys())
             if blocklist_sites:
                 possible_sites = list(
                     filter(lambda key: (
-                        (key not in blocklist_sites) and (key.replace("_Disk","") not in blocklist_sites)
-                        ),  possible_sites)
+                        (key not in blocklist_sites) and (key.replace("_Disk", "") not in blocklist_sites)
+                        ), possible_sites)
                 )
 
             if len(possible_sites) == 0 and not partial_allowed and not include_redirector:
@@ -263,7 +260,6 @@ def get_dataset_files_replicas(
                     )
                     outsite.append(site)
                     found = True
-
 
         if not found and include_redirector:
             # The file was not found at any of the allowed sites
@@ -307,7 +303,6 @@ def get_dataset_files_replicas(
             sites_counts[site] += 1
 
     return outfiles, outsites, sites_counts
-
 
 
 def get_dataset_files_from_dbs(


### PR DESCRIPTION
This is a small addition to the sorting options in `build_dataset` and `dataset-discovery-cli`
In particular:
- adds an additional sorting option (additional to the recently added `geoip`) called `priority`
- provides option to give a list of prioritised sites using `prioritylist-sites` (similar to for instance `blocklist-sites`) (flag is `-ps`)
- for `build-dataset` this means, that if available, first priority is chosen, if not available second and so on. If no prioritised site is available, default behaviour is applied.
- in `dataset-discovery-cli`, replicas of files are then ordered such that prioritised sites are listed on top if available the rest of the sites are still ordered according to default.

Solves issue https://github.com/PocketCoffea/PocketCoffea/issues/225

-- Additional changes --
- sorting is now listed, in `sites-filters`
- priority-list is also reset when resetting in `sites-filters` (`sorting` is Not reset)
- some formatting fixes
- fixed `__main__()` function call in `dataset_query.py`

