### PR TITLE
Separate datasets by year in ROOT export

### DIFF
--- a/pocket_coffea/utils/export.py
+++ b/pocket_coffea/utils/export.py
@@ -15,6 +15,7 @@ def save_histogram_to_root(
     year: str,
     category: str,
     output_file: os.PathLike,
+    datasets: Iterable[str] = None,
 ) -> None:
     """Save histograms for one variable to a root file.
 
@@ -26,18 +27,27 @@ def save_histogram_to_root(
     :type category: str
     :param output_file: Root file to save histograms
     :type output_file: os.PathLike
+    :param datasets: If given, only datasets in this set are summed (used to restrict
+        the sum to the current `year`'s datasets). If None, all datasets are summed.
+    :type datasets: Iterable[str], optional
 
-    The histograms for each sample are summed over all datasets.
+    The histograms for each sample are summed over the selected datasets.
     If the histogram has a variation axis, each variation is saved separately.
     """
+    datasets = None if datasets is None else set(datasets)
     with uproot.recreate(output_file) as root_file:
         for subsample, sub_dict in hist_dict.items():
             subsample = subsample.removesuffix(f"_{year}")
 
-            # sum all datasets for the category
-            hist_sum = reduce(
-                add, (histogram[category, ...] for histogram in sub_dict.values())
-            )
+            # sum only the datasets belonging to this year (all datasets if unfiltered)
+            selected = [
+                h for ds, h in sub_dict.items() if datasets is None or ds in datasets
+            ]
+            if not selected:
+                # This subsample has no datasets in the requested year -> nothing to write.
+                continue
+
+            hist_sum = reduce(add, (histogram[category, ...] for histogram in selected))
 
             # save histograms to root file
             if "variation" not in hist_sum.axes.name:
