### PR TITLE
Add split-by-category feature for handling large outputs with histograms from a large number of categories

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -165,3 +165,16 @@ logging:
   distributed.nanny: warning
   distributed.scheduler: warning
 ```
+
+## Split large outputs into categories
+
+If your configuration contains a large number of categories, variables, and systematics, the number of histograms can grow very large. Although on disk, the size of the *merged* `output_all.coffea` is usually less than O(10 GB), the full accumulation process can consume around O(100 GB) of RAM. This seems unavoidable as coffea accumulation necessarily happens on memory. This can be addressed in one of two ways:
+
+- The `merge-output` script dumps partial `.coffea` outputs whenever memory usage exceeds 50% of the available RAM on the machine. However, this means one still has to use a different large-memory machine to merge them into one `.coffea` file and/or read them all into memory during plotting. The fragmented `.coffea` dumps consume less space on disk and are fewer in number, so it is easier to `scp` them to other machines using this approach.
+
+- A more efficient solution is to split outputs into "category groups" (i.e. channels or regions of the analysis) and merge/process only one group of categories at one time. Since plots are typically made per channel, this lets one do everything without loading multiple caetegory-grouped files into the memory.
+
+Currently, the second solution is implemented only for the `condor@lxplus` executor. It can be utilized as follows:
+  * `runner`: Pass `--split-by-category` to `runner` (actually gets passed to the executor parameters). The output from each job is then further split to contain 8 categories per output file, so each job produces `n_groups = n_categories/8` output files. This is handled through the `split-output` command, which in turn calls `utils.filter_output.filter_output_by_category`.
+  * `merge-outputs`: Handles the merging per category automatically (no extra flag needed) if `--split-by-category` was passed to `runner`. This will produce `n_groups` merged outputs, containing mutually exclusive groups of categories.
+  * `make-plots`: Pass `--split-by-category` flag to handle only the category-wise merged outputs.

--- a/pocket_coffea/executors/executors_lxplus.py
+++ b/pocket_coffea/executors/executors_lxplus.py
@@ -8,47 +8,53 @@ from .executors_base import IterativeExecutorFactory, FuturesExecutorFactory
 from pocket_coffea.utils.network import check_port
 from pocket_coffea.parameters.dask_env import setup_dask
 from pocket_coffea.utils.configurator import Configurator
+from pocket_coffea.utils.rucio import get_xrootd_sites_map
 import cloudpickle
 import yaml
+from copy import deepcopy
+
+def get_worker_env(run_options,x509_path,exec_name="dask"):
+    env_worker = [
+        'export XRD_RUNFORKHANDLER=1',
+        'export MALLOC_TRIM_THRESHOLD_=0'        ,
+        ]
+    if exec_name == "dask":
+        env_worker.append('ulimit -u unlimited')
+
+    if not run_options['ignore-grid-certificate']:
+        env_worker.append(f'export X509_USER_PROXY={x509_path}')
     
+    # Adding list of custom setup commands from user defined run options
+    if run_options.get("custom-setup-commands", None):
+        env_worker += run_options["custom-setup-commands"]
+
+    # Now checking for conda environment  conda-env:true
+    if run_options.get("conda-env", False):
+        env_worker.append(f'export PATH={os.environ["CONDA_PREFIX"]}/bin:$PATH')
+        if "CONDA_ROOT_PREFIX" in os.environ:
+            env_worker.append(f"{os.environ['CONDA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
+        elif "MAMBA_ROOT_PREFIX" in os.environ:
+            env_worker.append(f"{os.environ['MAMBA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
+        else:
+            raise Exception("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
+
+    # if local-virtual-env: true the dask job is configured to pickup
+    # the local virtual environment. 
+    if run_options.get("local-virtualenv", False):
+        env_worker.append(f"source {sys.prefix}/bin/activate")
+        if exec_name == "dask":
+            env_worker.append(f"export PYTHONPATH={sys.prefix}/lib:$PYTHONPATH")
+        elif exec_name == "condor":
+            pythonpath = sys.prefix.rsplit('/', 1)[0]
+            env_worker.append(f"export PYTHONPATH={pythonpath}")
+
+    return env_worker
 
 class DaskExecutorFactory(ExecutorFactoryABC):
 
     def __init__(self, run_options, outputdir, **kwargs):
         self.outputdir = outputdir
         super().__init__(run_options, **kwargs)
-
-    def get_worker_env(self):
-        env_worker = [
-            'export XRD_RUNFORKHANDLER=1',
-            'export MALLOC_TRIM_THRESHOLD_=0',
-            'ulimit -u unlimited',
-            ]
-        if not self.run_options['ignore-grid-certificate']:
-            env_worker.append(f'export X509_USER_PROXY={self.x509_path}')
-        
-        # Adding list of custom setup commands from user defined run options
-        if self.run_options.get("custom-setup-commands", None):
-            env_worker += self.run_options["custom-setup-commands"]
-
-        # Now checking for conda environment  conda-env:true
-        if self.run_options.get("conda-env", False):
-            env_worker.append(f'export PATH={os.environ["CONDA_PREFIX"]}/bin:$PATH')
-            if "CONDA_ROOT_PREFIX" in os.environ:
-                env_worker.append(f"{os.environ['CONDA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
-            elif "MAMBA_ROOT_PREFIX" in os.environ:
-                env_worker.append(f"{os.environ['MAMBA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
-            else:
-                raise Exception("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
-
-        # if local-virtual-env: true the dask job is configured to pickup
-        # the local virtual environment. 
-        if self.run_options.get("local-virtualenv", False):
-            env_worker.append(f"source {sys.prefix}/bin/activate")
-            env_worker.append(f"export PYTHONPATH={sys.prefix}/lib:$PYTHONPATH")
-
-        return env_worker
-    
         
     def setup(self):
         ''' Start the DASK cluster here'''
@@ -89,7 +95,7 @@ class DaskExecutorFactory(ExecutorFactoryABC):
                     "when_to_transfer_output": "ON_EXIT",
                     "+JobFlavour": f'"{self.run_options["queue"]}"'
                 },
-                env_extra=self.get_worker_env(),
+                env_extra=get_worker_env(self.run_options,self.x509_path,"dask"),
             )
 
         #Cluster adaptive number of jobs only if requested
@@ -131,43 +137,13 @@ class ExecutorFactoryCondorCERN(ExecutorFactoryManualABC):
     def get(self):
         pass
 
-    def get_worker_env(self):
-        env_worker = [
-            'export XRD_RUNFORKHANDLER=1',
-            'export MALLOC_TRIM_THRESHOLD_=0',
-            ]
-        if not self.run_options['ignore-grid-certificate']:
-            env_worker.append(f'export X509_USER_PROXY={self.x509_path.split("/")[-1]}')
-        
-        # Adding list of custom setup commands from user defined run options
-        if self.run_options.get("custom-setup-commands", None):
-            env_worker += self.run_options["custom-setup-commands"]
-
-        # Now checking for conda environment  conda-env:true
-        if self.run_options.get("conda-env", False):
-            env_worker.append(f'export PATH={os.environ["CONDA_PREFIX"]}/bin:$PATH')
-            if "CONDA_ROOT_PREFIX" in os.environ:
-                env_worker.append(f"{os.environ['CONDA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
-            elif "MAMBA_ROOT_PREFIX" in os.environ:
-                env_worker.append(f"{os.environ['MAMBA_ROOT_PREFIX']} activate {os.environ['CONDA_DEFAULT_ENV']}")
-            else:
-                raise Exception("CONDA prefix not found in env! Something is wrong with your conda installation if you want to use conda in the dask cluster.")
-
-        # if local-virtual-env: true the dask job is configured to pickup
-        # the local virtual environment. 
-        if self.run_options.get("local-virtualenv", False):
-            env_worker.append(f"source {sys.prefix}/bin/activate")
-            pythonpath = sys.prefix.rsplit('/', 1)[0]
-            env_worker.append(f"export PYTHONPATH={pythonpath}:$PYTHONPATH")
-
-        return env_worker
-
     def prepare_jobs(self, splits):
         config_files = [ ]
         jobs_config = {
             "job_name": self.job_name,
             "job_dir": os.path.abspath(self.jobs_dir),
             "output_dir": os.path.abspath(self.outputdir),
+            "split_by_category": self.run_options["split-by-category"],
             "config_pkl_total": f"{os.path.abspath(self.outputdir)}/configurator.pkl",
             "jobs_list": {}
         }
@@ -199,8 +175,23 @@ class ExecutorFactoryCondorCERN(ExecutorFactoryManualABC):
         abs_jobdir_path = os.path.abspath(self.jobs_dir)
         os.makedirs(f"{self.jobs_dir}/logs", exist_ok=True)
         
-        env_extras_list=self.get_worker_env()
+        env_extras_list=get_worker_env(self.run_options,self.x509_path,"condor")
         env_extras= "\n".join(env_extras_list)
+
+        pythonpath = sys.prefix.rsplit('/', 1)[0]
+
+        if self.run_options["split-by-category"]:
+            splitcommands = '''
+    cd output
+    split-output output_all.coffea -b category
+    rm output_all.coffea
+    for f in *.coffea; do
+        cp "$f" "$3/${f%.coffea}_job_$1.coffea"
+    done
+    cd ..
+'''
+        else:
+            splitcommands = "cp output/output_all.coffea $3/output_job_$1.coffea"
 
         script = f"""#!/bin/bash
 {env_extras}
@@ -211,11 +202,12 @@ rm -f $JOBDIR/job_$1.idle
 
 echo "Starting job $1"
 touch $JOBDIR/job_$1.running
-pocket-coffea run --cfg $2 -o output EXECUTOR --chunksize $4
+
+python {pythonpath}/pocket_coffea/scripts/runner.py --cfg $2 -o output EXECUTOR --chunksize $4
 # Do things only if the job is successful
 if [ $? -eq 0 ]; then
     echo 'Job successful'
-    cp output/output_all.coffea $3/output_job_$1.coffea
+    {splitcommands}
 
     rm $JOBDIR/job_$1.running
     touch $JOBDIR/job_$1.done
@@ -287,35 +279,128 @@ echo 'Done'"""
         with open(f"{self.jobs_dir}/jobs_config.yaml") as f:
             jobs_config = yaml.safe_load(f)
 
+        if jobs_to_recreate == "auto":
+            failedjobs = [f.replace(".failed","") for f in os.listdir(self.jobs_dir) if f.endswith(".failed")]
+            runningjobs = [f.replace(".running","") for f in os.listdir(self.jobs_dir) if f.endswith(".running")]
+            idlejobs = [f.replace(".idle","") for f in os.listdir(self.jobs_dir) if f.endswith(".idle")]
+            jobs_to_recreate = failedjobs + runningjobs + idlejobs
+            if len(jobs_to_recreate) == 0:
+                print(f"Could not automatically find *.failed/*.running/*.idle files in {self.jobs_dir}. All jobs probably succeeded! Exiting.")
+                exit()
+            jobs_to_recreate = ','.join(jobs_to_recreate)
+
         jobs_to_redo = []
         for j in jobs_to_recreate.split(","):
             if not j.startswith("job_"):
                 jobs_to_redo.append(f"job_{j}")
+            else:
+                jobs_to_redo.append(j)
         print(f"Recreating jobs: {jobs_to_redo}")
-        # Check if the job is in the list of jobs to recreate
+
+        # Check which jobs failed due to an XRootD error:
+        # for such files we want to find an alternate site
+        xrootdfailurefilelist = os.popen(f"grep -il {self.jobs_dir}/logs/*.err -e 'XRootD error'").read().split()
+        xrootdfailurejoblist = ["job_"+f.split("/")[-1].split(".")[-2] for f in xrootdfailurefilelist]
+        # move processed logs to a backup directory
+        if len(xrootdfailurefilelist) > 0:
+            backupdir = f"{self.jobs_dir}/logs/processed"
+            os.system(f"mkdir -p {backupdir}")
+            os.system(f"mv {' '.join(xrootdfailurefilelist)} {backupdir}")
+
+        sitemap = get_xrootd_sites_map()
+        
         for job in jobs_to_redo:
+            # Check if the job is in the list of jobs to recreate
             if job not in jobs_config["jobs_list"]:
                 print(f"Job {job} not found in the list of jobs")
                 continue
-            # Open the configurator and modify the fileset.
-            # This is usually done to change a file location
-            # Load the configurator
-            config = cloudpickle.load(open(f"{self.jobs_dir}/config_{job}.pkl", "rb"))
-            # Modify the fileset
-            config.set_filesets_manually(jobs_config["jobs_list"][job]["filesets"])
-            # Save the configurator
-            cloudpickle.dump(config, open(f"{self.jobs_dir}/config_{job}.pkl", "wb"))
+
+            # If the job failed due to XRootD error, find an alternative site
+            if job in xrootdfailurejoblist:
+                print(f"Replacing input files in {job} since it failed due to an XRootD error.")
+                current_fileset = jobs_config["jobs_list"][job]["filesets"]
+                new_fileset = deepcopy(current_fileset)
+                for sample, dct in new_fileset.items():
+                    newfllist = []
+                    for fl in dct['files']:
+                        newfl = find_other_file(fl,sitemap)
+                        newfllist.append(newfl)
+                    new_fileset[sample]['files'] = newfllist
+                
+                # Update files in the configurator
+                config = cloudpickle.load(open(f"{self.jobs_dir}/config_{job}.pkl", "rb"))
+                config.set_filesets_manually(new_fileset)
+                cloudpickle.dump(config, open(f"{self.jobs_dir}/config_{job}.pkl", "wb"))
+
+            # If the job failed due to timeout, increase the timelimit
+            if job in runningjobs:
+                update_queue(f"{self.jobs_dir}/{job}.sub",job)
+
             # Resubmit the job
             dry_run = self.run_options.get("dry-run", False)
             if dry_run:
                 print(f"Dry run, not resubmitting  {job}")
             else:
-                os.system(f"rm {self.jobs_dir}/{job}.failed")
+                if job in failedjobs:
+                    os.system(f"rm {self.jobs_dir}/{job}.failed")
+                elif job in runningjobs:
+                    os.system(f"rm {self.jobs_dir}/{job}.running")
                 os.system(f"touch {self.jobs_dir}/{job}.idle")
                 os.system(f"cd {self.jobs_dir} && condor_submit {job}.sub")
                 print(f"Resubmitted {job}")
 
+def find_other_file(filepath,sitemap):
+    if filepath.startswith("root:/"):
+        rootpref = filepath.split("/store/")[0]
+        file = "/store/"+filepath.split("/store/")[1]
+    else:
+        rootpref = None
+        file = filepath
+    
+    command = f'dasgoclient -query="site file={file}"'    
+    sites = os.popen(command,'r').read().split()
+    for site in sites:
+        if site not in sitemap:
+            continue
+        sitepath = sitemap[site]
+        if not isinstance(sitepath,str):
+            continue
+        if rootpref:
+            if rootpref in sitepath or sitepath in rootpref:
+                continue
+        return sitepath+file
+                        
+    print(f"WARNING: No alternative site found for {filepath}. Redoing with the same file!")
+    return filepath    
 
+def update_queue(subfile,job):
+    with open(subfile, 'r') as fl:
+        lines = fl.readlines()
+    
+    with open(subfile, 'w') as fl:
+        for ln in lines:
+            if ln.startswith("+JobFlavour"):
+                q = ln.split('"')[-2]
+                idx = queues.index(q)
+                if idx + 1 < len(queues):
+                    newq = queues[idx+1]
+                    print(f"Bumping {job} from {q} to {newq}")
+                else:
+                    print(f"{job}: Already at the highest queue! Cannot bump up.")
+                    newq = q
+                fl.write(f'+JobFlavour = "{newq}"\n')
+            else:
+                fl.write(ln)
+
+queues = [
+    "espresso",
+    "microcentury",
+    "longlunch",
+    "workday",
+    "tomorrow",
+    "testmatch",
+    "nextweek"
+]
                 
 def get_executor_factory(executor_name, **kwargs):
     if executor_name == "iterative":

--- a/pocket_coffea/parameters/executor_options_defaults.yaml
+++ b/pocket_coffea/parameters/executor_options_defaults.yaml
@@ -36,6 +36,7 @@ condor@lxplus:
   conda-env: false
   local-virtualenv: false
   max-retries: 3
+  split-by-category: false
 
 
 dask@T3_CH_PSI:

--- a/pocket_coffea/scripts/merge_outputs.py
+++ b/pocket_coffea/scripts/merge_outputs.py
@@ -38,9 +38,9 @@ def merge_group_reduction(output_files, N_reduction=5, cachedir="merge_cache", m
                 if result is None:
                     result = batch_acc
                 else:
-                    result = func([result, batch_acc])
-                if verbose:                    
-                    mem_usage = psutil.Process(os.getpid()).memory_info().rss / 1024**3
+                    result = func([result, batch_acc])                                   
+                mem_usage = psutil.Process(os.getpid()).memory_info().rss / 1024**3
+                if verbose: 
                     print(f"Current memory usage: {mem_usage:.3f} GB ({mem_usage/max_mem_gb*100:.1f}%)")
                 del batch_acc
                 progress.update(task1, advance=len(batch))

--- a/pocket_coffea/scripts/merge_outputs.py
+++ b/pocket_coffea/scripts/merge_outputs.py
@@ -1,7 +1,7 @@
 from coffea.util import load, save
 from coffea.processor import accumulate 
 import click
-import os
+import os, sys
 from rich import print
 from rich.console import Console
 from rich.progress import Progress
@@ -11,31 +11,98 @@ from pocket_coffea.utils.filter_output import compare_dict_types
 from pocket_coffea.utils.skim import save_skimed_dataset_definition
 from itertools import islice
 from functools import reduce
+import pickle
+from glob import glob
+import psutil, gc
+mem_threshold = 0.5 # ~50% + memory needed to dump files, is the empirical threshold on lxplus
 
-def merge_group_reduction(output_files, N_reduction=5):
+
+def merge_group_reduction(output_files, N_reduction=5, cachedir="merge_cache", max_mem_gb=8, verbose=False):
     with Progress() as progress:
         task1 = progress.add_task("[red]Merging...", total=len(output_files))
     
         def reduce_in_groups(func, iterable, group_size):
             result = None
-            it = iter(iterable)
-            while batch := list(islice(it, group_size)):
-                loaded_batch = [load(f) for f in batch]
-                if result is None:
-                    result = func(loaded_batch)
-                else:
-                    result = func([result, func(loaded_batch)])
-                progress.update(task1, advance=len(batch))
-            return result
-       
-        return reduce_in_groups(accumulate, output_files, N_reduction)
-        
+            if isinstance(iterable,list):
+                it = iter(iterable)
+            else:
+                it = iterable
 
-def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False):
+            while batch := list(islice(it, group_size)):
+                if verbose:
+                    filesize = sum([os.path.getsize(f) for f in batch])/1024**3
+                    print(f"File size (on disk) to load: {filesize:.3f} GB")
+                loaded_batch = [load(f) for f in batch]
+                batch_acc = func(loaded_batch)
+                del loaded_batch
+                if result is None:
+                    result = batch_acc
+                else:
+                    result = func([result, batch_acc])
+                if verbose:                    
+                    mem_usage = psutil.Process(os.getpid()).memory_info().rss / 1024**3
+                    print(f"Current memory usage: {mem_usage:.3f} GB ({mem_usage/max_mem_gb*100:.1f}%)")
+                del batch_acc
+                progress.update(task1, advance=len(batch))
+                if mem_usage > max_mem_gb * mem_threshold:
+                    # return the result so-far, and remaining iterator
+                    return result, it
+                
+            return result, None
+
+        itr = output_files
+        counter = 0
+        while itr:
+            result, itr = reduce_in_groups(accumulate, itr, N_reduction)
+            if counter==0 and itr is None:
+                # Got full merge in one pass, no need to cache intermediate results
+                return result
+            else:
+                # We are here because memory usage of "result" exceeded max_memory. Cache it on disk and start again.
+                os.system(f"mkdir -p {cachedir}")
+                interm_output = f"{cachedir}/merge_{counter}.coffea"
+                print(f"[green]Dumping intermediate result to {interm_output} since memory utilization of merged object exceeded {mem_threshold*100:.0f}% of {max_mem_gb:.1f} GB.[/]")
+                save(result, interm_output)
+                if verbose: 
+                    print(f"Intermediate output size on disk: {os.path.getsize(interm_output)/1024**3:.3f} GB")
+                print()
+                del result
+                gc.collect()
+                counter += 1
+
+    new_output_files = glob(f"{cachedir}/*.coffea")
+    print(f"[green][b]Since outputs were too large to fit in memory, I created {len(new_output_files)} fragmented output files.[/] These may be moved to and merged on a high-memory machine.[/]")
+    exit()
+
+def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, N_reduction=5, max_mem_gb=None, cache_dir=None, verbose=False):
     '''Merge coffea output files'''
+    if jobs_config is not None:
+        # read the job configuration file
+        print(f"Reading job configuration file {jobs_config}")
+        with open(jobs_config, 'r') as f:
+            job_config = yaml.safe_load(f)
+        if "split_by_category" in job_config:   # Ensure back compatibility
+            split_by_category = job_config["split_by_category"]
+            print("Jobs were split by category, hence will merge per category.")
+        else:
+            split_by_category = False
+
+    if outputfile is None:
+        if jobs_config is None:
+            print("[red]Need to specify outputfile (-o) if no job configuration (-jc) is specified![/]")
+            exit(1)
+        else:
+            outputfile = os.path.join(job_config['output_dir'], "output_merged.coffea")
+            print(f"Setting {outputfile} as output file.")
+
     if os.path.exists(outputfile) and not force:
         print(f"[red]Output file {outputfile} already exists. Use -f to overwrite it.")
         exit(1)
+    
+    if max_mem_gb is None:
+        max_mem_gb = psutil.virtual_memory().available / 1024 ** 3
+        print(f"Setting max memory usage to {max_mem_gb:.1f} GB. Output will be split into smaller chunks if memory usage exceeds {mem_threshold*100:.0f}%.")
+        print("[b]If you still see OOM kills, set a lower max memory with -m.[/]")
                 
     # quite different behaviour in case of just files merging, or in case of merging jobs
     if jobs_config is None:
@@ -56,55 +123,106 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False):
                 if type_mismatches[i]:
                     print(f"    {f}")
             raise TypeError("Type mismatch found between the values of the input dictionaries. Please check the input files.")
-
-        total_out =  merge_group_reduction(inputfiles, N_reduction=5)
+        
+        if cache_dir is None:
+            cache_dir = '/'.join(output_files[0].split("/")[:-1])+"/merge_cache"
+        total_out =  merge_group_reduction(inputfiles, N_reduction=N_reduction, cachedir=cache_dir, max_mem_gb=max_mem_gb, verbose=verbose)
         save(total_out, outputfile)
         print(f"[green]Output saved to {outputfile}")
 
     else:
-        # read the job configuration file
-        print(f"Reading job configuration file {jobs_config}")
-        with open(jobs_config, 'r') as f:
-            job_config = yaml.safe_load(f)
-
         jobs_list = job_config['jobs_list']
         alldone = True
         output_files = []
+        output_files_by_category = {}
         # First check that the jobs are done
-        for job_name, job in jobs_list.items():
-            # Check output
-            if not os.path.exists(job['output_file']):
-                print(f"[red]Job {job_name} output is missing[/]")
-                alldone = False
-            output_files.append(job['output_file'])
+        with Progress() as progress:
+            task_ = progress.add_task("[red]Checking output files form jobs...", total=len(list(jobs_list.keys())))
+            for job_name, job in jobs_list.items():
+                # Check output
+                if split_by_category:
+                    # Listing all files with glob is slow   
+                    this_job_outputs = glob(job['output_file'].replace("job_","*job_"))
+                    if len(this_job_outputs) == 0:
+                        print(f"[red]Job {job_name} output is missing[/]")
+                        alldone = False
+                    else:
+                        output_files.extend(this_job_outputs)
+                        for this_job_output in this_job_outputs:
+                            this_category = "category" + this_job_output.split("category")[1].split("_")[0]
+                            if this_category not in output_files_by_category:
+                                output_files_by_category[this_category] = []
+                            output_files_by_category[this_category].append(this_job_output)
+                else:
+                    if not os.path.exists(job['output_file']):
+                        print(f"[red]Job {job_name} output is missing[/]")
+                        alldone = False
+                    output_files.append(job['output_file'])
+                progress.update(task_, advance=1)
+
         if not alldone:
             print(f"[red]Not all jobs are done yet[/]")
             exit(1)
         print(f"[green]All jobs are done[/]")
-        print(output_files)
 
-        # Loading the configurator
+        noutput = len(output_files)
+        if noutput < 100:
+            print(output_files)
+        else:
+            print(f"Found {noutput} output files.")
+
         cloudpickle_config = job_config['config_pkl_total']
         with open(cloudpickle_config, 'rb') as f:
             configurator = cloudpickle.load(f)
 
-        # Since it was jobs, there was no postprocessing
-        # we do it now after merging all the output
-        print(f"Merging output...")
-        total_output = merge_group_reduction(output_files, N_reduction=5)
+        if split_by_category:
+            output_file_bunches = list(output_files_by_category.values())
+            suffs = list(output_files_by_category.keys())
+        else:
+            output_file_bunches = [output_files]
+            suffs = [None]
+
+        for this_output_files,suff in zip(output_file_bunches,suffs):
+            # Output file will be renamed with suffix if this is category-split
+            thisoutputfile = outputfile
+            if suff:
+                thisoutputfile = thisoutputfile.replace(".coffea",f"_{suff}.coffea")
             
-        # Apply postprocessing
-        print(f"Applying postprocessing...")
-        total_output = configurator.processor_instance.postprocess(total_output)
+            # Check if output exists, again because these might be category-split outputs
+            if os.path.exists(thisoutputfile) and not force:
+                print(f"[red]Output file {thisoutputfile} already exists. Use -f to overwrite it. Skipping.[/]")
+                continue
 
-        # In case of skimming jobs save the dataset definition (like in runner)
-        if configurator.save_skimmed_files:
-            print(f"[blue]Saving skimmed dataset definition[/]")
-            save_skimed_dataset_definition(total_output, f"{job_config['output_dir']}/skimmed_dataset_definition.json")
+            if suff:
+                print(f"[green]Doing set: {suff}[/]")
 
-        # Save the output
-        print(f"[green]Saving output to {outputfile}...[/]")
-        save(total_output, outputfile)
+            # Do larger files first, so that OOM kills happen early on rather than later
+            this_output_files = sorted(this_output_files, key=os.path.getsize, reverse=True)
+
+            # Since it was jobs, there was no postprocessing
+            # we do it now after merging all the output
+            print(f"Merging output...")
+            if cache_dir is None:
+                cache_dir = os.path.join(job_config['output_dir'],"merge_cache")
+            if suff:
+                cache_dir += f"_{suff}"
+            total_output = merge_group_reduction(this_output_files, N_reduction=N_reduction, cachedir=cache_dir, max_mem_gb=max_mem_gb, verbose=verbose)
+                
+            # Apply postprocessing
+            print(f"Applying postprocessing...")
+            total_output = configurator.processor_instance.postprocess(total_output)
+
+            # In case of skimming jobs save the dataset definition (like in runner)
+            if configurator.save_skimmed_files:
+                print(f"[blue]Saving skimmed dataset definition[/]")
+                save_skimed_dataset_definition(total_output, f"{job_config['output_dir']}/skimmed_dataset_definition.json")
+
+            # Save the output            
+            print(f"[green]Saving output to {thisoutputfile}...[/]")
+            save(total_output, thisoutputfile)
+
+            del total_output
+
         print(f"[green]Done![/]")
 
 @click.command()
@@ -117,7 +235,7 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False):
 @click.option(
     "-o",
     "--outputfile",
-    required=True,
+    required=False,
     type=str,
     help="Output file",
 )
@@ -128,6 +246,36 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False):
     type=str,
     help="Job configuration file",
 )
+@click.option(
+    "-n",
+    "--reduction",
+    required=False,
+    type=int,
+    default=5,
+    help="Number of output files to accumulate at a time",
+)
+@click.option(
+    "-m",
+    "--max_mem_gb",
+    required=False,
+    type=float,
+    help="Max memory (in GB) allotted to the accumulated result, after which it is dumped to disk. Use about one-fourth of available RAM, e.g. 8 for a 32GB RAM machine.",
+)
+@click.option(
+    "-c",
+    "--cache_dir",
+    required=False,
+    type=str,
+    default=None,
+    help="Cache dir for intermediate dumps, if any",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Display memory consumed by objects",
+)
+
 # overwrite option
 @click.option(
     "-f",
@@ -136,9 +284,9 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False):
     help="Overwrite output file if it exists",
 )
 
-def main(inputfiles, outputfile, jobs_config, force):
+def main(inputfiles, outputfile, jobs_config, force, reduction, max_mem_gb, cache_dir, verbose):
     '''Merge coffea output files'''
-    merge_outputs(inputfiles, outputfile, jobs_config, force)
+    merge_outputs(inputfiles, outputfile, jobs_config, force, reduction, max_mem_gb, cache_dir, verbose)
 
 if __name__ == "__main__":
     main()

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -64,10 +64,10 @@ def make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
                 all_files.extend(valid_files)        
 
         print("[b]Since we are splitting by category, will handle only one file per pass.[/]")
-        for file in all_files:
+        for ifl, file in enumerate(all_files):
             make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, [file],
                workers, only_cat, only_year, only_syst, exclude_hist, only_hist, split_systematics, partial_unc_band, no_syst,
-               overwrite, log_x, log_y, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare, index_file, no_cache, False)
+               overwrite or ifl > 0, log_x, log_y, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare, index_file, no_cache, False)
             gc.collect()
 
         print("[green]Done making plots for all category-split files![/]")

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -45,8 +45,8 @@ import concurrent.futures
 @click.option('--no-cache', is_flag=True, help='Do not cache the histograms for faster plotting', required=False, default=False)
 @click.option('--split-by-category', is_flag=True, help='If split-by-category was used during running and merging', required=False, default=False)
 
-def make_plots(*args):
-    return make_plots_core(*args)
+def make_plots(*args, **kwargs):
+    return make_plots_core(*args, **kwargs)
 
 def make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
                workers, only_cat, only_year, only_syst, exclude_hist, only_hist, split_systematics, partial_unc_band, no_syst,

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -10,6 +10,8 @@ from pocket_coffea.utils.plot_utils import PlotManager
 from pocket_coffea.parameters import defaults
 from coffea.processor import accumulate 
 import click
+import gc
+from rich import print
 
 import concurrent.futures
 
@@ -41,11 +43,35 @@ import concurrent.futures
 @click.option('--compare', is_flag=True, help='Plot comparison of the samples, instead of data/MC', required=False, default=False)
 @click.option('--index-file', type=str, help='Path of the index file to be copied recursively in the plots directory and its subdirectories', required=False, default=None)
 @click.option('--no-cache', is_flag=True, help='Do not cache the histograms for faster plotting', required=False, default=False)
+@click.option('--split-by-category', is_flag=True, help='If split-by-category was used during running and merging', required=False, default=False)
 
-def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
+def make_plots(*args):
+    return make_plots_core(*args)
+
+def make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
                workers, only_cat, only_year, only_syst, exclude_hist, only_hist, split_systematics, partial_unc_band, no_syst,
-               overwrite, log_x, log_y, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare, index_file, no_cache):
+               overwrite, log_x, log_y, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare, index_file, no_cache, split_by_category):
     '''Plot histograms produced by PocketCoffea processors'''
+
+    if split_by_category: 
+        if not inputfiles:
+            all_files = glob.glob(f"{input_dir}/*merged_category*.coffea")
+        else:
+            all_files = []
+            for pattern in inputfiles:
+                matched_files = glob.glob(pattern)  # Expand wildcards
+                valid_files = [file for file in matched_files if os.path.isfile(file)]
+                all_files.extend(valid_files)        
+
+        print("[b]Since we are splitting by category, will handle only one file per pass.[/]")
+        for file in all_files:
+            make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, [file],
+               workers, only_cat, only_year, only_syst, exclude_hist, only_hist, split_systematics, partial_unc_band, no_syst,
+               overwrite, log_x, log_y, density, verbose, format, systematics_shifts, no_ratio, no_systematics_ratio, compare, index_file, no_cache, False)
+            gc.collect()
+
+        print("[green]Done making plots for all category-split files![/]")
+        exit()
 
     # Using the `input_dir` argument, read the default config and coffea files (if not set with argparse):
     if cfg==None:
@@ -54,6 +80,8 @@ def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
         inputfiles = (os.path.join(input_dir, "output_all.coffea"),)
     if outputdir==None:
         outputdir = os.path.join(input_dir, "plots")
+
+    
 
     # Load yaml file with OmegaConf
     if cfg[-5:] == ".yaml":
@@ -71,7 +99,7 @@ def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
     try:
         OmegaConf.resolve(parameters)
     except Exception as e:
-        print("Error during resolution of OmegaConf parameters magic, please check your parameters files.")
+        print("[red]Error during resolution of OmegaConf parameters magic, please check your parameters files.[/]")
         raise(e)
 
     style_cfg = parameters['plotting_style']
@@ -86,7 +114,7 @@ def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
 
     def load_single_file(file):
         """Helper function to load a single file."""
-        print(f"Loading: {file}")
+        print(f"[pink]Loading: {file}[/]")
         return load(file)
     # Use ThreadPoolExecutor to load files concurrently
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -140,7 +168,7 @@ def make_plots(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
         else:
             plotter.plot_datamc_all(syst=(not no_syst), ratio = (not no_ratio), spliteras=False, format=format)
 
-    print("Output plots are saved at: ", outputdir)
+    print(f"[green]Output plots are saved at: {outputdir}[/]")
 
 
 if __name__ == "__main__":

--- a/pocket_coffea/scripts/split_output.py
+++ b/pocket_coffea/scripts/split_output.py
@@ -2,26 +2,41 @@ import os
 from coffea.util import load, save
 import click
 from rich import print
-from pocket_coffea.utils.filter_output import filter_output_by_year
+from pocket_coffea.utils.filter_output import filter_output_by_year, filter_output_by_category
 
-def split_output(inputfile, outputfile, overwrite):
+def split_output(inputfile, outputfile, by, ncategory_per_file, overwrite):
     '''Split coffea output files'''
     if outputfile is None:
-        outputfile = inputfile.replace(".coffea", "_{}.coffea")
+        outputfile = inputfile.replace("_all.coffea", "_{}.coffea")
     else:
-        outputfile = outputfile.replace(".coffea", "_{}.coffea")
+        outputfile = outputfile.replace("_all.coffea", "_{}.coffea")
     print(f"[blue]Reading input file: {inputfile}")
     out_all = load(inputfile)
-    years = list(out_all["datasets_metadata"]["by_datataking_period"].keys())
-    outputfiles = {year : outputfile.format(year) for year in years}
-    print(f"[blue]Splitting output by year. {len(years)} output files will be saved:[/]")
-    print(sorted(outputfiles.values()))
-    for year, outputfile in outputfiles.items():
-        out = filter_output_by_year(out_all, year)
-        if os.path.exists(outputfile) and not overwrite:
-            raise FileExistsError(f"Output file {outputfile} already exists. Use --overwrite to overwrite the output files.")
-        save(out, outputfile)
-        print(f"[green]Output saved to {outputfile}")
+
+    if by == "year":
+        years = list(out_all["datasets_metadata"]["by_datataking_period"].keys())
+        outputfiles = {year : outputfile.format(year) for year in years}
+        print(f"[blue]Splitting output by year. {len(years)} output files will be saved:[/]")
+        print(sorted(outputfiles.values()))
+        for year, outputfile in outputfiles.items():
+            out = filter_output_by_year(out_all, year)
+            if os.path.exists(outputfile) and not overwrite:
+                raise FileExistsError(f"Output file {outputfile} already exists. Use --overwrite to overwrite the output files.")
+            save(out, outputfile)
+            print(f"[green]Output saved to {outputfile}")
+
+    elif by == "category" or by == "categories":
+        allcategories = sorted(list(out_all["sumw"].keys()))
+        ncats = len(allcategories)
+        categoryblocks = [allcategories[i:i+ncategory_per_file] for i in range(0, ncats, ncategory_per_file)]
+        print(f"[blue]Splitting output by category: into {len(categoryblocks)} files, each with {ncategory_per_file} categories, totalling {ncats} categories.[/]")
+        for ib, block in enumerate(categoryblocks):
+            out = filter_output_by_category(out_all, block)
+            thisoutput = outputfile.format(f"category{ib}")
+            if os.path.exists(thisoutput) and not overwrite:
+                raise FileExistsError(f"Output file {thisoutput} already exists. Use --overwrite to overwrite the output files.")
+            save(out, thisoutput)
+            print(f"[green]Output {ib+1}/{len(categoryblocks)} saved to {thisoutput}")
 
 @click.command()
 @click.argument(
@@ -39,14 +54,30 @@ def split_output(inputfile, outputfile, overwrite):
     help="Output file",
 )
 @click.option(
+    "-b",
+    "--by",
+    required=False,
+    default="year",
+    type=str,
+    help="Split by year or by category",
+)
+@click.option(
+    "-n",
+    "--ncategory-per-file",
+    required=False,
+    default=8,
+    type=int,
+    help="If splitting by category, specify how many categories go into one output.",
+)
+@click.option(
     "--overwrite",
     is_flag=True,
     help="Overwrite output file if it already exists",
 )
 
-def main(inputfile, outputfile, overwrite):
+def main(inputfile, outputfile, by, ncategory_per_file, overwrite):
     '''Split coffea output files'''
-    split_output(inputfile, outputfile, overwrite)
+    split_output(inputfile, outputfile, by, ncategory_per_file, overwrite)
 
 if __name__ == "__main__":
     main()

--- a/pocket_coffea/utils/filter_output.py
+++ b/pocket_coffea/utils/filter_output.py
@@ -33,6 +33,29 @@ def filter_output_by_year(o, year):
     o_filtered["datasets_metadata"]["by_dataset"] = defaultdict(dict, {k : val for k, val in o["datasets_metadata"]["by_dataset"].items() if val["year"] == year})
     return o_filtered
 
+def filter_output_by_category(o, categories):
+    allkeys = list(o.keys())
+    o_filtered = {key : {} for key in allkeys}
+
+    keys_2d = ["sumw", "sumw2", "cutflow"]
+    for key in keys_2d:
+        allkeys.remove(key)
+        o_filtered[key] = {k : val for k, val in o[key].items() if k in categories+['initial', 'skim', 'presel']}
+
+    keys_4d = ["variables"]
+    for key in keys_4d:
+        allkeys.remove(key)
+        for k, val in o[key].items():
+            o_filtered[key][k] = {}
+            for s, _dict in val.items():
+                o_filtered[key][k][s] = {}
+                for sam, hist in _dict.items():
+                    o_filtered[key][k][s][sam] = hist[{'cat' : categories}]
+
+    for key in allkeys:
+        o_filtered[key] = o[key]
+    return o_filtered
+
 def compare_dict_types(d1, d2, path=""):
     """
     Recursively compare the types of values between two dictionaries.

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -12,7 +12,6 @@ from decimal import Decimal
 import numpy as np
 import awkward as ak
 import hist
-import pickle
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -234,7 +233,7 @@ class PlotManager:
                     cache=self.cache
                 )
         del self.hists_to_plot
-        
+
         if self.save:
             self.make_dirs()
             if self.index_file is not None:

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 import numpy as np
 import awkward as ak
 import hist
+import pickle
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -204,7 +205,7 @@ class PlotManager:
                         del hs[sample]
                 vs[year] = hs
             self.hists_to_plot[variable] = vs
-
+        
         for variable, histoplot in self.hists_to_plot.items():
             for year, h_dict in histoplot.items():
                 if self.only_year and year not in self.only_year:
@@ -232,6 +233,8 @@ class PlotManager:
                     verbose=self.verbose,
                     cache=self.cache
                 )
+        del self.hists_to_plot
+        
         if self.save:
             self.make_dirs()
             if self.index_file is not None:
@@ -468,7 +471,7 @@ class Shape:
         self.is_data_only = len(self.samples_mc) == 0
 
         if not self.is_data_only:
-            self.syst_manager = SystManager(self, self.style)
+            self.syst_manager = SystManager(self, self.style, verbose=self.verbose)
 
     @property
     def dense_axes(self):
@@ -1521,9 +1524,10 @@ class Shape:
 class SystManager:
     '''This class handles the systematic uncertainties of 1D MC histograms.'''
 
-    def __init__(self, shape: Shape, style: Style) -> None:
+    def __init__(self, shape: Shape, style: Style, verbose: int = 1) -> None:
         self.shape = shape
         self.style = style
+        self.verbose = verbose
         assert all(
             [
                 (var == "nominal") | var.endswith(("Up", "Down"))
@@ -1547,10 +1551,10 @@ class SystManager:
     def update(self, cat, stacks):
         '''Updates the dictionary of systematic uncertainties with the new cached stacks.'''
         for syst_name in self.systematics:
-            self.syst_dict[cat][syst_name] = SystUnc(self.shape, stacks, syst_name)
+            self.syst_dict[cat][syst_name] = SystUnc(self.shape, stacks, syst_name, verbose=self.verbose)
 
     def total(self, cat):
-        return SystUnc(self.shape, name="total", syst_list=list(self.syst_dict[cat].values()))
+        return SystUnc(self.shape, name="total", syst_list=list(self.syst_dict[cat].values()), verbose=self.verbose)
 
     def mcstat(self, cat):
         return self.syst_dict[cat]["mcstat"]
@@ -1567,12 +1571,13 @@ class SystUnc:
     returning a `SystUnc` instance corresponding to their sum in quadrature.'''
 
     def __init__(
-            self, shape: Shape, stacks: dict = None, name: str = None, syst_list: list = None
+            self, shape: Shape, stacks: dict = None, name: str = None, syst_list: list = None, verbose: int = 1
     ) -> None:
         self.shape = shape
         self.style = shape.style
         self.name = name
         self.is_mcstat = self.name == "mcstat"
+        self.verbose = verbose
 
         # Initialize the arrays of the nominal yield and squared errors as 0
         self.nominal = 0.0
@@ -1609,7 +1614,7 @@ class SystUnc:
         '''Sum in quadrature of two systematic uncertainties.
         In case multiple objects are summed, the information on the systematic uncertainties that
         have been summed is stored in self.syst_list.'''
-        return SystUnc(self.shape, name=f"{self.name}_{other.name}", syst_list=[self, other])
+        return SystUnc(self.shape, name=f"{self.name}_{other.name}", syst_list=[self, other], verbose=self.verbose)
 
     @property
     def up(self):
@@ -1681,10 +1686,11 @@ class SystUnc:
                 if not all(stacks["mc_nominal_sum"].values() == h_var):
                     # Then, we check if the variation is empty
                     if all(h_var == np.zeros_like(h_var)):
-                        print(
-                            f"WARNING: Empty variation found for systematic {self.name} in histogram {self.shape.name}. "+
-                            "Please check if the input histograms are filled properly."
-                        )
+                        if self.verbose>=1:
+                            print(
+                                f"WARNING: Empty variation found for systematic {self.name} in histogram {self.shape.name}. "+
+                                "Please check if the input histograms are filled properly."
+                            )
 
     def _get_err2_from_syst(self):
         '''Method used in the constructor to instanstiate a SystUnc object from


### PR DESCRIPTION
The main feature addition is splitting outputs into different categories so that large .coffea files need not be handled in memory during plotting. This enables analyses that have many categories which makes the `merge-output` script fail.

New features:

**`condor@lxplus` executor:**

- ~~Unfortunately some overlaps with #358~~ Resolved
- `--split-by-category` option which splits `output_all.coffea` into several chunks, each containing disjoint set of 8 categories. It calls `split-output`, which now has a new feature `--by category`, which in turn calls another new function, `utils.filter_output.filter_output_by_category`.

**Thoughts:** Coding-wise, this would be easier and more natural to handle by directly calling `utils.filter_output.filter_output_by_category` on `output` within `runner`. But this felt more like an executor's job (specifically, only for manual executors) so I decided to make `--split-by-category` an executor option instead of cluttering `runner`.

**`merge-output` script:**

- **Feature 1:** If memory usage exceeds 50% of available memory, an OOM kill is impending. Avoid this by dumping to disk the accumulated result so far. Then proceed with the remaining files. This is necessary when accumulating a large number of `categories × variables × systematics` even while using a small `N_reduction` value, since the accumulated `result` keeps growing in memory when more categories get added by a new file.
- **Feature 2:** If `--split-by-category` was saved as true in the `jobs_config`, it merges per category-group in a for loop instead of merging all files once. Thus it produces as many outputs as category-groups, instead of just one.
- Overall improved memory handling by explicitly deleting intermediate python objects from memory. 

**`make-plots` script:**

- Handle `--split-by-category` (explicit flag added) by calling itself *once per* category-group.

**`plot_utils` script:**

- Better handling of `--verbose`.
- Delete histograms from memory once `Shape` is created.

**Documentation:**

- Added section "Split large outputs into categories" in `recipes`.