### PR TITLE
Fixed typo for 2022EE smearing lepton sf

### DIFF
--- a/pocket_coffea/parameters/lepton_scale_factors.yaml
+++ b/pocket_coffea/parameters/lepton_scale_factors.yaml
@@ -114,7 +114,7 @@ lepton_scale_factors:
           file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2022_Summer22EE/electronSS.json.gz
           correction_name:
             scale: "Scale"
-            smear: "Smear"
+            smear: "Smearing"
         '2023_preBPix':
           file: /cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2023_Summer23/electronSS.json.gz
           correction_name:


### PR DESCRIPTION
Very small fix of a typo in the `lepton_scale_factors.yaml`.
"Smear" would not be found by PocketCoffea and lead to a crash, if `ElectronsScaleCalibrator`, so the smearing parameter needs to be named "Smearing".