### PR TITLE
Fixed muon SF evaluation 2023

### DIFF
--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -193,15 +193,21 @@ def get_mu_sf(params, year, pt, eta, counts, key=''):
         raise Exception(f"Muon SF key {key} not recognized")
     
     sfName = muonSF.sf_name[year][key]
+
+    if year in ["2023_preBPix", "2023_postBPix", "2024"]:
+        # Starting from 2023 SFs require non-abs value of eta:
+        eta = eta.to_numpy()
+    else:
+        eta = np.abs(eta.to_numpy())
     
     sf = muon_correctionset[sfName].evaluate(
-        np.abs(eta.to_numpy()), pt.to_numpy(), "nominal"
+        eta, pt.to_numpy(), "nominal"
     )
     sfup = muon_correctionset[sfName].evaluate(
-        np.abs(eta.to_numpy()), pt.to_numpy(), "systup"
+        eta, pt.to_numpy(), "systup"
     )
     sfdown = muon_correctionset[sfName].evaluate(
-        np.abs(eta.to_numpy()), pt.to_numpy(), "systdown"
+        eta, pt.to_numpy(), "systdown"
     )
     
     # The unflattened arrays are returned in order to have one row per event.

--- a/pocket_coffea/parameters/jets_calibration.yaml
+++ b/pocket_coffea/parameters/jets_calibration.yaml
@@ -786,7 +786,7 @@ jets_calibration:
 
 
   rescale_MET_config:
-    20216_PreVFP:
+    2016_PreVFP:
       apply: True
       MET_collection: "MET"
       Jet_collection: "Jet"


### PR DESCRIPTION
Muon SF evaluation moved to eta instead of |abs| in 2023. 

Thanks for the [analysis_recipes](https://gitlab.cern.ch/cms-analysis/general/analysis_recipes/) tools for catching it!! 