### PR TITLE
Fixes for Histogram/Weights handling

### DIFF
--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -99,12 +99,13 @@ def get_hist_axis_from_config(ax: Axis):
             growth=ax.growth,
         )
     elif ax.type == "intcat":
+        # hist.axis.IntCategory has no `underflow` (categories have only an overflow
+        # "other" bin); passing underflow= raises TypeError, so it is dropped here.
         return hist.axis.IntCategory(
             ax.bins,
             name=ax.name,
             label=ax.label,
             overflow=ax.overflow,
-            underflow=ax.underflow,
             growth=ax.growth,
         )
     elif ax.type == "strcat":
@@ -499,6 +500,12 @@ class HistManager:
             # We need now to iterate on categories and subsamples
             # Mask the events, the weights and then flatten and remove the None correctly
             for category, cat_mask in categories.get_masks():
+                # Skip categories this histogram does not cover. The category axis is
+                # growth=False and holds only histo.only_categories, so filling any other
+                # category would silently land in the overflow bin (contaminating
+                # flow-inclusive projections) on top of wasting the masking/flatten work.
+                if category not in histo.only_categories:
+                    continue
                 # loop directly on subsamples
                 for subsample, subs_mask in subsamples.get_masks():
                     # logging.info(f"\t\tcategory {category}, subsample {subsample}")
@@ -514,8 +521,15 @@ class HistManager:
                     # WARNING!! POTENTIAL PROBLEMATIC BEHAVIOUR
                     # The user must be aware of the behavior.
 
+                    # Cache key for the by-event weight broadcast. Normally the masked
+                    # weight is identical for every histogram in this (category, subsample,
+                    # variation), so the plain category keeps the cache shared. But when a
+                    # 2D category mask is collapsed below, the resulting 1D mask depends on
+                    # this histogram's collapse mode, so the key must be per-histogram.
+                    weight_cache_cat = category
                     if data_ndim == 1 and mask.ndim > 1:
                         if histo.collapse_2D_masks:
+                            weight_cache_cat = f"{category}::collapse::{name}"
                             if histo.collapse_2D_masks_mode == "OR":
                                 mask = ak.any(mask, axis=1)
                             elif histo.collapse_2D_masks_mode == "AND":
