### PR TITLE
filter samples before check for mc/data only

### DIFF
--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -391,9 +391,9 @@ class Shape:
             type(h_dict) in [dict, defaultdict]
         ), "The Shape object receives a dictionary of hist.Hist objects as argument."
         self.group_samples()
+        self.filter_samples()
         self.is_mc_only = len(self.samples_data) == 0
         self.is_data_only = len(self.samples_mc) == 0
-        self.filter_samples()
         self.rescale_samples()
         if not self.is_data_only:
             self.replace_missing_variations()


### PR DESCRIPTION
in commit dcff6e5968a0795e30470d895aca082163334815 the assignments for `is_mc_only` and `is_data_only` in the Shape class have been moved
this leads to the following error when excluding all data samples

```python
# at this point there are still data samples available
self.is_mc_only = len(self.samples_data) == 0
# i.e. self.is_mc_only = True
# here samples are filtered
self.filter_samples()
# -> self.samples_data = [] -> len() == 0
# self.is_mc_only should be false
```
this leads to a inaccurate assertion error here
https://github.com/PocketCoffea/PocketCoffea/blob/8fb0e362422e5c5cbdc181f9e0ad2e6376218645/pocket_coffea/utils/plot_utils.py#L425-L428

there are no data samples since they have been filtered as they should be, so the set will be empty. However the check should have never been done. If the data samples have been filtered out `is_mc_only` should have been `True`

@mmarchegiani 
can you please check
this shouldnt break any logic you implemented in the original commit

FYI @NinaHerfort 