### PR TITLE
Fix CartesianSelection serialize/template_mask and StandardSelection

### DIFF
--- a/pocket_coffea/lib/categorization.py
+++ b/pocket_coffea/lib/categorization.py
@@ -221,7 +221,7 @@ class StandardSelection:
             self.categories[k] = []
             for c in cuts:
                 if not isinstance(c, Cut):
-                    raise Exception(f"The cut is not defined as a Cut object: {cut}")
+                    raise Exception(f"The cut is not defined as a Cut object: {c}")
                 self.categories[k].append(c.id)
                 self.cut_functions.append(c)
                 self.cut_dict[c.id] = c
@@ -284,7 +284,7 @@ class StandardSelection:
 
     @property
     def template_mask(self):
-        if self.ready and self.ismulti_dim:
+        if self.ready and self.is_multidim:
             return self.storage.template_mask
         else:
             return None
@@ -464,10 +464,13 @@ class CartesianSelection:
 
     @property
     def template_mask(self):
-        if self.ready and self.ismulti_dim:
-            return self.storage.template_mask
-        else:
-            return None
+        # A CartesianSelection has no single MaskStorage (it caches per-multi-index
+        # products); the multidim template, when relevant, lives in the common
+        # StandardSelection. `self.ready`/`self.storage`/`self.ismulti_dim` were never
+        # set here, so the previous body raised AttributeError if ever accessed.
+        if self.has_common_cats:
+            return self.common_cats.template_mask
+        return None
 
     def keys(self):
         return self.categories
@@ -487,7 +490,11 @@ class CartesianSelection:
     def serialize(self):
         return {
             "type": "CartesianSelection",
-            "common_categories": self.common_cats.serialize(),
+            # When no common categories are given, `self.common_cats` is an empty dict
+            # (not a StandardSelection), which has no serialize() -> guard it.
+            "common_categories": (
+                self.common_cats.serialize() if self.has_common_cats else None
+            ),
             "multicuts": [m.serialize() for m in self.multicuts],
             "is_multidim": self.is_multidim,
             "multidim_collection": self.multidim_collection,

--- a/tests/test_categorization_serialize.py
+++ b/tests/test_categorization_serialize.py
@@ -1,0 +1,41 @@
+"""Offline unit tests for CartesianSelection serialize / error paths (no EOS needed).
+
+The Configurator serializes the categories at every run start, so a
+CartesianSelection built with only multicuts (no common categories) previously
+crashed at config-save time because `self.common_cats` was a plain `{}`.
+"""
+import pytest
+
+from pocket_coffea.lib.cut_definition import Cut
+from pocket_coffea.lib.categorization import (
+    MultiCut,
+    CartesianSelection,
+    StandardSelection,
+)
+
+
+def _cut_fn(events, params, **kwargs):
+    return None
+
+
+def test_cartesian_serialize_without_common_cats():
+    c_lo = Cut(name="binA_lo", params={"x": 0}, function=_cut_fn)
+    c_hi = Cut(name="binA_hi", params={"x": 1}, function=_cut_fn)
+    mc = MultiCut(name="binA", cuts=[c_lo, c_hi], cuts_names=["lo", "hi"])
+    cs = CartesianSelection(multicuts=[mc])  # no common_cats
+
+    s = cs.serialize()  # previously raised AttributeError on {}.serialize()
+    assert s["type"] == "CartesianSelection"
+    assert s["common_categories"] is None
+    assert len(s["multicuts"]) == 1
+
+    # template_mask previously referenced unset attributes -> AttributeError.
+    assert cs.template_mask is None
+
+
+def test_standardselection_rejects_non_cut_with_clear_message():
+    with pytest.raises(Exception) as exc:
+        StandardSelection({"cat": ["not_a_cut"]})
+    # The message must name the offending object (the fix); the old code raised a
+    # NameError on an undefined variable instead.
+    assert "not_a_cut" in str(exc.value)


### PR DESCRIPTION
- CartesianSelection.serialize() called self.common_cats.serialize(), but when no common categories are given self.common_cats is a plain {} (no serialize()). Since the Configurator serializes categories at every run start, a CartesianSelection built from only multicuts crashed with AttributeError at config-save time. Guard it (common_categories -> None when absent).
- CartesianSelection.template_mask referenced self.ready/self.storage/self.ismulti_dim, none of which are ever set on that class -> AttributeError if accessed. Delegate to the common StandardSelection (or None), matching how the class actually stores masks.
- StandardSelection.template_mask used the misspelled self.ismulti_dim -> is_multidim.
- StandardSelection.__init__ error path formatted an undefined `cut` (loop var is `c`) -> NameError instead of the intended message. Use `c`.

Adds an offline test building a CartesianSelection with only multicuts and asserting serialize()/template_mask no longer raise, plus the corrected error message.