### PR TITLE
Filter invalid files in a dataset

### DIFF
--- a/pocket_coffea/utils/dataset.py
+++ b/pocket_coffea/utils/dataset.py
@@ -173,6 +173,7 @@ class Sample:
                 verify=False,
             )
             filesjson = r.json()
+            invalid_list = []
             for fj in filesjson:
                 if 'is_file_valid' not in fj.keys():
                     # print("fj=", fj)
@@ -180,11 +181,11 @@ class Sample:
                 else:
                     if fj["is_file_valid"] == 0:
                         #print(fj)
-                        print(f"\t WARNING: A file not valid on DAS: {fj['logical_file_name']}")
+                        print(f"\t WARNING: This file is Not Valid on DAS: {fj['logical_file_name']}")
                         print("\t We are skipping it")
-                        #raise Exception(f"Invalid files in sample {self}!")
+                        invalid_list.append(fj['logical_file_name'])                        
                         continue
-                    
+                        
                     self.fileslist_redirector.append(fj['logical_file_name'])
                     self.metadata["nevents"] += fj['event_count']
                     self.metadata["size"] += fj['file_size']
@@ -194,7 +195,7 @@ class Sample:
             if self.metadata.get("dbs_instance", "prod/global") == "prod/global":
                 # Now query rucio to get the concrete dataset passing the sites filtering options
                 files_replicas, sites, sites_counts = rucio.get_dataset_files_replicas(
-                    das_name, **self.sites_cfg, mode="first", sort=self.sort_replicas
+                    das_name, **self.sites_cfg, mode="first", sort=self.sort_replicas, invalid_list=invalid_list
                 )
             else:
                 # Use DBS to get the site

--- a/pocket_coffea/utils/rucio.py
+++ b/pocket_coffea/utils/rucio.py
@@ -120,17 +120,18 @@ def _get_pfn_for_site(path, rules):
 
 
 def get_dataset_files_replicas(
-    dataset,
-    allowlist_sites=None,
-    include_redirector=False,
-    blocklist_sites=None,
-    prioritylist_sites=None,
-    regex_sites=None,
-    mode="full",
-    partial_allowed=False,
-    client=None,
-    scope="cms",
-    sort: str = "geoip",
+        dataset,
+        allowlist_sites=None,
+        include_redirector=False,
+        blocklist_sites=None,
+        prioritylist_sites=None,
+        regex_sites=None,
+        mode="full",
+        partial_allowed=False,
+        client=None,
+        scope="cms",
+        sort: str = "geoip",
+        invalid_list=[],
 ):
     """Query the Rucio server to get information about the location of all the replicas of the files in a CMS dataset.
 
@@ -158,7 +159,10 @@ def get_dataset_files_replicas(
         partial_allowed: bool, default False
         scope:  rucio scope, "cms"
         sort: str, default 'geoip'
-            sort replicas (for details check rucio documentation)
+            Sort replicas (for details check rucio documentation)
+        invalid_list: list
+            A list of invalid files for this dataset (to be exluded in the output).
+            Rucio does not know of invalid files, so these need to be obtained beforehand from DAS.
 
     Returns
     -------
@@ -194,6 +198,10 @@ def get_dataset_files_replicas(
         rses_sorted = [pfn["rse"] for pfn in pfns.values()]
         rses = {rse: rses[rse] for rse in rses_sorted}
         found = False
+        if filedata["name"] in invalid_list:
+            #print(f"The following file is invalid, we skip it:\n {filedata['name']}")
+            continue
+
         if allowlist_sites:
             for site in allowlist_sites:
                 if site in rses:


### PR DESCRIPTION
It could happen sometimes that a Valid dataset contains a few invalid files.
Example in `/Zto2Nu-2Jets_PTNuNu-200to400_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM` dataset, where one file is invalid.

Rucio does not know about invalid file, but DAS knows.

This PR allows to filter such files.