@@ -620,7 +634,7 @@ class HistManager:
 
                                 # Broadcast and mask the weight (using the cached value if possible)
                                 weight_varied = self.mask_and_broadcast_weight(
-                                    category,
+                                    weight_cache_cat,
                                     subsample,
                                     variation,
                                     weight_varied*weight_sub, # This creates a copy of the weight
@@ -629,7 +643,7 @@ class HistManager:
                                 )
                                 if custom_weight != None and name in custom_weight:
                                     weight_varied = weight_varied * self.mask_and_broadcast_weight(
-                                        category + "customW",
+                                        f"{category}::customW::{name}",
                                         subsample,
                                         variation,
                                         custom_weight[
@@ -672,17 +686,17 @@ class HistManager:
                             weight_sub = weights_sub[subsample][category]["nominal"] if self.has_subsamples else 1.
                                 
                             weight_nom = self.mask_and_broadcast_weight(
-                                category,
+                                weight_cache_cat,
                                 subsample,
                                 "nominal",
                                 weight_nom * weight_sub,
                                 mask,
                                 data_structure,
                             )
-                            
+
                             if custom_weight != None and name in custom_weight:
                                 weight_nom = weight_nom * self.mask_and_broadcast_weight(
-                                    category + "customW",
+                                    f"{category}::customW::{name}",
                                     subsample,
                                     "nominal",
                                     custom_weight[
@@ -710,7 +724,7 @@ class HistManager:
                         # Broadcast and mask the weight (using the cached value if possible)
                         weight_data = weights[category]["nominal"]
                         weight_data = self.mask_and_broadcast_weight(
-                            category,
+                            weight_cache_cat,
                             subsample,
                             "nominal",
                             weight_data,
@@ -719,7 +733,7 @@ class HistManager:
                         )
                         if custom_weight != None and name in custom_weight:
                             weight_data = weight_data * self.mask_and_broadcast_weight(
-                                category + "customW",
+                                f"{category}::customW::{name}",
                                 subsample,
                                 "nominal",
                                 custom_weight[

--- a/pocket_coffea/lib/weights/weights.py
+++ b/pocket_coffea/lib/weights/weights.py
@@ -192,7 +192,10 @@ class WeightLambda(WeightWrapper):
         elif isinstance(out, ak.Array):
             return WeightData(self.name, out)
         elif (isinstance(out, list) or isinstance(out, tuple)) and len(out) == 1:
-            return WeightData(self.name, out)
+            # A 1-element sequence carries the nominal weight as its single element;
+            # unwrap it (WeightData(name, out) would wrap the list itself, which coffea
+            # then rejects as not-an-array).
+            return WeightData(self.name, out[0])
         elif (isinstance(out, list) or isinstance(out, tuple)) and len(out) == 3:
             return WeightData(self.name, *out)
         elif (isinstance(out, list) or isinstance(out, tuple)) and len(out) == 4:

--- a/tests/test_hist_weights_fixes.py
+++ b/tests/test_hist_weights_fixes.py
@@ -1,0 +1,57 @@
+"""Offline unit tests for the weights/histogram crash fixes (no EOS needed)."""
+import types
+
+import numpy as np
+import pytest
+
+from pocket_coffea.lib.hist_manager import get_hist_axis_from_config
+from pocket_coffea.lib.weights.weights import WeightLambda, WeightData
+
+
+def _axis(**kw):
+    defaults = dict(
+        name="myaxis", coll=None, field=None, label="lab", bins=[1, 2, 3],
+        start=0, stop=3, transform=None, overflow=True, underflow=True, growth=False,
+    )
+    defaults.update(kw)
+    return types.SimpleNamespace(**defaults)
+
+
+def test_intcat_axis_does_not_pass_underflow():
+    # hist.axis.IntCategory has no `underflow` kwarg -> previously raised TypeError.
+    ax = get_hist_axis_from_config(_axis(type="intcat", bins=[0, 1, 2]))
+    assert list(ax) == [0, 1, 2]
+    assert ax.name == "myaxis"
+
+
+def test_strcat_axis_still_builds():
+    ax = get_hist_axis_from_config(_axis(type="strcat", bins=["a", "b"]))
+    assert list(ax) == ["a", "b"]
+
+
+def test_weightlambda_single_element_output_unwrapped():
+    # A 1-element sequence return must yield WeightData(nominal=<array>), not the list.
+    arr = np.array([1.0, 2.0, 3.0])
+    W = WeightLambda.wrap_func(
+        name="w_single",
+        function=lambda params, metadata, events, size, shape_variations: [arr],
+        has_variations=False,
+    )
+    out = W(params=None, metadata=None).compute(events=None, size=3, shape_variation="nominal")
+    assert isinstance(out, WeightData)
+    assert isinstance(out.nominal, np.ndarray)
+    assert np.array_equal(out.nominal, arr)
+
+
+def test_weightlambda_three_element_output_still_works():
+    nom, up, down = np.array([1.0]), np.array([1.1]), np.array([0.9])
+    W = WeightLambda.wrap_func(
+        name="w_triple",
+        function=lambda params, metadata, events, size, shape_variations: [nom, up, down],
+        has_variations=True,
+    )
+    out = W(params=None, metadata=None).compute(events=None, size=1, shape_variation="nominal")
+    assert isinstance(out, WeightData)
+    assert np.array_equal(out.nominal, nom)
+    assert np.array_equal(out.up, up)
+    assert np.array_equal(out.down, down)


### PR DESCRIPTION
- get_hist_axis_from_config passed underflow= to hist.axis.IntCategory, which does not accept it (verified against hist 2.9) -> any `intcat` axis crashed at histogram creation. Drop the unsupported kwarg.
- The fill loop iterated every category regardless of a histogram's only_categories, so excluded categories were filled into the (growth=False) category-axis overflow bin, silently contaminating flow-inclusive projections and wasting the masking/flatten work. Skip categories not in histo.only_categories.
- The weights_cache keyed the broadcast weight on (category, subsample, variation) only. Custom weights are a per-histogram dict and a collapsed 2D->1D mask depends on the histogram's collapse mode, so two histograms sharing that key got each other's weight. Key those cases per-histogram; the common path keeps the shared cache, so standard output is unchanged (test_new_weights baseline byte-identical).
- WeightLambda.compute wrapped a 1-element list return as the nominal weight instead of unwrapping out[0], which coffea then rejected as not-an-array.

Adds offline unit tests for the intcat axis and both WeightLambda return forms. Verified against full-config baselines: test_new_weights, test_custom_weights, test_custom_weights_on_data, test_shape_variations_and_weights_bysubsample, test_columns_export all pass unchanged.
