### PR TITLE
Prevent save_skimmed_files from failing with --test

### DIFF
--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -312,7 +312,7 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
     # If the processor has skimmed NanoAOD, we export a dataset_definition file
     if config.save_skimmed_files and config.do_postprocessing:
         from pocket_coffea.utils.skim import save_skimed_dataset_definition
-        save_skimed_dataset_definition(output, f"{outputdir}/skimmed_dataset_definition.json")
+        save_skimed_dataset_definition(output, f"{outputdir}/skimmed_dataset_definition.json", check_initial_events=not test)
         
     # Closing the executor if needed
     executor_factory.close()


### PR DESCRIPTION
Small fix to enable `run --test` runs with `save_skimmed_files` on.

If running `pocket-coffea run ...` with `save_skimmed_files` defined in the `Configurator()`, PocketCoffea is comparing the amount of initial events in the metadata with the amount of initial events in the cutflow ([here](https://github.com/PocketCoffea/PocketCoffea/blob/main/pocket_coffea/utils/skim.py#L97)).

When running with the `--test` flag enabled, this will generally throw an exception, because in this case only 2 files will be read in leading to a smaller array of events.

The fix will now skip this check if running with `--test` activated.