### PR TITLE
Changing jec_data tag defaults for 22/23 after change in JME files

### DIFF
--- a/pocket_coffea/parameters/jets_calibration.yaml
+++ b/pocket_coffea/parameters/jets_calibration.yaml
@@ -48,24 +48,21 @@ default_jets_calibration:
       2022_preEE:
         json_path: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,JME,jet_jerc.json.gz}
         jec_mc: Summer22_22Sep2023_V3_MC
-        jec_data: Summer22_22Sep2023_RunCD_V3_DATA
+        jec_data: Summer22_22Sep2023_V3_DATA
         jer: Summer22_22Sep2023_JRV1_MC
         level: L1L2L3Res
       
       2022_postEE:
         json_path: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,JME,jet_jerc.json.gz}
         jec_mc: Summer22EE_22Sep2023_V3_MC
-        jec_data:
-          E: Summer22EE_22Sep2023_RunE_V3_DATA
-          F: Summer22EE_22Sep2023_RunF_V3_DATA
-          G: Summer22EE_22Sep2023_RunG_V3_DATA
+        jec_data: Summer22EE_22Sep2023_V3_DATA
         jer: Summer22EE_22Sep2023_JRV1_MC
         level: L1L2L3Res
 
       2023_preBPix:
         json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jet_jerc.json.gz}
         jec_mc: Summer23Prompt23_V2_MC
-        jec_data: Summer23Prompt23_V2_DATA
+        jec_data: Summer23Prompt23_V3_DATA
         jer: Summer23Prompt23_RunCv1234_JRV1_MC
         level: L1L2L3Res
       


### PR DESCRIPTION
Changing jec_data tag defaults for 22 after change in JME files, after JEC format was changed in [1].
Also, for 2023preBPix, there seems to have been a change `Summer23Prompt23_V2_DATA` -> `Summer23Prompt23_V3_DATA`, which does not seem to be documented yet [2].

Feel free to have a look @valsdav 

[1] https://gitlab.cern.ch/cms-analysis-corrections/JME/Run3-22CDSep23-Summer22-NanoAODv12/-/merge_requests/2
[2] https://cms-analysis-corrections.docs.cern.ch/corrections_era/Run3-23CSep23-Summer23-NanoAODv12/JME/latest/