### PR TITLE
Fix local hadd crash and merge_outputs robustness

### DIFF
--- a/pocket_coffea/scripts/hadd_skimmed_files.py
+++ b/pocket_coffea/scripts/hadd_skimmed_files.py
@@ -118,6 +118,11 @@ def _write_do_hadd_job_splitbyfile_script(path="do_hadd_job_splitbyfile.py"):
 
 
 def do_hadd(group, overwrite=False):
+    # ROOT is imported here (not at module scope) so this function works both in the
+    # local Pool.map path and when it is inherited by worker processes; the previous
+    # code referenced an undefined `R` because `import ROOT as R` was function-local to
+    # hadd_skimmed_files() only.
+    import ROOT as R
     try:
         chain = R.TChain('Events')
         for inputfile in group[1]:
@@ -136,9 +141,11 @@ def do_hadd(group, overwrite=False):
         output_tree.Write()
         output_file.Close()
         return group[0], 0
-    except subprocess.CalledProcessError as e:
+    except Exception as e:
+        # Was `except subprocess.CalledProcessError`, which never matches (this body
+        # uses ROOT, not subprocess), so any real ROOT failure crashed the whole pool.
         print("Error producing group: ", group[0])
-        print(e.stderr)
+        print(e)
         return group[0], 1
 
 @click.command()

--- a/pocket_coffea/scripts/merge_outputs.py
+++ b/pocket_coffea/scripts/merge_outputs.py
@@ -106,6 +106,9 @@ def append_configs(c1, c2):
 
 def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace=False, N_reduction=5, max_mem_gb=None, cache_dir=None, verbose=False, skip_check=False, mark_failed=False, configurator=None, skip_initial_events_check_datasets=None):
     '''Merge coffea output files'''
+    # Initialised so the "no inputs and no -jc" branch below can test it without
+    # NameError (it is only assigned when a jobs_config is provided).
+    job_config = None
     if replace and len(inputfiles) == 0:
         print("[red]--replace only works when merging explicit input files (not with -jc).[/]")
         exit(1)
@@ -156,14 +159,19 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace
             print(f"Found {ninput} output files.")
 
         type_mismatches = []
-        f0 = inputfiles[0]
+        # Load the reference file once instead of re-deserializing it for every
+        # comparison (it was reloaded N-1 times, doubling I/O on large campaigns).
+        d0 = load(inputfiles[0])
         for f in inputfiles[1:]:
-            type_mismatch_found = compare_dict_types(load(f0), load(f))
+            type_mismatch_found = compare_dict_types(d0, load(f))
             type_mismatches.append(type_mismatch_found)
         if any(type_mismatches):
             print("[red]Type mismatch found between the values of the input dictionaries for the following files:")
-            for i, f in enumerate(inputfiles):
-                if type_mismatches[i]:
+            # type_mismatches has one entry per file compared against the reference,
+            # i.e. it lines up with inputfiles[1:], not the full inputfiles list
+            # (indexing the full list raised IndexError).
+            for f, mism in zip(inputfiles[1:], type_mismatches):
+                if mism:
                     print(f"    {f}")
             raise TypeError("Type mismatch found between the values of the input dictionaries. Please check the input files.")
         

