### PR TITLE
Fix possible bad skim save path issue

### DIFF
--- a/pocket_coffea/utils/skim.py
+++ b/pocket_coffea/utils/skim.py
@@ -63,7 +63,7 @@ def copy_file(
     )
     merged_subdirs = "/".join(subdirs) if xrootd else os.path.sep.join(subdirs)
     destination = (
-        location + merged_subdirs + f"/{fname}"
+        f"{location}/" + merged_subdirs + f"/{fname}"
         if xrootd
         else os.path.join(location, os.path.join(merged_subdirs, fname))
     )


### PR DESCRIPTION
Small fix for issue https://github.com/PocketCoffea/PocketCoffea/issues/325. 

Basically ensures that a `/` is introduced between the location and the subdirectories when the `save_skimmed_files`  parameter does not contain a `/` at the end. This would otherwise lead to an issue, where the generated dataset definition would have invalid paths. 

This will Not break if a `/` is already written in the `save_skimmed_files` parameter, because `//` is treated the same way as `/` for saving a file.

A more detailed explanation of the issue can be found in the issue:)