### PR TITLE
Fix trigger-name prefix stripping (lstrip char-set bug)

### DIFF
--- a/pocket_coffea/lib/cut_functions.py
+++ b/pocket_coffea/lib/cut_functions.py
@@ -1,6 +1,6 @@
 import awkward as ak
 from .cut_definition import Cut
-from .triggers import get_trigger_mask_byprimarydataset,  apply_trigger_mask
+from .triggers import get_trigger_mask_byprimarydataset,  apply_trigger_mask, remove_trigger_prefix
 import correctionlib
 import numpy as np
 from coffea.lumi_tools import LumiMask
@@ -57,7 +57,7 @@ def get_HLTsel_custom(trigger_list, invert=False):
 
     The Cut function does not read the triggers configuration, but uses the list of triggers provided dynamically.
     '''
-    triggers_to_apply = [t.lstrip("HLT_") for t in trigger_list]
+    triggers_to_apply = [remove_trigger_prefix(t, "HLT_") for t in trigger_list]
     return Cut(
         name="HLT_trigger_"+ "_".join(trigger_list),
         params={"triggers_to_apply": triggers_to_apply,  "invert": invert},
@@ -112,7 +112,7 @@ def get_L1sel_custom(trigger_list, invert=False):
 
     The Cut function does not read the triggers configuration, but uses the list of triggers provided dynamically.
     '''
