### PR TITLE
Moved electron Scale and Smearing to ET dependent for all Run3

### DIFF
--- a/pocket_coffea/parameters/lepton_scale_factors.yaml
+++ b/pocket_coffea/parameters/lepton_scale_factors.yaml
@@ -160,34 +160,34 @@ lepton_scale_factors:
       
       correctionlib_config:
         '2022_preEE':
-          file: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,EGM,electronSS.json.gz,2025-04-15}
+          file: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,EGM,electronSS_EtDependent.json.gz}
           correction_name:
             scale: "Scale"
-            smear: "Smearing"
-          et_dependent: false
+            smear: "SmearAndSyst"
+          et_dependent: true
         '2022_postEE':
-          file: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,EGM,electronSS.json.gz,2025-04-15}
+          file: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,EGM,electronSS_EtDependent.json.gz}
           correction_name:
             scale: "Scale"
-            smear: "Smearing"
-          et_dependent: false
+            smear: "SmearAndSyst"
+          et_dependent: true
         '2023_preBPix':
-          file: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,EGM,electronSS.json.gz,2025-04-15}
+          file: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,EGM,electronSS_EtDependent.json.gz}
           correction_name:
-            scale: "2023PromptC_ScaleJSON"
-            smear: "2023PromptC_SmearingJSON"
-          et_dependent: false
+            scale: "Scale"
+            smear: "SmearAndSyst"
+          et_dependent: true
         '2023_postBPix':
-          file: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,EGM,electronSS.json.gz,2025-04-15}
+          file: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,EGM,electronSS_EtDependent.json.gz}
           correction_name:
-            scale: "2023PromptD_ScaleJSON"
-            smear: "2023PromptD_SmearingJSON"
-          et_dependent: false
+            scale: "Scale"
+            smear: "SmearAndSyst"
+          et_dependent: true
         '2024':
-          file: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,EGM,electronSS_EtDependent_v1.json.gz,2025-08-15}
+          file: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,EGM,electronSS_EtDependent.json.gz}
           correction_name:
-            scale: "EGMScale_Compound_Ele_2024"
-            smear: "EGMSmearAndSyst_ElePTsplit_2024"
+            scale: "Scale"
+            smear: "SmearAndSyst"
           et_dependent: true
     
     # The trigger SF configuration is expected to have this structure


### PR DESCRIPTION
EGM updates its recommendations for electron and photon scale and smearing [cms-talk](https://cms-talk.web.cern.ch/t/updated-scale-and-smearing-recommendations-for-run3/135168). 

All the Run3 eras are now configured to use the EtDependent scale and smearing correction. 