### PR TITLE
Fix an empty variations check

### DIFF
--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -1677,8 +1677,9 @@ class SystUnc:
         for h in stacks["mc"]:
             for variation in h.axes[0]:
                 h_var = h[{'variation': variation}].values()
-                # First, we check that the variation is not equal to the nominal
-                if not all(stacks["mc_nominal_sum"].values() == h_var):
+                h_nom = h[{'variation': 'nominal'}].values()
+                # First, we check that the variation is not equal to the nominal            
+                if not all(h_nom == h_var):
                     # Then, we check if the variation is empty
                     if all(h_var == np.zeros_like(h_var)):
                         print(


### PR DESCRIPTION
I think the `check_empty_variations()` is bugged, when it tries to compare the nominal and variations hist.
This is a fix.