### PR TITLE
Use absolute paths +  argument in split-output

### DIFF
--- a/pocket_coffea/executors/executors_lxplus.py
+++ b/pocket_coffea/executors/executors_lxplus.py
@@ -186,12 +186,11 @@ class ExecutorFactoryCondorCERN(ExecutorFactoryManualABC):
             runnercmd = "pocket-coffea run"
 
         # Specify output filename to split-output script ->
-        # This will save files such as output_CAT1.coffea, output_CAT2.coffea ...
+        # This will save files such as output_CAT1.coffea, output_CAT2.coffea (remove "_all" from split outputs)...
         if self.run_options["split-by-category"]:
-            output_filename = "output.coffea"
             splitcommands = f'''
                 cd {abs_output_path}
-                split-output output_all.coffea -b category -o {output_filename}
+                split-output output_all.coffea -b category -o output.coffea
                 rm output_all.coffea
                 for f in *.coffea; do
                     cp "$f" "$3/${{f%.coffea}}_job_$1.coffea"

--- a/pocket_coffea/executors/executors_lxplus.py
+++ b/pocket_coffea/executors/executors_lxplus.py
@@ -185,18 +185,20 @@ class ExecutorFactoryCondorCERN(ExecutorFactoryManualABC):
         else:
             runnercmd = "pocket-coffea run"
 
+        # Specify output filename to split-output script ->
+        # This will save files such as output_CAT1.coffea, output_CAT2.coffea ...
         if self.run_options["split-by-category"]:
-            splitcommands = '''
-    cd output
-    split-output output_all.coffea -b category
-    rm output_all.coffea
-    for f in *.coffea; do
-        cp "$f" "$3/${f%.coffea}_job_$1.coffea"
-    done
-    cd ..
-'''
+            output_filename = "output.coffea"
+            splitcommands = f'''
+                cd {abs_output_path}
+                split-output output_all.coffea -b category -o {output_filename}
+                rm output_all.coffea
+                for f in *.coffea; do
+                    cp "$f" "$3/${{f%.coffea}}_job_$1.coffea"
+                done
+            '''
         else:
-            splitcommands = "cp output/output_all.coffea $3/output_job_$1.coffea"
+            splitcommands = f"cp {abs_output_path}/output_all.coffea $3/output_job_$1.coffea"
 
         script = f"""#!/bin/bash
 {env_extras}


### PR DESCRIPTION
This PR implements a small patch to the new `ExecutorFactoryCondorCERN`.
I had to modify the bash script in `splitcommands`.

Improvements:

* When splitting output by category, the output filename is now explicitly set to `output.coffea` using the `-o` option so that the split outputs will be like `output_CAT1.coffea`, `output_CAT2.coffea` (remove `_all` subscript)
* The split-output command uses the absolute output path for consistency.
* The script now uses the absolute output path (`abs_output_path`) for all output file operations, both when splitting by category and when copying unsplit output files.

These changes are needed following commit https://github.com/PocketCoffea/PocketCoffea/commit/e934caf3ce804d18c58bfba9507eb22b040d380e.

@mondalspandan, could you have a look if the script will work as intended? Thanks!