### PR TITLE
Moved default JEC tags to previous version

### DIFF
--- a/pocket_coffea/parameters/jets_calibration.yaml
+++ b/pocket_coffea/parameters/jets_calibration.yaml
@@ -2,7 +2,7 @@ default_jets_calibration:
   factory_config_clib:
     AK4PFchs:
       2016_PreVFP:
-        json_path: ${cvmfs:Run2-2016preVFP-UL-NanoAODv9,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2016preVFP-UL-NanoAODv9,JME,jet_jerc.json.gz,2025-04-11}
         jec_mc: Summer19UL16APV_V7_MC
         jec_data:
           B: Summer19UL16APV_RunBCD_V7_DATA
@@ -14,14 +14,14 @@ default_jets_calibration:
         level: L1L2L3Res
 
       2016_PostVFP:
-        json_path: ${cvmfs:Run2-2016postVFP-UL-NanoAODv9,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2016postVFP-UL-NanoAODv9,JME,jet_jerc.json.gz,2025-04-11}
         jec_mc: Summer19UL16_V7_MC
         jec_data: Summer19UL16_RunFGH_V7_DATA
         jer: Summer20UL16_JRV3_MC
         level: L1L2L3Res
 
       "2017":
-        json_path: ${cvmfs:Run2-2017-UL-NanoAODv9,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2017-UL-NanoAODv9,JME,jet_jerc.json.gz,2025-04-11}
         jec_mc: Summer19UL17_V5_MC
         jec_data:
           B: Summer19UL17_RunB_V5_DATA
@@ -33,7 +33,7 @@ default_jets_calibration:
         level: L1L2L3Res
 
       "2018":
-        json_path: ${cvmfs:Run2-2018-UL-NanoAODv9,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2018-UL-NanoAODv9,JME,jet_jerc.json.gz,2025-04-11}
         jec_mc: Summer19UL18_V5_MC
         jec_data:
           A: Summer19UL18_RunA_V5_DATA
@@ -46,42 +46,42 @@ default_jets_calibration:
 
     AK4PFPuppi:
       2022_preEE:
-        json_path: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,JME,jet_jerc.json.gz,2026-04-13}
         jec_mc: Summer22_22Sep2023_V3_MC
         jec_data: Summer22_22Sep2023_V3_DATA
         jer: Summer22_22Sep2023_JRV1_MC
         level: L1L2L3Res
       
       2022_postEE:
-        json_path: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,JME,jet_jerc.json.gz,2026-04-13}
         jec_mc: Summer22EE_22Sep2023_V3_MC
         jec_data: Summer22EE_22Sep2023_V3_DATA
         jer: Summer22EE_22Sep2023_JRV1_MC
         level: L1L2L3Res
 
       2023_preBPix:
-        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jet_jerc.json.gz,2026-04-13}
         jec_mc: Summer23Prompt23_V3_MC
         jec_data: Summer23Prompt23_V3_DATA
         jer: Summer23Prompt23_RunCv1234_JRV1_MC
         level: L1L2L3Res
       
       2023_postBPix:
-        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jet_jerc.json.gz,2026-04-13}
         jec_mc: Summer23BPixPrompt23_V3_MC
         jec_data: Summer23BPixPrompt23_V3_DATA
         jer: Summer23BPixPrompt23_RunD_JRV1_MC
         level: L1L2L3Res
 
       "2024":
-        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz,2025-12-02}
         jec_mc: Summer24Prompt24_V2_MC
         jec_data: Summer24Prompt24_V2_DATA
         jer: Summer23BPixPrompt23_RunD_JRV1_MC  # For the time being the 2023 jers shall be used https://cms-jerc.web.cern.ch/Recommendations/#2024_1
         level: L1L2L3Res
 
       "2025":
-        json_path: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,jet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,jet_jerc.json.gz,2026-02-09}
         jec_mc: Winter25Prompt25_V3_MC
         jec_data: Winter25Prompt25_V3_DATA
         jer: Summer23BPixPrompt23_RunD_JRV1_MC  # For the time being the 2023 jers shall be used https://cms-jerc.web.cern.ch/Recommendations/#2024_1
@@ -90,69 +90,69 @@ default_jets_calibration:
 
     AK8PFPuppi:
       2016_PreVFP:
-        json_path: ${cvmfs:Run2-2016preVFP-UL-NanoAODv9,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2016preVFP-UL-NanoAODv9,JME,fatJet_jerc.json.gz,2025-04-11}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFchs.2016_PreVFP.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFchs.2016_PreVFP.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFchs.2016_PreVFP.jer}"
         level: L1L2L3Res
 
       2016_PostVFP:
-        json_path: ${cvmfs:Run2-2016postVFP-UL-NanoAODv9,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2016postVFP-UL-NanoAODv9,JME,fatJet_jerc.json.gz,2025-04-11}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFchs.2016_PostVFP.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFchs.2016_PostVFP.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFchs.2016_PostVFP.jer}"
         level: L1L2L3Res
 
       "2017":
-        json_path: ${cvmfs:Run2-2017-UL-NanoAODv9,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2017-UL-NanoAODv9,JME,fatJet_jerc.json.gz,2025-04-11}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFchs.2017.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFchs.2017.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFchs.2017.jer}"
         level: L1L2L3Res
 
       "2018":
-        json_path: ${cvmfs:Run2-2018-UL-NanoAODv9,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run2-2018-UL-NanoAODv9,JME,fatJet_jerc.json.gz,2025-04-11}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFchs.2018.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFchs.2018.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFchs.2018.jer}"
         level: L1L2L3Res
 
       2022_preEE:
-        json_path: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,JME,fatJet_jerc.json.gz,2026-04-13}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2022_preEE.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2022_preEE.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2022_preEE.jer}"
         level: L1L2L3Res
 
       2022_postEE:
-        json_path: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,JME,fatJet_jerc.json.gz,2026-04-13}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2022_postEE.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2022_postEE.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2022_postEE.jer}"
         level: L1L2L3Res
 
       2023_preBPix:
-        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,fatJet_jerc.json.gz,2026-04-13}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_preBPix.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_preBPix.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_preBPix.jer}"
         level: L1L2L3Res
 
       2023_postBPix:
-        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,fatJet_jerc.json.gz,2026-04-13}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_postBPix.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_postBPix.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_postBPix.jer}"
         level: L1L2L3Res
 
       "2024":
-        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,fatJet_jerc.json.gz,2025-12-02}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jer}"
         level: L1L2L3Res
       "2025":
-        json_path: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,fatJet_jerc.json.gz}
+        json_path: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,fatJet_jerc.json.gz,2026-02-09}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2025.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2025.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2025.jer}"


### PR DESCRIPTION
JetMET changed the format of JER evaluation and updated the tags. 
https://cms-talk.web.cern.ch/t/new-jer-smearing-inputs-available-for-2024-and-2025/145723 

In order to keep the latest version of PocketCoffea working while we work on the updated code for the JER evaluation (thanks @phnattla!), I'm freezing the default JetMET tags to the previous version. 
