### PR TITLE
Propagate variations config to Calibrators

### DIFF
--- a/pocket_coffea/lib/calibrators/calibrator.py
+++ b/pocket_coffea/lib/calibrators/calibrator.py
@@ -45,11 +45,18 @@ class Calibrator(ABC, metaclass=CalibratorRegistry):
     # The calibrated collections format is expected to be "collection.field"
     calibrated_collections: List[str] = []
     
-    def __init__(self, params=None, metadata=None, **kwargs):
+    def __init__(self, params=None, metadata=None, do_variations=True, **kwargs):
+        '''
+        The constructor of the calibrator. It receives the params and metadata
+        dictionaries. The derived class can use them to configure the calibrator.
+        The do_variations flag is used to enable or disable the variations: that's used 
+        by the calibrators manager to signal to the calibrator that the variations
+        are available but not requested for this chunk (from configuration)'''
         self.params = params
         self.metadata = metadata
         self.isMC = self.metadata["isMC"]
         self.year = self.metadata["year"]
+        self.do_variations = do_variations  
         # Variations must be setup in the constructor of the derived class.
         
     @abstractmethod

--- a/pocket_coffea/lib/calibrators/calibrators_manager.py
+++ b/pocket_coffea/lib/calibrators/calibrators_manager.py
@@ -30,6 +30,7 @@ class CalibratorsManager():
                  events,
                  params,
                  metadata=None,
+                 requested_calibrator_variations=None,
                  **kwargs
                  ):
         self.calibrator_list = calibrators_list
@@ -38,6 +39,7 @@ class CalibratorsManager():
         self.metadata = metadata
         self.available_variations = ["nominal"]
         self.available_variations_bycalibrator = defaultdict(list)
+        self.requested_calibrator_variations = requested_calibrator_variations
         self.original_coll = {}
 
         # Initialize all the calibrators
@@ -45,8 +47,10 @@ class CalibratorsManager():
             if calibrator.isMC_only and not metadata["isMC"]:
                 # do not run the calibrator on data if it is MC only
                 continue
-            
-            C = calibrator(params, metadata, **kwargs)
+
+            C = calibrator(params, metadata, 
+                          do_variations=calibrator_name in requested_calibrator_variations,
+                            **kwargs)
             C.initialize(events)
             self.calibrator_sequence.append(C)
             # storing the list of calibrator touching a collection in a dictionary

--- a/pocket_coffea/lib/calibrators/calibrators_manager.py
+++ b/pocket_coffea/lib/calibrators/calibrators_manager.py
@@ -48,9 +48,13 @@ class CalibratorsManager():
                 # do not run the calibrator on data if it is MC only
                 continue
 
-            C = calibrator(params, metadata, 
-                          do_variations=calibrator_name in requested_calibrator_variations,
-                            **kwargs)
+            if requested_calibrator_variations is not None and calibrator.name not in requested_calibrator_variations:
+                # If the calibrator is not in the list of requested variations, we initialize it without variations
+                C = calibrator(params, metadata, do_variations=False, **kwargs)
+            else:
+                # If the calibrator is in the list of requested variations, we initialize it with variations
+                C = calibrator(params, metadata, do_variations=True, **kwargs)
+           
             C.initialize(events)
             self.calibrator_sequence.append(C)
             # storing the list of calibrator touching a collection in a dictionary

--- a/pocket_coffea/lib/calibrators/common/common.py
+++ b/pocket_coffea/lib/calibrators/common/common.py
@@ -20,7 +20,7 @@ class JetsCalibrator(Calibrator):
     isMC_only = False
 
     def __init__(self, params, metadata, do_variations, jme_factory, **kwargs):
-        super().__init__(params, metadata, do_variations, **kwargs)
+        super().__init__(params, metadata, do_variations=True, **kwargs)
         self.jme_factory = jme_factory
         self._year = metadata["year"]
         self.jet_calib_param = self.params.jets_calibration

--- a/pocket_coffea/lib/calibrators/common/common.py
+++ b/pocket_coffea/lib/calibrators/common/common.py
@@ -19,8 +19,8 @@ class JetsCalibrator(Calibrator):
     has_variations = True
     isMC_only = False
 
-    def __init__(self, params, metadata, jme_factory, **kwargs):
-        super().__init__(params, metadata, **kwargs)
+    def __init__(self, params, metadata, do_variations, jme_factory, **kwargs):
+        super().__init__(params, metadata, do_variations, **kwargs)
         self.jme_factory = jme_factory
         self._year = metadata["year"]
         self.jet_calib_param = self.params.jets_calibration