-    triggers_to_apply = [t.lstrip("L1_") for t in trigger_list]
+    triggers_to_apply = [remove_trigger_prefix(t, "L1_") for t in trigger_list]
     return Cut(
         name="L1_trigger_"+ "_".join(trigger_list),
         params={"triggers_to_apply": triggers_to_apply,  "invert": invert},

--- a/pocket_coffea/lib/triggers.py
+++ b/pocket_coffea/lib/triggers.py
@@ -1,5 +1,21 @@
+import logging
 import numpy as np
 import awkward as ak
+
+# Track trigger names already reported as missing so the warning is not emitted
+# once per chunk (this module is imported once per worker process).
+_missing_trigger_warned = set()
+
+
+def remove_trigger_prefix(name, prefix):
+    '''Remove `prefix` from the start of a trigger `name`.
+
+    This is a genuine prefix removal: `str.lstrip(prefix)` must NOT be used because
+    it strips any leading character contained in `prefix` (a character set), which
+    silently mangles trigger names, e.g. ``"HLT_TkMu50".lstrip("HLT_")`` -> ``"kMu50"``.
+    '''
+    return name[len(prefix):] if name.startswith(prefix) else name
+
 
 def apply_trigger_mask(events, triggers_to_apply, year, invert=False, trigger_type="HLT"):
     '''Computes the HLT/L1 trigger mask doing the OR of all the triggers in the list
@@ -26,6 +42,19 @@ def apply_trigger_mask(events, triggers_to_apply, year, invert=False, trigger_ty
         else:
             if trigger in events_trigger.fields:
                 trigger_mask = trigger_mask | events_trigger[trigger]
+            else:
+                # A requested trigger is not present in this NanoAOD file. This can be
+                # legitimate (trigger menu evolution across eras / NanoAOD versions) but
+                # is also how a mistyped or mangled trigger name would silently vanish
+                # from the OR, so surface it loudly (once per name per worker).
+                key = (trigger_type, year, trigger)
+                if key not in _missing_trigger_warned:
+                    _missing_trigger_warned.add(key)
+                    logging.warning(
+                        f"[triggers] {trigger_type} path '{trigger}' (year {year}) not found "
+                        f"in events.{trigger_type} fields; it is skipped in the trigger OR. "
+                        f"Check the trigger name if this is unexpected."
+                    )
 
     if invert:
         trigger_mask = ~trigger_mask
@@ -57,14 +86,15 @@ def get_trigger_mask_byprimarydataset(events, trigger_dict, year, isMC, primaryD
     if primaryDatasets:
         # if primary dataset is passed, take all the requested trigger
         for pd in primaryDatasets:
-            triggers_to_apply += [t.lstrip(trigger_prefix) for t in cfg[pd]]
+            triggers_to_apply += [remove_trigger_prefix(t, trigger_prefix) for t in cfg[pd]]
     else:
         if isMC:
             # If MC take the OR of all primary datasets
             for pd, trgs in cfg.items():
-                triggers_to_apply += [t.lstrip(trigger_prefix) for t in trgs]
+                triggers_to_apply += [remove_trigger_prefix(t, trigger_prefix) for t in trgs]
         else:
             # If Data take only the specific pd
-            triggers_to_apply += [t.lstrip(trigger_prefix) for t in cfg[events.metadata["primaryDataset"]]]
+            triggers_to_apply += [remove_trigger_prefix(t, trigger_prefix) for t in cfg[events.metadata["primaryDataset"]]]
 
+    # trigger_prefix is "HLT_" or "L1_"; stripping the single trailing "_" is unambiguous.
     return apply_trigger_mask(events, triggers_to_apply, year, invert=invert, trigger_type=trigger_prefix.rstrip("_"))

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,83 @@
+"""Offline unit tests for trigger-name handling (no EOS / proxy needed).
+
+These synthesize a minimal `events` object with an `HLT` record so the trigger
+helpers can be exercised without loading NanoAOD. They specifically use a trigger
+name (`TkMu50`) that the old `str.lstrip("HLT_")` implementation mangled to
+`kMu50` and then silently dropped from the OR.
+"""
+import numpy as np
+import awkward as ak
+
+from pocket_coffea.lib.triggers import (
+    remove_trigger_prefix,
+    apply_trigger_mask,
+    get_trigger_mask_byprimarydataset,
+)
+
+
+def _make_events():
+    """A 4-event synthetic object exposing `events.HLT.<path>`."""
+    hlt = ak.Array(
+        {
+            "TkMu50": np.array([True, False, False, True]),
+            "IsoMu24": np.array([False, True, False, False]),
+            "Ele32_WPTight_Gsf": np.array([False, False, True, False]),
+        }
+    )
+    return ak.Array({"event": np.arange(4, dtype=np.int64), "HLT": hlt})
+
+
+def test_remove_trigger_prefix_is_not_charset_strip():
+    # The whole point: prefix removal, not str.lstrip character-set stripping.
+    assert remove_trigger_prefix("HLT_TkMu50", "HLT_") == "TkMu50"
+    assert remove_trigger_prefix("HLT_TripleMu_12_10_5", "HLT_") == "TripleMu_12_10_5"
+    assert remove_trigger_prefix("L1_LooseIsoEG28er2p1", "L1_") == "LooseIsoEG28er2p1"
+    # No prefix present -> unchanged.
+    assert remove_trigger_prefix("TkMu50", "HLT_") == "TkMu50"
+    # Sanity: the old buggy behaviour is what we are avoiding.
+    assert "HLT_TkMu50".lstrip("HLT_") == "kMu50"
+
+
+def test_apply_trigger_mask_or():
+    events = _make_events()
+    mask = apply_trigger_mask(events, ["TkMu50", "IsoMu24"], year="2018", trigger_type="HLT")
+    expected = events.HLT.TkMu50 | events.HLT.IsoMu24
+    assert ak.all(mask == expected)
+    assert ak.sum(mask) == 3
+
+
+def test_apply_trigger_mask_skips_unknown(caplog):
+    events = _make_events()
+    with caplog.at_level("WARNING"):
+        mask = apply_trigger_mask(
+            events, ["TkMu50", "ThisPathDoesNotExist"], year="2018", trigger_type="HLT"
+        )
+    # Unknown path contributes nothing; TkMu50 still drives the mask.
+    assert ak.all(mask == events.HLT.TkMu50)
+    # ...and the drop is surfaced, not silent.
+    assert any("ThisPathDoesNotExist" in rec.message for rec in caplog.records)
+
+
+def test_bypd_regression_prefixed_names_survive():
+    """Config stores full `HLT_...` names; they must map to the stripped fields.
+
+    Pre-fix, `HLT_TkMu50` became `kMu50` (not a field) and was silently dropped,
+    so the OR reduced to IsoMu24 only. This asserts both paths contribute.
+    """
+    events = _make_events()
+    trigger_dict = {"2018": {"SingleMu": ["HLT_TkMu50", "HLT_IsoMu24"]}}
+
+    # MC path: OR of all primary datasets.
+    mask_mc = get_trigger_mask_byprimarydataset(
+        events, trigger_dict, year="2018", isMC=True, trigger_prefix="HLT_"
+    )
+    expected = events.HLT.TkMu50 | events.HLT.IsoMu24
+    assert ak.all(mask_mc == expected)
+    assert ak.sum(mask_mc) == 3  # would be 1 if HLT_TkMu50 were dropped
+
+    # Explicit primaryDatasets path (applies to MC and data alike).
+    mask_pd = get_trigger_mask_byprimarydataset(
+        events, trigger_dict, year="2018", isMC=True,
+        primaryDatasets=["SingleMu"], trigger_prefix="HLT_",
+    )
+    assert ak.all(mask_pd == expected)


### PR DESCRIPTION
`str.lstrip("HLT_")` / `lstrip("L1_")` strip a *character set*, not a prefix, so trigger names starting with H/L/T after the prefix were mangled, e.g. `HLT_TkMu50` -> `kMu50` and `HLT_TripleMu_12_10_5` -> `ripleMu_12_10_5`. `apply_trigger_mask` then silently skipped the mangled (unknown) name, dropping it from the trigger OR and losing events with no error.

- Add `remove_trigger_prefix()` (genuine prefix removal) and route all four sites through it (triggers.py x3 + cut_functions.py custom-trigger helpers).
- Log a de-duplicated WARNING when a requested trigger is absent from the file, so a genuinely-missing or mistyped path is surfaced instead of vanishing.
- Add offline unit tests (synthetic `.HLT` record) covering the prefix removal, the OR, the missing-trigger warning, and a `get_trigger_mask_byprimarydataset` regression on `HLT_TkMu50`.

Behaviour change: configs whose trigger names were being silently dropped will now include those paths in the OR (that is the fix). The 2017 Ele32 special-case guard is intentionally left unchanged pending analyst confirmation.