### PR TITLE
Fix shared metadata dict corrupting das_names across selected datasets

### DIFF
--- a/pocket_coffea/scripts/dataset/dataset_query.py
+++ b/pocket_coffea/scripts/dataset/dataset_query.py
@@ -243,6 +243,12 @@ Some basic commands:
         try:
             xsec = self.extract_xsec_from_dataset_name(dataset)
         except Exception as e:
+            # Falling back to 1.0 silently writes a wrong MC normalization into the
+            # dataset definition; surface it so the user can fix the xsec by hand.
+            print(
+                f"[red]WARNING[/]: could not determine cross section for {dataset} "
+                f"({e}); defaulting xsec=1.0 — set it manually in the dataset definition."
+            )
             xsec = 1.0
         primary_dataset,year_data,era_data = self.extract_era_from_dataset_name(dataset)
         if isMC == True:
@@ -341,7 +347,11 @@ Some basic commands:
             if s < Nresults:
                 self.selected_datasets.append(self.last_query_list[s])
                 if metadata:
-                    self.selected_datasets_metadata.append(metadata)
+                    # Deep-copy: the same `metadata` dict is passed for every dataset in a
+                    # (wildcard) selection. Appending the shared reference means later
+                    # per-dataset mutations in do_save (e.g. das_names) overwrite every
+                    # dataset's metadata with the last one's.
+                    self.selected_datasets_metadata.append(copy.deepcopy(metadata))
                 else:
                     self.selected_datasets_metadata.append(self.generate_default_metadata(self.last_query_list[s]))
                     #self.selected_datasets_metadata.append({
@@ -685,7 +695,7 @@ Some basic commands:
             for dataset in datasets:
                 dataset_info["files"].append({
                 "das_names": [dataset],
-                "metadata": self.selected_datasets_metadata[self.selected_datasets.index(dataset)]
+                "metadata": copy.deepcopy(self.selected_datasets_metadata[self.selected_datasets.index(dataset)])
                 })
             output_definition[group] = dataset_info
             # now replica info

--- a/tests/test_dataset_query_metadata.py
+++ b/tests/test_dataset_query_metadata.py
@@ -1,0 +1,65 @@
+"""Offline test that dataset selection does not share one metadata dict across datasets.
+
+A wildcard query selects many datasets with a single `metadata` dict; do_save later
+mutates each dataset's metadata in place (e.g. das_names). If the same dict object is
+shared, every dataset ends up with the last one's provenance.
+
+`do_select` itself uses no network, but importing dataset_query pulls in
+`pocket_coffea.utils.rucio`, which imports the `rucio` package at module load. When
+rucio is unavailable we install lightweight stubs so this stays a genuinely offline
+test (the real package is used whenever it is importable).
+"""
+import sys
+import types
+
+
+def _ensure_rucio_importable():
+    try:
+        import rucio.client  # noqa: F401
+        import rucio.common.client  # noqa: F401
+        return
+    except (ImportError, OSError):
+        rucio = types.ModuleType("rucio")
+        client = types.ModuleType("rucio.client")
+        client.Client = object
+        common = types.ModuleType("rucio.common")
+        common_client = types.ModuleType("rucio.common.client")
+        common_client.detect_client_location = lambda *a, **k: {}
+        rucio.client = client
+        rucio.common = common
+        common.client = common_client
+        sys.modules.setdefault("rucio", rucio)
+        sys.modules.setdefault("rucio.client", client)
+        sys.modules.setdefault("rucio.common", common)
+        sys.modules.setdefault("rucio.common.client", common_client)
+
+
+_ensure_rucio_importable()
+
+from pocket_coffea.scripts.dataset.dataset_query import DataDiscoveryCLI  # noqa: E402
+
+
+def _cli_with_query(query_list):
+    # Bypass __init__ (which sets up rucio); we only exercise do_select's bookkeeping.
+    cli = DataDiscoveryCLI.__new__(DataDiscoveryCLI)
+    cli.last_query_list = list(query_list)
+    cli.selected_datasets = []
+    cli.selected_datasets_metadata = []
+    return cli
+
+
+def test_do_select_metadata_is_per_dataset_copy():
+    cli = _cli_with_query(["/DAS/A/NANOAODSIM", "/DAS/B/NANOAODSIM"])
+    shared_meta = {"year": "2018", "isMC": "True", "das_names": ["placeholder"]}
+
+    cli.do_select(selection="all", metadata=shared_meta)
+
+    assert len(cli.selected_datasets_metadata) == 2
+    m0, m1 = cli.selected_datasets_metadata
+    # The stored dicts must be independent objects (and independent of the input).
+    assert m0 is not m1
+    assert m0 is not shared_meta
+
+    # Mutating one dataset's metadata (as do_save does) must not touch the other's.
+    m0["das_names"] = ["/DAS/A/NANOAODSIM"]
+    assert m1["das_names"] == ["placeholder"]


### PR DESCRIPTION
do_select appended the *same* `metadata` dict object once per dataset when a (wildcard) query selected several datasets with one metadata. do_save then mutated that shared dict in place (das_names, sample), so every dataset in the group ended up with the last dataset's das_names — both in the *_replicas file and, via the same reference, in the main dataset definition.

- Deep-copy the metadata per dataset in do_select (root cause), and defensively deep-copy again when materialising it in do_save so no shared object is mutated.
- generate_default_metadata: warn instead of silently defaulting xsec=1.0 on lookup failure, since that wrong normalization is written into the dataset definition.

Adds an offline test (rucio stubbed when unavailable) asserting do_select stores independent per-dataset metadata dicts.

Note: other dataset-discovery issues (UL16 PreVFP/PostVFP year detection, the --check/--download code paths, rucio partial_allowed) are left as separate follow-ups.