### PR TITLE
Bump to V2 of 2024 JECs, add UParT in jet selection, hotfix in make_plots script

### DIFF
--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -123,6 +123,10 @@ def jet_selection(events, jet_type, params, year, leptons_collection="", jet_tag
                 B   = "btagRobustParTAK4B"
                 CvL = "btagRobustParTAK4CvL"
                 CvB = "btagRobustParTAK4CvB"
+            elif "UParT" in jet_tagger:
+                B   = "btagUParTAK4B"
+                CvL = "btagUParTAK4CvL"
+                CvB = "btagUParTAK4CvB"
             else:
                 raise NotImplementedError(f"This tagger is not implemented: {jet_tagger}")
             
@@ -321,7 +325,7 @@ def get_dijet(jets, taggerVars=True, remnant_jet = False):
     fields["j2mass"] = ak.where( (njet >= 2), jets[:,1].mass, -1)
 
 
-    if "jetId" in jets.fields and taggerVars:
+    if taggerVars:
         '''This dijet fuction should work for GenJets as well. But the btags are not available for them
         Thus, one has to check if a Jet is a GenJet or reco Jet. The jetId variable is only available in reco Jets'''
         fields["j1CvsL"] = ak.where( (njet >= 2), jets[:,0]["btagCvL"], -1)

--- a/pocket_coffea/parameters/jets_calibration.yaml
+++ b/pocket_coffea/parameters/jets_calibration.yaml
@@ -78,8 +78,8 @@ default_jets_calibration:
 
       "2024":
         json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz}
-        jec_mc: Summer24Prompt24_V1_MC
-        jec_data: Summer24Prompt24_V1_DATA
+        jec_mc: Summer24Prompt24_V2_MC
+        jec_data: Summer24Prompt24_V2_DATA
         jer: Summer23BPixPrompt23_RunD_JRV1_MC  # For the time being the 2023 jers shall be used https://cms-jerc.web.cern.ch/Recommendations/#2024_1
         level: L1L2L3Res
 

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -77,7 +77,7 @@ def make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
     if cfg==None:
         cfg = os.path.join(input_dir, "parameters_dump.yaml")
     if not inputfiles:
-        inputfiles = (os.path.join(input_dir, "output_all.coffea"),)
+        inputfiles = (os.path.join(input_dir, "output_merged.coffea"),)
     if outputdir==None:
         outputdir = os.path.join(input_dir, "plots")
 


### PR DESCRIPTION
- JME released V2 of 2024 JECs as of December 2, 2025
- Storing UParT values as B/CvsL/CvsB during jet selection for 2024; remove jetId requirement for 2024 
- Change from `output_all.coffea` to `output_merged.coffea` was not propagated to `make-plots`; doing this now