### PR TITLE
Apply minpt in nElectron/nMuon; include collection in Cut identity

### DIFF
--- a/pocket_coffea/lib/cut_definition.py
+++ b/pocket_coffea/lib/cut_definition.py
@@ -32,8 +32,22 @@ class Cut:
         )
 
     def __hash__(self):
-        '''The Cut is unique by its name, the  function, and the dict of parameters.'''
-        return hash((self.name, json.dumps(self.params), self.function))
+        '''The Cut is unique by its name, collection, function, and parameters.
+
+        `collection` must be part of the identity: two otherwise-identical cuts
+        applied to different collections (e.g. "events" vs "Jet") produce masks of
+        different dimensionality and must not be deduplicated to one. The params are
+        serialized with sorted keys (order-independent) and `default=str` so
+        non-JSON-serializable values (e.g. numpy scalars) do not raise.
+        '''
+        return hash(
+            (
+                self.name,
+                self.collection,
+                json.dumps(self.params, sort_keys=True, default=str),
+                self.function,
+            )
+        )
 
     def __eq__(self, other):
         return hash(self) == hash(other)

--- a/pocket_coffea/lib/cut_functions.py
+++ b/pocket_coffea/lib/cut_functions.py
@@ -411,23 +411,23 @@ def nBtagEq(events, params, year, processor_params, **kwargs):
 
 
 def nElectron(events, params, year, **kwargs):
-    '''Mask for min N electrons with minpt.'''
-    if params["coll"] == "ElectronGood":
-        return events.nElectronGood >= params["N"]
-    elif params["coll"] == "Electron":
-        return events.nElectron >= params["N"]
+    '''Mask for min N electrons above `minpt`.'''
+    coll = params["coll"]
+    minpt = params.get("minpt", 0)
+    if coll in ("ElectronGood", "Electron"):
+        return ak.sum(events[coll].pt > minpt, axis=1) >= params["N"]
     else:
-        raise Exception(f"The collection '{params['coll']}' does not exist.")
+        raise Exception(f"The collection '{coll}' does not exist.")
 
 
 def nMuon(events, params, year, **kwargs):
-    '''Mask for min N electrons with minpt.'''
-    if params["coll"] == "MuonGood":
-        return events.nMuonGood >= params["N"]
-    elif params["coll"] == "Muon":
-        return events.nMuon >= params["N"]
+    '''Mask for min N muons above `minpt`.'''
+    coll = params["coll"]
+    minpt = params.get("minpt", 0)
+    if coll in ("MuonGood", "Muon"):
+        return ak.sum(events[coll].pt > minpt, axis=1) >= params["N"]
     else:
-        raise Exception(f"The collection '{params['coll']}' does not exist.")
+        raise Exception(f"The collection '{coll}' does not exist.")
 
 
 ##########################33

--- a/tests/test_cut_functions_offline.py
+++ b/tests/test_cut_functions_offline.py
@@ -1,0 +1,54 @@
+"""Offline unit tests for cut helpers (no EOS / proxy needed).
+
+Covers the `minpt` threshold in nElectron/nMuon (previously accepted but ignored)
+and the Cut identity now including `collection` and tolerating non-JSON params.
+"""
+import numpy as np
+import awkward as ak
+
+from pocket_coffea.lib.cut_functions import nElectron, nMuon
+from pocket_coffea.lib.cut_definition import Cut
+
+
+def _events():
+    electrons = ak.zip({"pt": ak.Array([[35.0, 20.0, 5.0], [40.0], []])})
+    muons = ak.zip({"pt": ak.Array([[50.0, 12.0], [8.0], [33.0, 31.0]])})
+    return ak.Array({"ElectronGood": electrons, "MuonGood": muons})
+
+
+def test_nElectron_applies_minpt():
+    events = _events()
+    # pt>30 counts: [1, 1, 0]
+    assert ak.to_list(nElectron(events, {"coll": "ElectronGood", "N": 1, "minpt": 30}, "2018")) == [True, True, False]
+    assert ak.to_list(nElectron(events, {"coll": "ElectronGood", "N": 2, "minpt": 30}, "2018")) == [False, False, False]
+    # With no threshold, counts are [3, 1, 0] -> the N=2 result differs, proving minpt is honoured.
+    assert ak.to_list(nElectron(events, {"coll": "ElectronGood", "N": 2, "minpt": 0}, "2018")) == [True, False, False]
+
+
+def test_nMuon_applies_minpt():
+    events = _events()
+    # pt>30 counts: [1, 0, 2]
+    assert ak.to_list(nMuon(events, {"coll": "MuonGood", "N": 2, "minpt": 30}, "2018")) == [False, False, True]
+    # No threshold -> counts [2, 1, 2]
+    assert ak.to_list(nMuon(events, {"coll": "MuonGood", "N": 2, "minpt": 0}, "2018")) == [True, False, True]
+
+
+def _f(events, params, **kwargs):
+    return None
+
+
+def test_cut_identity_includes_collection():
+    c_events = Cut(name="x", params={"a": 1, "b": 2}, function=_f, collection="events")
+    c_jet = Cut(name="x", params={"a": 1, "b": 2}, function=_f, collection="Jet")
+    assert hash(c_events) != hash(c_jet)
+    assert c_events.id != c_jet.id
+    assert c_events != c_jet
+
+
+def test_cut_hash_is_param_order_independent_and_numpy_safe():
+    c1 = Cut(name="y", params={"a": 1, "b": 2}, function=_f)
+    c2 = Cut(name="y", params={"b": 2, "a": 1}, function=_f)
+    assert hash(c1) == hash(c2)
+    # A numpy-scalar param must not break hashing/id.
+    c_np = Cut(name="z", params={"thr": np.float64(3.5)}, function=_f)
+    assert isinstance(c_np.id, str)


### PR DESCRIPTION
nElectron/nMuon accepted a `minpt` argument, baked it into the cut name, but never applied it — the mask was just `events.nXGood >= N`. Count objects above the threshold instead. Behaviour change: configs using `get_nElectron(N, minpt>0)` (or nMuon) now honour the pt cut; minpt=0 is unchanged.

Cut.__hash__ omitted `collection`, so two cuts identical except for the collection they act on (e.g. "events" vs "Jet", producing masks of different dimensionality) hashed/compared equal and were deduplicated to one in StandardSelection. Add `collection` to the identity, and serialize params with sort_keys=True (order-independent) and default=str (tolerate numpy scalars).

Adds offline unit tests for the minpt threshold and the collection-aware, param-order-independent, numpy-safe Cut identity. Verified test_categorization and test_cartesian_categorization still pass (cut-id change does not alter output).