--- a/tests/test_merge_hadd.py
+++ b/tests/test_merge_hadd.py
@@ -1,0 +1,95 @@
+"""Offline tests for merge_outputs / hadd fixes.
+
+do_hadd needs ROOT (present in the CI container). The rucio stub is defensive in case
+an import chain pulls it (the local image's rucio file is unreadable).
+"""
+import sys
+import types
+
+import pytest
+
+
+def _ensure_rucio_importable():
+    try:
+        import rucio.client  # noqa: F401
+        import rucio.common.client  # noqa: F401
+        return
+    except (ImportError, OSError):
+        rucio = types.ModuleType("rucio")
+        client = types.ModuleType("rucio.client")
+        client.Client = object
+        common = types.ModuleType("rucio.common")
+        common_client = types.ModuleType("rucio.common.client")
+        common_client.detect_client_location = lambda *a, **k: {}
+        rucio.client = client
+        rucio.common = common
+        common.client = common_client
+        sys.modules.setdefault("rucio", rucio)
+        sys.modules.setdefault("rucio.client", client)
+        sys.modules.setdefault("rucio.common", common)
+        sys.modules.setdefault("rucio.common.client", common_client)
+
+
+_ensure_rucio_importable()
+
+
+def _install_fake_root():
+    """Minimal ROOT stub so do_hadd can be exercised where ROOT is not installed."""
+    if "ROOT" in sys.modules:
+        return
+
+    class _Tree:
+        def Write(self):
+            pass
+
+    class _Chain:
+        def Add(self, f):
+            pass
+
+        def CloneTree(self, n):
+            return _Tree()
+
+    class _File:
+        def Close(self):
+            pass
+
+    root = types.ModuleType("ROOT")
+    root.TChain = lambda name: _Chain()
+    root.TFile = types.SimpleNamespace(Open=lambda path, mode: _File())
+    sys.modules["ROOT"] = root
+
+
+def test_do_hadd_does_not_nameerror_on_R(tmp_path):
+    # The fix binds R via `import ROOT as R` inside do_hadd; verify it resolves R (here a
+    # stub) and returns a (path, code) tuple instead of raising NameError on unbound R.
+    _install_fake_root()
+    from pocket_coffea.scripts.hadd_skimmed_files import do_hadd
+
+    out = str(tmp_path / "out.root")
+    result = do_hadd((out, [str(tmp_path / "does_not_exist.root")]))
+    assert result == (out, 0)
+
+
+def test_merge_outputs_no_inputs_no_config_exits_cleanly(tmp_path):
+    import pocket_coffea.scripts.merge_outputs as mo
+
+    # Previously this raised NameError on the unset job_config; it should now print a
+    # message and exit(1).
+    with pytest.raises(SystemExit):
+        mo.merge_outputs([], str(tmp_path / "out.coffea"), jobs_config=None, force=True)
+
+
+def test_merge_outputs_loads_reference_file_once(tmp_path, monkeypatch):
+    import pocket_coffea.scripts.merge_outputs as mo
+
+    calls = []
+    monkeypatch.setattr(mo, "load", lambda f: calls.append(f) or {})
+    # Force a "mismatch" so merge stops right after the type-check loop.
+    monkeypatch.setattr(mo, "compare_dict_types", lambda a, b: True)
+
+    files = [str(tmp_path / f"f{i}.coffea") for i in range(3)]
+    with pytest.raises(TypeError):
+        mo.merge_outputs(files, str(tmp_path / "out.coffea"), jobs_config=None, force=True)
+
+    # Reference loaded once + each of the other two once = 3 (old code reloaded f0 -> 4).
+    assert len(calls) == 3


### PR DESCRIPTION
- hadd_skimmed_files.do_hadd referenced R (ROOT), but `import ROOT as R` was local to hadd_skimmed_files() only, so the module-level do_hadd used by Pool.map raised NameError; and its `except subprocess.CalledProcessError` never matched (the body uses ROOT, not subprocess), so any real ROOT failure crashed the whole pool. Import ROOT inside do_hadd and broaden the except.
- merge_outputs: initialise job_config so the "no input files and no -jc" branch prints its message and exits instead of raising NameError.
- merge_outputs: load the reference file once instead of re-deserialising it for every comparison (it was reloaded N-1 times).
- merge_outputs: the type-mismatch report indexed type_mismatches (len N-1) with enumerate(inputfiles) (len N) -> IndexError on a genuine mismatch; zip against inputfiles[1:] instead.

Adds offline tests (ROOT stubbed) for do_hadd's R binding, the no-input exit, and the load-once behaviour.

Note: the merge auto-postprocess double-rescale guard and the runner adapt_chunksize / --process-separately items from the review are left as separate follow-ups.