@@ -75,7 +85,16 @@ def export_coffea_output_to_root(
     """
 
     # load coffea output, get variables histograms
-    histograms = load(coffea_output)["variables"]
+    output = load(coffea_output)
+    histograms = output["variables"]
+
+    # Map each dataset to its data-taking period so the per-year export sums only the
+    # datasets of that year. Without this, a sample split across years was summed over
+    # ALL years and the identical all-years total was written into every year directory.
+    by_dataset = output.get("datasets_metadata", {}).get("by_dataset", {})
+    datasets_by_year = {}
+    for dataset, meta in by_dataset.items():
+        datasets_by_year.setdefault(meta.get("year"), set()).add(dataset)
 
     # make sure all variables are present in the coffea output
     # remove variables that are not present in the coffea output
@@ -95,8 +114,27 @@ def export_coffea_output_to_root(
     for variable in common_variables:
         hist_dict = histograms[variable]
         for year in years:
+            # Restrict to this year's datasets when the metadata is available. If the
+            # output has no datasets_metadata (older files), fall back to summing all
+            # datasets and warn that per-year separation cannot be guaranteed.
+            if by_dataset:
+                datasets = datasets_by_year.get(year)
+                if datasets is None:
+                    warnings.warn(
+                        f"No datasets found for year {year} in datasets_metadata; "
+                        f"writing an empty export for this year."
+                    )
+                    datasets = set()  # write nothing rather than the all-years sum
+            else:
+                warnings.warn(
+                    "Coffea output has no datasets_metadata; cannot separate datasets "
+                    "by year, summing all datasets for every requested year."
+                )
+                datasets = None  # legacy behaviour: sum all datasets
             for category in categories:
                 output_file = Path(output_dir, year, category, f"{variable}.root")
                 output_file.parent.mkdir(parents=True, exist_ok=True)
 
-                save_histogram_to_root(hist_dict, year, category, output_file)
+                save_histogram_to_root(
+                    hist_dict, year, category, output_file, datasets=datasets
+                )

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -705,10 +705,13 @@ class Shape:
         h_dict_grouped = {}
         samples_in_map = []
 
-        cleaned_samples_list = self.style.samples_groups.copy()
+        # Deep-copy the per-group lists: a shallow .copy() shares the inner lists with
+        # self.style.samples_groups, so removing missing samples below would both mutate
+        # the shared style and skip elements (list modified while iterating it).
+        cleaned_samples_list = {k: list(v) for k, v in self.style.samples_groups.items()}
         for sample_new, samples_list in self.style.samples_groups.items():
             #print(sample_new, samples_list)
-            for s_to_group in samples_list:
+            for s_to_group in list(samples_list):
                 if s_to_group not in self.h_dict.keys():
                     if self.verbose>=1:
                         print(f"{self.name}: WARNING. Sample ",s_to_group," is not in the list of samples: ", list(self.h_dict.keys()), "Skipping it.")

--- a/tests/test_export_root.py
+++ b/tests/test_export_root.py
@@ -1,0 +1,56 @@
+"""Offline test that ROOT export separates datasets by year (no EOS needed).
+
+Previously the per-year export summed over ALL datasets of a sample regardless of
+year, writing the identical all-years total into every year directory.
+"""
+import hist
+import uproot
+from coffea.util import save
+
+from pocket_coffea.utils.export import (
+    save_histogram_to_root,
+    export_coffea_output_to_root,
+)
+
+
+def _hist(cat, n_entries):
+    h = hist.Hist(
+        hist.axis.StrCategory([cat], name="cat", growth=True),
+        hist.axis.Regular(4, 0.0, 4.0, name="x"),
+    )
+    h.fill(cat=cat, x=[0.5] * n_entries)
+    return h
+
+
+def test_save_histogram_filters_by_year(tmp_path):
+    hist_dict = {"ttbb": {"ttbb_2017": _hist("baseline", 10), "ttbb_2018": _hist("baseline", 3)}}
+    out = tmp_path / "x.root"
+    save_histogram_to_root(hist_dict, "2018", "baseline", out, datasets={"ttbb_2018"})
+    with uproot.open(out) as f:
+        assert f["ttbb"].values().sum() == 3  # only 2018, not 13
+
+
+def test_export_coffea_output_separates_years(tmp_path):
+    output = {
+        "variables": {
+            "myvar": {"ttbb": {"ttbb_2017": _hist("baseline", 10), "ttbb_2018": _hist("baseline", 3)}}
+        },
+        "datasets_metadata": {
+            "by_dataset": {"ttbb_2017": {"year": "2017"}, "ttbb_2018": {"year": "2018"}}
+        },
+    }
+    coffea_file = tmp_path / "out.coffea"
+    save(output, coffea_file)
+    root_dir = tmp_path / "root"
+
+    export_coffea_output_to_root(
+        coffea_file, root_dir, ["myvar"], ["baseline"], ["2017", "2018"]
+    )
+
+    with uproot.open(root_dir / "2017" / "baseline" / "myvar.root") as f:
+        v2017 = f["ttbb"].values().sum()
+    with uproot.open(root_dir / "2018" / "baseline" / "myvar.root") as f:
+        v2018 = f["ttbb"].values().sum()
+
+    assert v2017 == 10
+    assert v2018 == 3  # not 13 -> the two years are genuinely separated


### PR DESCRIPTION
- save_histogram_to_root/export_coffea_output_to_root used `year` only to strip a name suffix while summing over ALL datasets of a sample, so a sample split across years produced the identical all-years-summed template in every year directory. Derive the per-year dataset set from the output's datasets_metadata and sum only those (falling back to the legacy all-datasets sum, with a warning, when metadata is absent).
- group_samples used a shallow copy of style.samples_groups, so removing a missing sample mutated the shared style list and skipped the next element while iterating, and could leave an absent sample that later KeyError'd on sample_is_MC[...[0]]. Copy the inner lists and iterate a snapshot.

Adds an offline test exporting a two-year sample and asserting each year directory gets only its own datasets. (The plotting density-ratio and plot_comparison items from the review are left as follow-ups needing visual validation.)