### PR TITLE
Add --replace flag to merge-outputs

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -192,6 +192,15 @@ Follow these instructions to skim the files on EOS:
    an already-merged file double-rescales the histograms (the `sum_genweights` is not reset
    between passes), so never feed a merged output back into `merge-outputs`.
    :::
+   :::{tip}
+   To re-run only a few datasets and substitute them into an existing merge, use
+   `--replace`: the **first** input file is treated as the base, and every dataset that also
+   appears in the remaining (incoming) files is removed from the base before merging, so the
+   newer files *replace* rather than *sum with* the base content. For example
+   `merge-outputs base.coffea rerun_datasetX_job_*.coffea -o output_total.coffea --replace -f`.
+   As above, use raw (un-postprocessed) outputs and make sure the configurator picked up for
+   postprocessing knows every dataset that survives the replacement.
+   :::
 
 5. Once done, we usually do an hadd to sum all the small files produced by each saved chunk. An utility script to compute the groups and correctly hadd them is available `pocket-coffea hadd-skimmed-files -fl ../output_total.coffea -o root://eoscms.cern.ch//eos/cms/store/group/phys_higgs/ttHbb/Run3_dileptonic_skim_hadd -e 400000 --dry  -s 6 `
    this script creates some files to be able to send out jobs that runs the hadd for each group of files. Note that it reads the merged `output_total.coffea` produced in the previous step, so the per-chunk event counts and `sum_genweights` are taken from there.

--- a/pocket_coffea/scripts/merge_outputs.py
+++ b/pocket_coffea/scripts/merge_outputs.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.progress import Progress
 import cloudpickle
 import yaml
-from pocket_coffea.utils.filter_output import compare_dict_types
+from pocket_coffea.utils.filter_output import compare_dict_types, get_datasets_in_output, remove_datasets_from_output
 from pocket_coffea.utils.skim import save_skimed_dataset_definition
 from itertools import islice
 from functools import reduce
@@ -104,8 +104,11 @@ def append_configs(c1, c2):
             
     return c1
 
-def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, N_reduction=5, max_mem_gb=None, cache_dir=None, verbose=False, skip_check=False, mark_failed=False, configurator=None, skip_initial_events_check_datasets=None):
+def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace=False, N_reduction=5, max_mem_gb=None, cache_dir=None, verbose=False, skip_check=False, mark_failed=False, configurator=None, skip_initial_events_check_datasets=None):
     '''Merge coffea output files'''
+    if replace and len(inputfiles) == 0:
+        print("[red]--replace only works when merging explicit input files (not with -jc).[/]")
+        exit(1)
     if jobs_config is not None:
         # check if the user provided the config file or the directory
         if not os.path.isfile(jobs_config):
@@ -166,8 +169,30 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, N_reduc
         
         if cache_dir is None:
             cache_dir = os.path.join(os.path.dirname(os.path.abspath(outputfile)), "merge_cache")
-        total_out =  merge_group_reduction(inputfiles, N_reduction=N_reduction, cachedir=cache_dir, 
-                                           max_mem_gb=max_mem_gb, verbose=verbose)
+
+        if replace:
+            if ninput < 2:
+                print("[red]--replace needs a base file plus at least one incoming file.[/]")
+                exit(1)
+            base_file, incoming_files = inputfiles[0], list(inputfiles[1:])
+            print(f"[blue]--replace: '{base_file}' is the base; {len(incoming_files)} "
+                  f"incoming file(s) will replace overlapping datasets.[/]")
+            incoming_out = merge_group_reduction(incoming_files, N_reduction=N_reduction, cachedir=cache_dir,
+                                                 max_mem_gb=max_mem_gb, verbose=verbose)
+            datasets_to_replace = get_datasets_in_output(incoming_out)
+            base_out = load(base_file)
+            base_datasets = get_datasets_in_output(base_out)
+            replaced = sorted(datasets_to_replace & base_datasets)
+            added    = sorted(datasets_to_replace - base_datasets)
+            print(f"Replacing {len(replaced)} dataset(s) already in base: {replaced}")
+            if added:
+                print(f"[yellow]{len(added)} incoming dataset(s) not in base (added): {added}[/]")
+            remove_datasets_from_output(base_out, datasets_to_replace)
+            total_out = accumulate([base_out, incoming_out])
+            del base_out, incoming_out
+        else:
+            total_out =  merge_group_reduction(inputfiles, N_reduction=N_reduction, cachedir=cache_dir,
+                                               max_mem_gb=max_mem_gb, verbose=verbose)
 
         if configurator is not None:
             configurators = configurator.split(",")
