### PR TITLE
fix log argument for SystUnc plotting

### DIFF
--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -1841,7 +1841,7 @@ class SystUnc:
                 loc="upper right",
             )
 
-    def plot(self, ratio=True, toplabel=None, log=False):
+    def plot(self, ratio=True, toplabel=None, log_x=False, log_y=False):
         """Plots the nominal, up and down systematic variations on the same plot."""
 
         # setup figure and corresponding axes


### PR DESCRIPTION
https://github.com/PocketCoffea/PocketCoffea/blob/b039f0f002a23aaf8811c0333b6bda77daf57f5a/pocket_coffea/utils/plot_utils.py#L1844-L1849

The plotting for systematics didn't accept `log_x `and `log_y `as arguments. I added them as arguments. 