### PR TITLE
condor@lxplus: Multiple attempts to copy; replace cp to eos with xrdcp; also copy columns output dir if local

### DIFF
--- a/pocket_coffea/executors/executors_lxplus.py
+++ b/pocket_coffea/executors/executors_lxplus.py
@@ -179,6 +179,24 @@ class ExecutorFactoryCondorCERN(ExecutorFactoryManualABC):
         env_extras= "\n".join(env_extras_list)
 
         pythonpath = sys.prefix.rsplit('/', 1)[0]
+
+        copy_command = "cp"
+        if abs_output_path.startswith("/eos/"):
+            abs_output_path = "root://eosuser.cern.ch/" + abs_output_path
+        if abs_output_path.startswith("root://eosuser.cern.ch/"):
+            copy_command = "xrdcp -f"
+
+        # Handle columns
+        columncommand = ""
+        if len(self.config.columns) > 0:
+            column_out_dir = self.config.workflow_options["dump_columns_as_arrays_per_chunk"]
+            if not os.path.isabs(column_out_dir) and not column_out_dir.startswith("root://eosuser.cern.ch/"):
+                # If the config contains an absolute path, then the
+                # parquets are written directly to disk (e.g. eos.)
+                # This may be unstable, but not much to do at the executor level
+                # Otherwise, copy the directory to outputdir
+                columncommand = f'run_with_retries "{copy_command} -r {column_out_dir} {abs_output_path}"'
+
         runnerpath = f"{pythonpath}/pocket_coffea/scripts/runner.py"
         if os.path.isfile(runnerpath):
             runnercmd = "python " + runnerpath
@@ -189,31 +207,44 @@ class ExecutorFactoryCondorCERN(ExecutorFactoryManualABC):
         # This will save files such as output_CAT1.coffea, output_CAT2.coffea (remove "_all" from split outputs)...
         if self.run_options["split-by-category"]:
             splitcommands = f'''
-                cd {abs_output_path}
-                split-output output_all.coffea -b category -o output.coffea
-                rm output_all.coffea
-                for f in *.coffea; do
-                    cp "$f" "$3/${{f%.coffea}}_job_$1.coffea"
-                done
-            '''
+    cd {abs_output_path}
+    split-output output_all.coffea -b category -o output.coffea
+    rm output_all.coffea
+    for f in *.coffea; do
+        run_with_retries "{copy_command} $f {abs_output_path}/${{f%.coffea}}_job_$1.coffea"
+    done
+'''
         else:
-            splitcommands = f"cp {abs_output_path}/output_all.coffea $3/output_job_$1.coffea"
+            splitcommands = f'run_with_retries "{copy_command} output/output_all.coffea {abs_output_path}/output_job_$1.coffea"'
 
         script = f"""#!/bin/bash
 {env_extras}
 
 JOBDIR={abs_jobdir_path}
 
+run_with_retries() {{
+    local cmd="$*"
+    for i in {{1..10}}; do
+        eval "$cmd" && return 0
+        sleep 10
+    done
+    echo "$cmd failed after 10 attempts."
+    rm $JOBDIR/job_$1.running
+    touch $JOBDIR/job_$1.failed
+    exit 1
+}}
+
 rm -f $JOBDIR/job_$1.idle
 
 echo "Starting job $1"
 touch $JOBDIR/job_$1.running
 
-{runnercmd} --cfg $2 -o output EXECUTOR --chunksize $4
+{runnercmd} --cfg $2 -o output EXECUTOR --chunksize $3
 # Do things only if the job is successful
 if [ $? -eq 0 ]; then
     echo 'Job successful'
     {splitcommands}
+    {columncommand}
 
     rm $JOBDIR/job_$1.running
     touch $JOBDIR/job_$1.done
@@ -222,7 +253,8 @@ else
     rm $JOBDIR/job_$1.running
     touch $JOBDIR/job_$1.failed
 fi
-echo 'Done'"""
+echo 'Done'
+"""
         
         if int(self.run_options["cores-per-worker"]) > 1:
             script = script.replace("EXECUTOR", f"--executor futures --scalout {self.run_options['cores-per-worker']}")
@@ -243,7 +275,7 @@ echo 'Done'"""
             '+JobFlavour': f'"{self.run_options["queue"]}"',
             'RequestCpus' : self.run_options['cores-per-worker'],
             'RequestMemory' : f"{self.run_options['mem-per-worker']}",
-            'arguments': f"$(ProcId) config_job_$(ProcId).pkl {abs_output_path} {self.run_options['chunksize']}",
+            'arguments': f"$(ProcId) config_job_$(ProcId).pkl {self.run_options['chunksize']}",
             'should_transfer_files':'YES',
             'when_to_transfer_output' : 'ON_EXIT',
             'transfer_input_files' : f"{abs_jobdir_path}/config_job_$(ProcId).pkl,{self.x509_path},{abs_jobdir_path}/job.sh",


### PR DESCRIPTION
This is to address #383 and the comments in it.

1. Make multiple attempts to copy using a bash function. Mark job as failed if copying any file fails after 10 attempts.
2. Whenever output directory is `/eos`, switch to `xrdcp -f` and prepend with `root://eosuser.cern.ch/`.
3. Copy column output directory too if a local column output path is specified.