@@ -384,6 +409,14 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, N_reduc
 )
 
 @click.option(
+    "--replace",
+    is_flag=True,
+    help="Treat the FIRST input file as a base: remove from it every dataset that "
+         "also appears in the remaining input files, so the later files replace "
+         "(instead of sum with) the base content. Use raw (un-postprocessed) outputs.",
+)
+
+@click.option(
     "-s",
     "--skip-check",
     is_flag=True,
@@ -405,9 +438,9 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, N_reduc
          "when a corrupted input file had to be skipped. Repeatable.",
 )
 
-def main(inputfiles, outputfile, jobs_config, force, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, skip_initial_events_check_datasets):
+def main(inputfiles, outputfile, jobs_config, force, replace, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, skip_initial_events_check_datasets):
     '''Merge coffea output files'''
-    merge_outputs(inputfiles, outputfile, jobs_config, force, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, list(skip_initial_events_check_datasets))
+    merge_outputs(inputfiles, outputfile, jobs_config, force, replace, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, list(skip_initial_events_check_datasets))
 
 if __name__ == "__main__":
     main()

--- a/pocket_coffea/utils/filter_output.py
+++ b/pocket_coffea/utils/filter_output.py
@@ -56,6 +56,45 @@ def filter_output_by_category(o, categories):
         o_filtered[key] = o[key]
     return o_filtered
 
+def get_datasets_in_output(o):
+    """Return the set of dataset names present in a coffea output.
+
+    cutflow['initial'] holds exactly one key per processed dataset (MC and data,
+    raw or postprocessed), see workflows/base.py. sum_genweights and
+    datasets_metadata['by_dataset'] are used as robust fallbacks.
+    """
+    datasets = set()
+    datasets |= set(o.get("cutflow", {}).get("initial", {}).keys())
+    datasets |= set(o.get("sum_genweights", {}).keys())
+    datasets |= set(o.get("datasets_metadata", {}).get("by_dataset", {}).keys())
+    return datasets
+
+def remove_datasets_from_output(o, datasets):
+    """Recursively delete every entry keyed by a name in `datasets` from a coffea
+    output dict, in place, wherever it appears.
+
+    Dataset names are unique strings (e.g. ``TTTo2L2Nu_2018``) that appear as dict
+    keys at various depths (sum_genweights, sumw/sumw2/cutflow/columns per category
+    or sample, variables/processing_metadata per variable->sample,
+    datasets_metadata['by_dataset']) and inside the
+    datasets_metadata['by_datataking_period'][year][sample] sets. A single generic
+    walk removes them everywhere without hardcoding each structure. This relies on
+    dataset names not colliding with category/sample/variable keys, which holds for
+    the <sample>_<year> naming convention. Returns `o`.
+    """
+    datasets = set(datasets)
+    def _recurse(node):
+        if isinstance(node, dict):              # also covers defaultdict
+            for k in list(node.keys()):
+                if k in datasets:
+                    del node[k]
+                else:
+                    _recurse(node[k])
+        elif isinstance(node, set):             # by_datataking_period[year][sample]
+            node.difference_update(datasets)
+    _recurse(o)
+    return o
+
 def compare_dict_types(d1, d2, path=""):
     """
     Recursively compare the types of values between two dictionaries.


### PR DESCRIPTION
Treat the first input file as a base and remove from it every dataset that also appears in the remaining (incoming) files before merging, so the newer files replace rather than sum with the base content.

- Add get_datasets_in_output / remove_datasets_from_output helpers in filter_output.py (generic recursive removal across all nested structures and the by_datataking_period sets)
- Wire --replace through merge_outputs/main; guard against <2 inputs and -jc mode; report replaced vs. added datasets
- Add unit tests and document the flag in docs/recipes.md