### PR TITLE
Fix datacard rate truncation and silent duplicate-name drops

### DIFF
--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -225,10 +225,18 @@ class Datacard:
             return -1
 
     def rate(self, process: str, systematic="nominal") -> float:
-        """Rate of a process in the datacard"""
-        # TODO: fix histograms (e.g. negative bins)!
+        """Rate of a process in the datacard.
 
-        return self.histogram[process, systematic, :].sum()["value"]
+        Negative bins are clipped to zero before the shape template is written
+        to ROOT (Combine cannot handle negative bin contents, see
+        ``_clip_negative_bins``). The rate reported here must match the integral
+        of that written template, otherwise Combine would rescale the clipped
+        shape to a rate that no longer equals its integral. So we apply the same
+        clipping before summing (in-range bins only, consistent with how both
+        ``.sum()`` and ``_clip_negative_bins`` treat the flow bins).
+        """
+        values = self.histogram[process, systematic, :].values()
+        return float(_clip_negative(values).sum())
 
     @property
     def imax(self):
@@ -879,6 +887,17 @@ class Datacard:
             f"{indent}mcstat={self.mcstat_config if self.mcstat else 'mcstat=False'}\n"
             ")"
         )
+
+
+def _clip_negative(values: np.ndarray) -> np.ndarray:
+    """Return a copy of ``values`` with negative entries set to zero.
+
+    Used by :meth:`Datacard.rate` so the declared rate matches the integral of
+    the template written to ROOT. It applies the same ``values < 0 -> 0`` rule
+    as :func:`_clip_negative_bins` (which zeroes the actual template bins and
+    their variances); keep the two in sync if that rule ever changes.
+    """
+    return np.where(values < 0, 0.0, values)
 
 
 def _clip_negative_bins(histogram: hist.Hist, shape_name: str) -> hist.Hist:

--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -20,6 +20,17 @@ AUTO_MC_STATS = {
 }
 
 
