### PR TITLE
fix syntax in help of dataset-discovery-cli

### DIFF
--- a/pocket_coffea/scripts/dataset/dataset_query.py
+++ b/pocket_coffea/scripts/dataset/dataset_query.py
@@ -143,7 +143,7 @@ Some basic commands:
   - [bold cyan]query-results[/]: List the results of the last dataset query
   - [bold cyan]list-selected[/]: Print a list of the selected datasets
   - [bold cyan]list-replicas[/]: Print the selected files replicas for the selected dataset
-  - [bold cyan][set-sorting][/]: Set the sorting mode for replicas
+  - [bold cyan]set-sorting[/]: Set the sorting mode for replicas
   - [bold cyan]sites-filters[/]: show the active sites filters and ask to clear them
   - [bold cyan]allow-sites[/]: Restrict the grid sites available for replicas query only to the requested list
   - [bold cyan]block-sites[/]: Exclude grid sites from the available sites for replicas query


### PR DESCRIPTION
the help did not print `set-sorting` because it was in square brackets and hence interpreted as rich styling
https://github.com/PocketCoffea/PocketCoffea/blob/9d068d27f1adac625bbe62240dd96600de23036d/pocket_coffea/scripts/dataset/dataset_query.py#L146
resulting in
```
Use this CLI tool to query the CMS datasets and to select interactively the grid sites to use for reading the files in your analysis.                                                    
Some basic commands:                                                                                                                                                                                                                         
  - list-replicas: Print the selected files replicas for the selected dataset                                                                                                            
  - : Set the sorting mode for replicas                                                                                                                                                                                                                                                                    
  - help: Print this help message 
```
fix -> removed the square brackets