@@ -147,13 +147,16 @@ class JetsPtRegressionCalibrator(JetsCalibrator):
 
     All the jets type with "Regression" in their name will be calibrated by this calibrator, the 
     others will be ignored (and should be calibrated by the JetsCalibrator).
+
+    The do_variations flag is passed to the base class, but it is not used in this calibrator,
+    as the variations are always computed by the coffea JEC evaluator.
     """
     name = "jet_calibration_with_pt_regression"
     has_variations = True
     isMC_only = False
 
-    def __init__(self, params, metadata, jme_factory, **kwargs):
-        super().__init__(params, metadata, jme_factory, **kwargs)
+    def __init__(self, params, metadata, do_variations, jme_factory, **kwargs):
+        super().__init__(params, metadata, do_variations, jme_factory, **kwargs)
         # It is filled dynamically in the initialize method depending on the parameters
         self.calibrated_collections = []
   
@@ -206,7 +209,7 @@ class JetsPtRegressionCalibrator(JetsCalibrator):
                 events=events,
                 jets=jets_regressed[reg_mask],  # passing the regressed jets
                 factory=self.jme_factory,
-                jet_type = jet_type,
+                jet_type=jet_type,
                 chunk_metadata={
                     "year": self.metadata["year"],
                     "isMC": self.metadata["isMC"],
@@ -353,8 +356,8 @@ class METCalibrator(Calibrator):
     isMC_only = False
     '''
     The MET calibrator applies the JEC to the MET collection.'''
-    def __init__(self, params, metadata, **kwargs):
-        super().__init__(params, metadata, **kwargs)
+    def __init__(self, params, metadata, do_variations=True, **kwargs):
+        super().__init__(params, metadata, do_variations, **kwargs)
         jet_calib_param = self.params.jets_calibration
         self.met_calib_cfg = jet_calib_param.rescale_MET_config[self.year]
         self.met_calib_active = self.met_calib_cfg.apply
@@ -394,8 +397,8 @@ class ElectronsScaleCalibrator(Calibrator):
     isMC_only = False
     calibrated_collections = ["Electron.pt", "Electron.pt_original"]
 
-    def __init__(self, params, metadata, **kwargs):
-        super().__init__(params, metadata, **kwargs)
+    def __init__(self, params, metadata, do_variations=True, **kwargs):
+        super().__init__(params, metadata, do_variations, **kwargs)
         self.ss_params = self.params.lepton_scale_factors.electron_sf.scale_and_smearing
         if not self.ss_params.apply[self.year]:
             # If the scale and smearing is not applied, we do not need to initialize the calibrator
@@ -464,8 +467,8 @@ class ElectronsScaleCalibrator(Calibrator):
 
 #####################################################
 class MuonsCalibrator(Calibrator):
-    def __init__(self, params, metadata, **kwargs):
-        super().__init__(params, metadata, **kwargs)
+    def __init__(self, params, metadata, do_variations=True, **kwargs):
+        super().__init__(params, metadata, do_variations, **kwargs)
         # initialize variations
 
     def initialize(self, events):

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -634,6 +634,7 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
             self.events,
             self.params,
             self._metadata,
+            requested_calibrator_variations=self.cfg.available_shape_variations[self._sample],
             # Additional arg to pass the jmefactory to the jet calibrator --> hacky
             jme_factory=self.jmefactory,
         )

--- a/tests/test_calibrators.py
+++ b/tests/test_calibrators.py
@@ -380,7 +380,9 @@ def test_jets_calibrator(events, params):
 
     from pocket_coffea.lib.jets import load_jet_factory
     jmefactory = load_jet_factory(params)
-    jets_calibrator = JetsCalibrator(params=params, metadata={"isMC": True, "year": "2018"}, jme_factory=jmefactory)
+    jets_calibrator = JetsCalibrator(params=params, metadata={"isMC": True, "year": "2018"},
+                                     do_variations=False,
+                                     jme_factory=jmefactory)
     jets_calibrator.initialize(events)
 
     orig_events = ak.copy(events)


### PR DESCRIPTION
added `do_variation` argument to Calibrator to signal to the initialization function is the variation will be actually used or not. 

This is propagated from the configuration to the CalibratorsManager. This can be useful to avoid computing the JEC variations if they are not used. 

FYI @phnattla 