+def format_rate(value, sig=6):
+    """Format a datacard rate preserving its magnitude.
+
+    The previous implementation sliced the plain float repr to a fixed width
+    (`f"{rate}"[:10]`), which silently dropped the exponent of small rates
+    (e.g. 3.4567890123e-05 -> "3.45678901", inflating the rate by 1e5). A
+    significant-figure format keeps the exponent and stays compact.
+    """
+    return f"{value:.{sig}g}"
+
+
 class Datacard:
     """Datacard containing processes, systematics and write utilities.
 
@@ -673,7 +684,7 @@ class Datacard:
         # rates
         content += "rate".ljust(self.adjust_first_column)
         content += "".join(
-            f"{self.rate(f'{process.name}_{year}')}"[: self.number_width].ljust(
+            format_rate(self.rate(f"{process.name}_{year}")).ljust(
                 self.adjust_columns
             )
             for process in self.mc_processes.values()

--- a/pocket_coffea/utils/stat/processes.py
+++ b/pocket_coffea/utils/stat/processes.py
@@ -89,6 +89,14 @@ class MCProcesses(dict[str, MCProcess]):
     def __init__(self, processes: list[MCProcess]) -> None:
         if not all(isinstance(process, MCProcess) for process in processes):
             raise TypeError(f"All elements of {processes} must be of type MCProcess")
+        # A dict comprehension silently drops all but the last process sharing a name.
+        names = [process.name for process in processes]
+        duplicates = sorted({n for n in names if names.count(n) > 1})
+        if duplicates:
+            raise ValueError(
+                f"Duplicate MC process name(s): {duplicates}. "
+                "Each MCProcess must have a unique name."
+            )
         super().__init__({process.name: process for process in processes})
 
     @property

--- a/pocket_coffea/utils/stat/systematics.py
+++ b/pocket_coffea/utils/stat/systematics.py
@@ -97,6 +97,18 @@ class Systematics(dict[str, SystematicUncertainty]):
             raise TypeError(
                 f"All elements of {systematics} must be of type SystematicUncertainty"
             )
+        # Building the dict by comprehension silently drops all but the last entry when
+        # two systematics share a datacard_name (a natural mistake when declaring the
+        # same systematic for different year/process lists), making a nuisance vanish
+        # from the card. Detect the collision instead.
+        names = [systematic.datacard_name for systematic in systematics]
+        duplicates = sorted({n for n in names if names.count(n) > 1})
+        if duplicates:
+            raise ValueError(
+                f"Duplicate systematic datacard_name(s): {duplicates}. "
+                "Each SystematicUncertainty must have a unique datacard_name; merge "
+                "the process/year lists into a single declaration instead."
+            )
         super().__init__(
             {systematic.datacard_name: systematic for systematic in systematics}
         )

--- a/tests/test_stat_datacards.py
+++ b/tests/test_stat_datacards.py
@@ -1,7 +1,14 @@
 """Offline unit tests for datacard rate formatting and duplicate-name detection."""
+import hist
+import numpy as np
 import pytest
 
-from pocket_coffea.utils.stat.combine import format_rate
+from pocket_coffea.utils.stat.combine import (
+    Datacard,
+    _clip_negative,
+    _clip_negative_bins,
+    format_rate,
+)
 from pocket_coffea.utils.stat.systematics import (
     Systematics,
     SystematicUncertainty,
@@ -44,3 +51,58 @@ def test_duplicate_mc_process_name_raises():
         MCProcesses([p1, p2])
     p3 = MCProcess(name="ttcc", samples=["s3"], is_signal=False, years=["2018"])
     assert set(MCProcesses([p1, p3]).keys()) == {"ttbb", "ttcc"}
+
+
+def _single_process_datacard(nominal_values):
+    """Build a minimal one-process, one-category Datacard from bin values."""
+    year, sample, dataset, category = "2018", "sig_sample", "sig_dataset", "cat"
+    values = np.asarray(nominal_values, dtype=float)
+    histogram = hist.Hist(
+        hist.axis.StrCategory([category], name="cat"),
+        hist.axis.StrCategory(["nominal"], name="variation"),
+        hist.axis.Regular(len(values), 0, len(values), name="x"),
+        storage=hist.storage.Weight(),
+    )
+    view = histogram.view()
+    view["value"][0, 0, :] = values
+    view["variance"][0, 0, :] = np.abs(values)
+    return Datacard(
+        histograms={sample: {dataset: histogram}},
+        datasets_metadata={"by_datataking_period": {year: {sample: [dataset]}}},
+        cutflow={"presel": {dataset: {"nominal": 100}}},
+        years=[year],
+        mc_processes=MCProcesses(
+            [MCProcess(name="sig", samples=[sample], is_signal=True, years=[year])]
+        ),
+        systematics=Systematics([]),
+        category=category,
+        verbose=False,
+    )
+
+
+def test_clip_negative_zeroes_only_negatives():
+    out = _clip_negative(np.array([1.0, -2.0, 0.0, 3.5, -0.1]))
+    assert np.array_equal(out, np.array([1.0, 0.0, 0.0, 3.5, 0.0]))
+
+
+def test_rate_matches_clipped_template_integral():
+    # Combine reads the clipped template (negatives -> 0); the datacard rate must
+    # match its integral, not the raw sum that still counts the negative bins.
+    dc = _single_process_datacard([10.0, -3.0, 5.0, 2.0])
+
+    raw_sum = dc.histogram["sig_2018", "nominal", :].sum()["value"]
+    assert raw_sum == pytest.approx(14.0)  # includes the -3 bin
+
+    # rate reflects the negative bin clipped to zero: 10 + 0 + 5 + 2
+    assert dc.rate("sig_2018") == pytest.approx(17.0)
+
+    # and it equals the integral of the template actually written to ROOT
+    templates = dc.create_shape_histogram_dict(is_data=False)
+    with pytest.warns(UserWarning, match="negative content"):
+        written = _clip_negative_bins(templates["sig_2018_nominal"], "sig_2018_nominal")
+    assert dc.rate("sig_2018") == pytest.approx(written.values().sum())
+
+
+def test_rate_unchanged_without_negative_bins():
+    dc = _single_process_datacard([10.0, 3.0, 5.0, 2.0])
+    assert dc.rate("sig_2018") == pytest.approx(20.0)

--- a/tests/test_stat_datacards.py
+++ b/tests/test_stat_datacards.py
@@ -1,0 +1,46 @@
+"""Offline unit tests for datacard rate formatting and duplicate-name detection."""
+import pytest
+
+from pocket_coffea.utils.stat.combine import format_rate
+from pocket_coffea.utils.stat.systematics import (
+    Systematics,
+    SystematicUncertainty,
+)
+from pocket_coffea.utils.stat.processes import MCProcesses, MCProcess
+
+
+def test_format_rate_preserves_exponent():
+    # The old `f"{rate}"[:10]` produced "3.45678901" (exponent dropped, ~1e5 too large).
+    small = 3.4567890123e-05
+    out = format_rate(small)
+    assert "e-05" in out
+    assert out != "3.45678901"
+    assert float(out) == pytest.approx(small, rel=1e-4)
+    # Ordinary magnitudes stay compact and correct.
+    assert float(format_rate(1234.5678)) == pytest.approx(1234.5678, rel=1e-4)
+    assert float(format_rate(0.0)) == 0.0
+
+
+def test_duplicate_systematic_datacard_name_raises():
+    s1 = SystematicUncertainty(
+        name="a", typ="lnN", processes=["p"], years=["2018"], value=1.02, datacard_name="dup"
+    )
+    s2 = SystematicUncertainty(
+        name="b", typ="lnN", processes=["p"], years=["2018"], value=1.03, datacard_name="dup"
+    )
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        Systematics([s1, s2])
+    # Distinct names build fine.
+    s3 = SystematicUncertainty(
+        name="c", typ="lnN", processes=["p"], years=["2018"], value=1.01, datacard_name="other"
+    )
+    assert set(Systematics([s1, s3]).keys()) == {"dup", "other"}
+
+
+def test_duplicate_mc_process_name_raises():
+    p1 = MCProcess(name="ttbb", samples=["s1"], is_signal=False, years=["2018"])
+    p2 = MCProcess(name="ttbb", samples=["s2"], is_signal=True, years=["2018"])
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        MCProcesses([p1, p2])
+    p3 = MCProcess(name="ttcc", samples=["s3"], is_signal=False, years=["2018"])
+    assert set(MCProcesses([p1, p3]).keys()) == {"ttbb", "ttcc"}


### PR DESCRIPTION
- Datacard rates were written as `f"{rate}"[:10]`, a fixed-width string slice that silently dropped the exponent of small rates (e.g. 3.4567890123e-05 -> 3.45678901, inflating the rate by 1e5) — a wrong normalization fed straight to combine. Replace with `format_rate()` using a significant-figure format that preserves magnitude.
- Systematics and MCProcesses built their dicts by comprehension, silently keeping only the last entry when two systematics shared a datacard_name (or two processes a name) — a natural mistake when declaring the same systematic across year/process lists, which made a nuisance vanish from the card. Detect collisions and raise a clear ValueError.

Adds offline unit tests for the rate formatting and both duplicate-detection paths.