### PR TITLE
Implementation of JEC calibrator using correctionlib

### DIFF
--- a/pocket_coffea/lib/calibrators/common/__init__.py
+++ b/pocket_coffea/lib/calibrators/common/__init__.py
@@ -1,7 +1,8 @@
-from .common import JetsCalibrator, METCalibrator, ElectronsScaleCalibrator, MuonsCalibrator, default_calibrators_sequence
+from .common import JetsCalibratorCorrlib, JetsCalibrator, METCalibrator, ElectronsScaleCalibrator, MuonsCalibrator, default_calibrators_sequence
 
 __all__ = [
     'JetsCalibrator',
+    'JetsCalibratorCorrlib'
     'METCalibrator', 
     'ElectronsScaleCalibrator',
     'MuonsCalibrator'

--- a/pocket_coffea/lib/calibrators/common/common.py
+++ b/pocket_coffea/lib/calibrators/common/common.py
@@ -2,8 +2,143 @@ from ..calibrator import Calibrator
 import numpy as np
 import awkward as ak
 import cachetools
-from pocket_coffea.lib.jets import jet_correction, met_correction_after_jec, load_jet_factory
+from pocket_coffea.lib.jets import jet_correction, met_correction_after_jec, load_jet_factory, jet_correction_corrlib
 from pocket_coffea.lib.leptons import get_ele_scaled, get_ele_smeared
+
+
+class JetsCalibratorCorrlib(Calibrator):
+    """
+    This calibator applies the JEC to the jets and their uncertainties. 
+    The set of calibrations to be applied is defined in the parameters file under the 
+    `jets_calibration.collection` section.
+    All the jet types that have apply_jec_MC or apply_jec_Data set to True will be calibrated.
+    If the pT regression is requested for a jet type, it should be done by the JetsPtRegressionCalibrator, 
+    this calibrator will raise an exception if configured to apply pT regression.
+    """
+    
+    name = "jet_calibration_corrlib"
+    has_variations = True
+    isMC_only = False
+
+    def __init__(self, params, metadata, **kwargs):
+        super().__init__(params, metadata, **kwargs)
+        self._year = metadata["year"]
+        self.jet_calib_param = self.params.jets_calibration
+        self.jets_calibrated = {}
+        self.jets_calibrated_types = []
+        # It is filled dynamically in the initialize method
+        self.calibrated_collections = []
+
+    def initialize(self, events):
+
+        # Load the calibration of each jet type requested by the parameters
+        for jet_type, jet_coll_name in self.jet_calib_param.collection[self.year].items():
+            # Check if the collection is enables in the parameters
+            if self.isMC:
+                if (self.jet_calib_param.apply_jec_MC[self.year][jet_type] == False):
+                    # If the collection is not enabled, we skip it
+                    continue
+            else:
+                if self.jet_calib_param.apply_jec_Data[self.year][jet_type] == False:
+                    # If the collection is not enabled, we skip it
+                    continue
+
+            if jet_coll_name in self.jets_calibrated:
+                # If the collection is already calibrated with another jet_type, raise an error for misconfiguration
+                raise ValueError(f"Jet collection {jet_coll_name} is already calibrated with another jet type. " +
+                                 f"Current jet type: {jet_type}. Previous jet types: {self.jets_calibrated[jet_coll_name]}")
+
+            # Check the Pt regression is not requested for this jet type 
+            # and in that case send a warning and skim them
+            if self.isMC and self.jet_calib_param.apply_pt_regr_MC[self.year][jet_type]:
+                print(f"WARNING: Jet type {jet_type} is requested to be calibrated with pT regression: " +
+                                    "skipped by JetCalibrator. Please activate the JetsPtRegressionCalibrator.")
+                continue
+            if not self.isMC and self.jet_calib_param.apply_pt_regr_Data[self.year][jet_type]:
+                print(f"WARNING: Jet type {jet_type} is requested to be calibrated with pT regression: " +
+                                    "skipped by JetCalibrator. Please activate the JetsPtRegressionCalibrator.")
+                continue
+
+            # register the collection as calibrated by this calibrator
+            self.calibrated_collections.append(jet_coll_name)
+
+            self.jets_calibrated[jet_coll_name] = jet_correction_corrlib(
+                params=self.params,
+                events=events,
+                jet_type = jet_type,
+                chunk_metadata={
+                    "year": self.metadata["year"],
+                    "isMC": self.metadata["isMC"],
+                    "era": self.metadata["era"] if "era" in self.metadata else None,
+                },
+                jec_syst=True,
+                jer_syst=True
+            )
+            
+            # Add to the list of the types calibrated
+            self.jets_calibrated_types.append(jet_type)
+
+        # Prepare the list of available variations
+        # For this we just read from the parameters
+        available_jet_variations = []
+        for jet_type in self.jet_calib_param.collection[self.year].keys():
+            if jet_type not in self.jets_calibrated_types:
+                # If the jet type is not calibrated, we skip it
+                continue
+            if jet_type in self.jet_calib_param.variations[self.year]:
+                # If the jet type has variations, we add them to the list
+                # of variations available for this calibrator
+                for variation in self.jet_calib_param.variations[self.year][jet_type]:
+                    available_jet_variations +=[
+                        f"{jet_type}_{variation}Up",
+                        f"{jet_type}_{variation}Down"
+                    ]
+                    # we want to vary independently each jet type
+        self._variations = list(sorted(set(available_jet_variations)))  # remove duplicates
+
+
+    def calibrate(self, events, orig_colls, variation, already_applied_calibrators=None):
+        # The values have been already calculated in the initialize method
+        # We just need to apply the corrections to the events
+        out = {}
+        # Set the nominals values for jets. For variations, only pt and mass need to be overwritten (see below).
+        for jet_coll_name, jets in self.jets_calibrated.items():
+            out[jet_coll_name] = jets
+        if variation == "nominal" or variation not in self._variations:
+            # If the variation is nominal or not in the list of variations, we return the nominal values
+            return out
+        
+        # Otherwise, adapt pt and mass according to calibrations:
+        # get the jet type from the variation name
+        variation_parts = variation.split("_")
+        jet_type = variation_parts[0]
+        if jet_type not in self.jet_calib_param.collection[self.year]:
+            raise ValueError(f"Jet type {jet_type} not found in the parameters for year {self.year}.")
+        # get the variation type from the variation name
+        if variation.endswith("Up"):
+            variation_type = "_".join(variation_parts[1:])[:-2]  # remove 'Up'
+            direction = "up"
+        elif variation.endswith("Down"):
+            variation_type = "_".join(variation_parts[1:])[:-4]  # remove 'Down'
+            direction = "down"
+        else:
+            raise ValueError(f"JET Variation {variation} is not recognized. It should end with 'Up' or 'Down'.")
+        
+        # get the jet collection name from the parameters
+        jet_coll_name = self.jet_calib_param.collection[self.year][jet_type]
+        if jet_coll_name not in self.jets_calibrated:
+            raise ValueError(f"Jet collection {jet_coll_name} not found in the calibrated jets.")
+        # Apply the variation to the jets
+        if direction == "up":
+            out[jet_coll_name]["pt"] = self.jets_calibrated[jet_coll_name][f"pt_{variation_type}_up"]
+            out[jet_coll_name]["mass"] = self.jets_calibrated[jet_coll_name][f"mass_{variation_type}_up"]
+        elif direction == "down":
+            # print(type(out[jet_coll_name]["pt"]))
+            out[jet_coll_name]["pt"] = self.jets_calibrated[jet_coll_name][f"pt_{variation_type}_down"]
+            out[jet_coll_name]["mass"] = self.jets_calibrated[jet_coll_name][f"mass_{variation_type}_down"]
+
+        return out
+
 
 class JetsCalibrator(Calibrator):
     """

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -8,6 +8,7 @@ import numpy as np
 import correctionlib
 from coffea.jetmet_tools import  CorrectedMETFactory
 from ..lib.deltaR_matching import get_matching_pairs_indices, object_matching
+from correctionlib.schemav2 import Correction, CorrectionSet
 
 
 def add_jec_variables(jets, event_rho, isMC=True):
@@ -520,3 +521,266 @@ def get_dijet(jets, taggerVars=True, remnant_jet = False):
         return dijet
     else:
         return dijet, remnant
+
+
+def get_jer_correction_set(jer_json, jer_ptres_tag, jer_sf_tag):
+    # learned from: https://github.com/cms-nanoAOD/correctionlib/issues/130
+    with gzip.open(jer_json) as fin:
+        cset = CorrectionSet.parse_raw(fin.read())
+
+    cset.corrections = [
+        c
+        for c in cset.corrections
+        if c.name
+        in (
+            jer_ptres_tag,
+            jer_sf_tag,
+        )
+    ]
+    cset.compound_corrections = []
+
+    res = Correction.parse_obj(
+        {
+            "name": "JERSmear",
+            "description": "Jet smearing tool",
+            "inputs": [
+                {"name": "JetPt", "type": "real"},
+                {"name": "JetEta", "type": "real"},
+                {
+                    "name": "GenPt",
+                    "type": "real",
+                    "description": "matched GenJet pt, or -1 if no match",
+                },
+                {"name": "Rho", "type": "real", "description": "entropy source"},
+                {"name": "EventID", "type": "int", "description": "entropy source"},
+                {
+                    "name": "JER",
+                    "type": "real",
+                    "description": "Jet energy resolution",
+                },
+                {
+                    "name": "JERsf",
+                    "type": "real",
+                    "description": "Jet energy resolution scale factor",
+                },
+            ],
+            "output": {"name": "smear", "type": "real"},
+            "version": 1,
+            "data": {
+                "nodetype": "binning",
+                "input": "GenPt",
+                "edges": [-1, 0, 1],
+                "flow": "clamp",
+                "content": [
+                    # stochastic
+                    {
+                        # rewrite gen_pt with a random gaussian
+                        "nodetype": "transform",
+                        "input": "GenPt",
+                        "rule": {
+                            "nodetype": "hashprng",
+                            "inputs": ["JetPt", "JetEta", "Rho", "EventID"],
+                            "distribution": "normal",
+                        },
+                        "content": {
+                            "nodetype": "formula",
+                            # TODO min jet pt?
+                            "expression": "1+sqrt(max(x*x - 1, 0)) * y * z",
+                            "parser": "TFormula",
+                            # now gen_pt is actually the output of hashprng
+                            "variables": ["JERsf", "JER", "GenPt"],
+                        },
+                    },
+                    # deterministic
+                    {
+                        "nodetype": "formula",
+                        # TODO min jet pt?
+                        "expression": "1+(x-1)*(y-z)/y",
+                        "parser": "TFormula",
+                        "variables": ["JERsf", "JetPt", "GenPt"],
+                    },
+                ],
+            },
+        }
+    )
+    cset.corrections.append(res)
+    ceval = cset.to_evaluator()
+    return ceval
+
+def get_jersmear(_eval_dict, _ceval, _jer_sf_tag, _syst="nom"):
+    _eval_dict.update({"systematic": _syst})
+    _inputs_jer_sf = [_eval_dict[input.name] for input in _ceval[_jer_sf_tag].inputs]
+    _jer_sf = _ceval[_jer_sf_tag].evaluate(*_inputs_jer_sf)
+    _eval_dict.update({"JERsf": _jer_sf})
+    _inputs = [_eval_dict[input.name] for input in _ceval["JERSmear"].inputs]
+    _jersmear = _ceval["JERSmear"].evaluate(*_inputs)
+    return _eval_dict, _jersmear
+
+
+def jet_correction_corrlib(
+    params,
+    events,
+    jet_type,
+    chunk_metadata,
+    level="L1L2L3Res",
+    jet_coll_name="Jet",
+    apply_jec=True,
+    jec_syst=True,
+    apply_jer=True,
+    jer_syst=True,
+):
+    isMC = chunk_metadata["isMC"]
+    year = chunk_metadata["year"]
+    era = chunk_metadata["era"]
+    jec_clib_dict = params["jets_calibration_clib"]
+    variations = params.jets_calibration.variations[year][jet_type]
+
+    json_path = jec_clib_dict[year]["json_path"]
+    jer_tag = None
+    if isMC:
+        jec_tag = jec_clib_dict[year]['jec_mc'] 
+        jer_tag = jec_clib_dict[year]['jer']
+    else:
+        if type(jec_clib_dict[year]['jec_data'])==str:
+            jec_tag = jec_clib_dict[year]['jec_data']
+        else:
+            jec_tag = jec_clib_dict[year]['jec_data'][chunk_metadata["era"]]
+
+    # no jer and variations applied on data
+    if not isMC:
+        apply_jer = jec_syst = jer_syst = False
+
+    tag_jec = "_".join([jec_tag, level, jet_type])
+
+    # get the correction sets
+    cset = correctionlib.CorrectionSet.from_file(json_path)
+
+    # prepare inputs
+    jets_jagged = events[jet_coll_name]
+    counts = ak.num(jets_jagged)
+
+    if ("event_id" not in jets_jagged.fields) and (apply_jer or jer_syst):
+        jets_jagged["event_id"] = ak.ones_like(jets_jagged.pt) * events.event
+    if ("run_nr" not in jets_jagged.fields):
+        jets_jagged["run_nr"] = ak.ones_like(jets_jagged.pt) * events.run
+    if year in ['2016_PreVFP', '2016_PostVFP','2017','2018']:
+        rho = events.fixedGridRhoFastjetAll
+    else:
+        rho = events.Rho.fixedGridRhoFastjetAll
+    jets_jagged = add_jec_variables(jets_jagged, rho, isMC)
+
+    # flatten
+
+    jets = ak.flatten(jets_jagged)
+    # evaluate dictionary
+    eval_dict = {
+        "JetPt": jets.pt_raw,
+        "JetEta": jets.eta,
+        "JetPhi": jets.phi,
+        "Rho": jets.event_rho,
+        "JetA": jets.area,
+        "run": jets.run_nr
+    }
+
+    # jec central
+    if apply_jec:
+        # get the correction
+        if tag_jec in list(cset.compound.keys()):
+            sf = cset.compound[tag_jec]
+        elif tag_jec in list(cset.keys()):
+            sf = cset[tag_jec]
+        else:
+            print(tag_jec, list(cset.keys()), list(cset.compound.keys()))
+            raise Exception(f"[No JEC correction: {tag_jec} - Year: {year} - Era: {era} - Level: {level}")
+        inputs = [eval_dict[input.name] for input in sf.inputs]
+        sf_value = sf.evaluate(*inputs)
+        # jets["pt_jec"] = sf_value * jets["pt_raw"]
+        # jets["mass_jec"] = sf_value * jets["mass_raw"]
+        # update the nominal pt and mass
+        jets["pt"] = sf_value * jets["pt_raw"]
+        jets["mass"] = sf_value * jets["mass_raw"]
+
+    # jer central and systematics
+    if apply_jer or jer_syst:
+        # learned from: https://github.com/cms-nanoAOD/correctionlib/issues/130
+
+        jer_ptres_tag = f"{jer_tag}_PtResolution_{jet_type}"
+        jer_sf_tag = f"{jer_tag}_ScaleFactor_{jet_type}"
+
+        ceval_jer = get_jer_correction_set(json_path, jer_ptres_tag, jer_sf_tag)
+        # update evaluate dictionary
+        eval_dict.update(
+            {
+                "JetPt": jets.pt,
+                "GenPt": jets.pt_gen,
+                "EventID": jets.event_id,
+            }
+        )
+        # get jer pt resolution
+        inputs_jer_ptres = [
+            eval_dict[input.name] for input in ceval_jer[jer_ptres_tag].inputs
+        ]
+        jer_ptres = ceval_jer[jer_ptres_tag].evaluate(*inputs_jer_ptres)
+        # update evaluate dictionary
+        eval_dict.update({"JER": jer_ptres})
+        # adjust pt gen
+        eval_dict.update(
+            {
+                "GenPt": np.where(
+                    np.abs(eval_dict["JetPt"] - eval_dict["GenPt"])
+                    < 3 * eval_dict["JetPt"] * eval_dict["JER"],
+                    eval_dict["GenPt"],
+                    -1.0,
+                ),
+            }
+        )
+        if apply_jer:
+            eval_dict, jersmear = get_jersmear(eval_dict, ceval_jer, jer_sf_tag, "nom")
+            jets["pt_jer"] = jets.pt * jersmear
+            jets["mass_jer"] = jets.mass * jersmear
+        if jer_syst:
+            # jer up
+            eval_dict, jersmear = get_jersmear(eval_dict, ceval_jer, jer_sf_tag, "up")
+            jets["pt_JER_up"] = jets.pt * jersmear
+            jets["mass_JER_up"] = jets.mass * jersmear
+            # jer down
+            eval_dict, jersmear = get_jersmear(eval_dict, ceval_jer, jer_sf_tag, "down")
+            jets["pt_JER_down"] = jets.pt * jersmear
+            jets["mass_JER_down"] = jets.mass * jersmear
+        if apply_jer:
+            # to avoid the sf: jer*jer_up or jer*jer_down, update the jer pt/mass after calculation of the jer up/down
+            jets["pt"] = jets["pt_jer"]
+            jets["mass"] = jets["mass_jer"]
+
+    # jec systematics
+    if jec_syst:
+        # update evaluate dictionary
+        eval_dict.update({"JetPt": jets.pt})
+        # loop over all JES variations
+        jes_strings = [s[4:] for s in variations if s.startswith("JES")]
+        for jes_vari in jes_strings:
+            # get the total uncertainty
+            tag_jec_syst = "_".join([jec_tag, "Regrouped" ,jes_vari, jet_type])
+            try:
+                sf = cset[tag_jec_syst]
+            except:
+                raise Exception(
+                    f"[ jerc_jet ] No JEC systematic: {tag_jec_syst} - Year: {year} - Era: {era}"
+                )
+            # systematics
+            inputs = [eval_dict[input.name] for input in sf.inputs]
+            sf_delta = sf.evaluate(*inputs)
+
+            # divide by correction since it is already applied before
+            corr_up_variation = 1 + sf_delta
+            corr_down_variation = 1 - sf_delta
+            # self.jets_calibrated[jet_coll_name][variation_type].up
+            jets[f"pt_JES_{jes_vari}_up"] = jets.pt * corr_up_variation
+            jets[f"pt_JES_{jes_vari}_down"] = jets.pt * corr_down_variation
+            jets[f"mass_JES_{jes_vari}_up"] = jets.mass * corr_up_variation
+            jets[f"mass_JES_{jes_vari}_down"] = jets.mass * corr_down_variation
+            # print("TESTS")
+    # print("TESTSTSTSTSTSTSTSTS")
+    jets_jagged = ak.unflatten(jets, counts)
+    # events.Jet = jets_jagged
+    return jets_jagged

--- a/pocket_coffea/parameters/jets_calibration.yaml
+++ b/pocket_coffea/parameters/jets_calibration.yaml
@@ -452,7 +452,6 @@ default_jets_calibration:
           - JES_Absolute
           - JES_Absolute_2016
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
           - JES_EC2_2016
           - JES_HF
@@ -467,7 +466,6 @@ default_jets_calibration:
           - JES_Absolute
           - JES_Absolute_2016
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
           - JES_EC2_2016
           - JES_HF
@@ -482,7 +480,6 @@ default_jets_calibration:
           - JES_Absolute
           - JES_Absolute_2017
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
           - JES_EC2_2017
           - JES_HF
@@ -498,7 +495,6 @@ default_jets_calibration:
           - JES_Absolute
           - JES_Absolute_2018
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
           - JES_EC2_2018
           - JES_HF
@@ -514,7 +510,6 @@ default_jets_calibration:
           - JES_Absolute
           - JES_Absolute_2022
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
           - JES_EC2_2022
           - JES_HF
@@ -527,24 +522,22 @@ default_jets_calibration:
       2022_postEE:
         AK4PFPuppi: 
           - JES_Absolute
-          - JES_Absolute_2022
+          - JES_Absolute_2022EE
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
-          - JES_EC2_2022
+          - JES_EC2_2022EE
           - JES_HF
-          - JES_HF_2022
+          - JES_HF_2022EE
           - JES_BBEC1
-          - JES_BBEC1_2022
+          - JES_BBEC1_2022EE
           - JES_RelativeBal
-          - JES_RelativeSample_2022
+          - JES_RelativeSample_2022EE
           - JER
       2023_preBPix:
         AK4PFPuppi:      
           - JES_Absolute
           - JES_Absolute_2023
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
           - JES_EC2_2023
           - JES_HF
@@ -557,17 +550,30 @@ default_jets_calibration:
       2023_postBPix:
         AK4PFPuppi:      
           - JES_Absolute
-          - JES_Absolute_2023
+          - JES_Absolute_2023BPix
           - JES_FlavorQCD
-          - JES_BBEC1
           - JES_EC2
-          - JES_EC2_2023
+          - JES_EC2_2023BPix
           - JES_HF
-          - JES_HF_2023
+          - JES_HF_2023BPix
           - JES_BBEC1
-          - JES_BBEC1_2023
+          - JES_BBEC1_2023BPix
           - JES_RelativeBal
-          - JES_RelativeSample_2023
+          - JES_RelativeSample_2023BPix
+          - JER
+      "2024":
+        AK4PFPuppi:      
+          - JES_Absolute
+          - JES_Absolute_2024
+          - JES_FlavorQCD
+          - JES_EC2
+          - JES_EC2_2024
+          - JES_HF
+          - JES_HF_2024
+          - JES_BBEC1
+          - JES_BBEC1_2024
+          - JES_RelativeBal
+          - JES_RelativeSample_2024
           - JER
       
     total_variation: 
@@ -659,6 +665,12 @@ jets_calibration:
       #AK8PFPuppi: "FatJet"
       #AK4PFPuppiPNetRegression: "Jet"
       #AK4PFPuppiPNetRegressionPlusNeutrino: "Jet"
+
+    "2024":
+      AK4PFPuppi: "Jet"
+      #AK8PFPuppi: "FatJet"
+      #AK4PFPuppiPNetRegression: "Jet"
+      #AK4PFPuppiPNetRegressionPlusNeutrino: "Jet"
      
   jec_name_map_MC: "${default_jets_calibration.jec_name_map_MC}"
   jec_name_map_Data: "${default_jets_calibration.jec_name_map_Data}"
@@ -692,6 +704,10 @@ jets_calibration:
       AK4PFPuppi: True
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True
+    "2024": 
+      AK4PFPuppi: True
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
 
   apply_jec_Data:  # this is needed to know which collection is corrected with which jet factory
     2016_PreVFP: 
@@ -719,6 +735,10 @@ jets_calibration:
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True
     2023_postBPix: 
+      AK4PFPuppi: True
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
+    "2024": 
       AK4PFPuppi: True
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True
@@ -823,4 +843,78 @@ jets_calibration:
   # The user can customize the wanted variations by changing the variations key in the user parameters.
   # the key default_jets_calibration.variations.full_variations contains the full setup of JET variations.
   # setup `jets_calibration.variations == "${default_jets_calibration.variations.full_variations}"` to use all variations
+  # variations: "${default_jets_calibration.variations.full_variations}"
   variations: "${default_jets_calibration.variations.total_variation}"
+
+jets_calibration_clib:
+  2016_PreVFP:
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2016preVFP_UL/jet_jerc.json.gz"
+    jec_mc: Summer19UL16_V7_MC
+    jec_data: Summer19UL16_RunFGH_V7_DATA
+    jer: Summer20UL16_JRV3_MC
+
+  2016_PostVFP:
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2016postVFP_UL/jet_jerc.json.gz"
+    jec_mc: Summer19UL16APV_V7_MC
+    jec_data:
+      B: Summer19UL16APV_RunBCD_V7_DATA
+      C: "${jets_calibration_clib.2016_PostVFP.jec_data.B}"
+      D: "${jets_calibration_clib.2016_PostVFP.jec_data.B}"
+      E: Summer19UL16APV_RunEF_V7_DATA
+      F: "${jets_calibration_clib.2016_PostVFP.jec_data.E}"
+    jer: Summer20UL16APV_JRV3_MC
+
+  "2017":
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2017_UL/jet_jerc.json.gz"
+    jec_mc: Summer19UL17_V5_MC
+    jec_data:
+      B: Summer19UL17_RunB_V5_DATA
+      C: Summer19UL17_RunC_V5_DATA
+      D: Summer19UL17_RunD_V5_DATA
+      E: Summer19UL17_RunE_V5_DATA
+      F: Summer19UL17_RunF_V5_DATA
+    jer: Summer19UL17_JRV2_MC
+
+  "2018":
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2018_UL/jet_jerc.json.gz"
+    jec_mc: Summer19UL18_V5_MC
+    jec_data:
+      A: Summer19UL18_RunA_V5_DATA
+      B: Summer19UL18_RunB_V5_DATA
+      C: Summer19UL18_RunC_V5_DATA
+      D: Summer19UL18_RunD_V5_DATA
+    jer: Summer19UL18_JRV2_MC
+
+  2022_preEE:
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jet_jerc.json.gz"
+    jec_mc: Summer22_22Sep2023_V2_MC
+    jec_data: Summer22_22Sep2023_RunCD_V2_DATA
+    jer: Summer22_22Sep2023_JRV1_MC
+
+  2022_postEE:
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22EE/jet_jerc.json.gz"
+    jec_mc: Summer22EE_22Sep2023_V2_MC
+    jec_data:
+      E: Summer22EE_22Sep2023_RunE_V2_DATA
+      F: Summer22EE_22Sep2023_RunF_V2_DATA
+      G: Summer22EE_22Sep2023_RunG_V2_DATA
+    jer: Summer22EE_22Sep2023_JRV1_MC
+
+  2023_preBPix:
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23/jet_jerc.json.gz"
+    jec_mc: Summer23Prompt23_V2_MC
+    jec_data: Summer23Prompt23_V2_DATA
+    jer: Summer23Prompt23_RunCv1234_JRV1_MC
+
+  2023_postBPix:
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23BPix/jet_jerc.json.gz"
+    jec_mc: Summer23BPixPrompt23_V3_MC
+    jec_data: Summer23BPixPrompt23_RunD_V3_DATA
+    jer: Summer23BPixPrompt23_RunD_JRV1_MC
+
+  "2024":
+    json_path: "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2024_Summer24/jet_jerc.json.gz"
+    jec_mc: Summer24Prompt24_V1_MC
+    jec_data: Summer24Prompt24_V1_DATA
+    jer: Summer23BPixPrompt23_RunD_JRV1_MC  # For the time being the 2023 jers shall be used https://cms-jerc.web.cern.ch/Recommendations/#2024_1
+


### PR DESCRIPTION
Implementation of correctionlib-based Jet Energy Corrections as new Calibrator for common use.
Json files are read directly from cvfms.
Tested so far only Run3. Results are consistent with previous implementation.
Also regrouped set of uncertainties (https://github.com/PocketCoffea/PocketCoffea/blob/main/pocket_coffea/parameters/jets_calibration.yaml#L449) work.