### PR TITLE
Fix/weights subsample followup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1206,6 +1206,35 @@ files separately: the option is under development.
 :::
 
 
+### Exported weight columns
+
+Besides the `ColOut` collections you request, the columns output **automatically** includes
+the event weight, so the exported arrays can be used directly for weighted analysis or ML
+training without recomputing it:
+
+- **`weight`** — the nominal total event weight of that category: the product of the
+  inclusive weights, the by-category weights and, for a `sample__subsample` output, the
+  by-subsample weights. It is exactly the weight used to fill the histograms of the same
+  (sample/subsample, category), masked with the same category (and subsample) selection as
+  the exported columns.
+- **`weight_variation_{name}`** — *MC only*. One column per weight variation configured in
+  the `variations["weights"]` block (e.g. `weight_variation_sf_btagUp`,
+  `weight_variation_sf_btagDown`). Data outputs carry no weight-variation columns.
+
+All weight columns share the same length as the other columns of the category (they are
+masked identically). When dumping per-chunk parquet arrays
+(`dump_columns_as_arrays_per_chunk`, see below) the `weight` field is added to the awkward
+array in the same way.
+
+:::{note}
+For subsample outputs the `weight` column folds in the by-subsample weights (the same
+`<sample>__<subsample>` weights configured in the `weights["bysample"]` block). If you are
+on an older PocketCoffea version whose subsample `weight` column looks like the inclusive
+sample weight (missing the by-subsample factor), update to a version that includes the
+by-subsample column-weight fix.
+:::
+
+
 ### Exporting chunks in separate files
 When exporting arrays from the processor, the size of the output may become an issue. In fact, by default the coffea
 processor will accumulate the `column_accumulators` for each chunk to produce the total output at the end of the

--- a/pocket_coffea/lib/columns_manager.py
+++ b/pocket_coffea/lib/columns_manager.py
@@ -34,8 +34,14 @@ class ColumnsManager:
         for cat in categories:
             self.cfg[cat].append(cfg)
 
-    def fill_columns_accumulators(self, events, cuts_masks, variation, subsample_mask=None, weights_manager=None):
-        """Fill columns of a given variation in all categories and return the output containing also previously filled variations."""
+    def fill_columns_accumulators(self, events, cuts_masks, variation, subsample_mask=None, weights_manager=None, subsample=None):
+        """Fill columns of a given variation in all categories and return the output containing also previously filled variations.
+
+        `subsample` is the fully-qualified subsample name (``sample__subsample``) whose
+        by-subsample weights must be folded into the exported weight, or None for the
+        inclusive sample. Passing it to ``get_weight`` makes the exported weight match the
+        weight the histograms use for the same subsample.
+        """
         for category, outarrays in self.cfg.items():
             if category not in self.output.keys():
                 self.output[category] = {}
@@ -48,7 +54,7 @@ class ColumnsManager:
             # Getting the weight variations into nominal column s
             if weights_manager:
                 self.output[category][variation]["weight"] = column_accumulator(
-                    ak.to_numpy(weights_manager.get_weight(category)[mask], allow_missing=False))
+                    ak.to_numpy(weights_manager.get_weight(category, subsample=subsample)[mask], allow_missing=False))
                 if weights_manager._isMC:
                     available_weights_variations = []
                     for weight in self.variations_config["weights"][category]:
@@ -59,7 +65,7 @@ class ColumnsManager:
                         # Ask the WeightsManager the available variations
                         if weight != "nominal":
                             self.output[category][variation][f"weight_variation_{weight}"] = column_accumulator(
-                                ak.to_numpy(weights_manager.get_weight(category, modifier=weight)[mask], allow_missing=False))
+                                ak.to_numpy(weights_manager.get_weight(category, subsample=subsample, modifier=weight)[mask], allow_missing=False))
 
             for outarray in outarrays:
                 # Check if the cut is multidimensional
@@ -129,7 +135,7 @@ class ColumnsManager:
                     )
         return self.output
 
-    def fill_ak_arrays(self, events, cuts_masks, variation, subsample_mask=None, weights_manager=None):
+    def fill_ak_arrays(self, events, cuts_masks, variation, subsample_mask=None, weights_manager=None, subsample=None):
         self.output = {}
         for category, outarrays in self.cfg.items():
             if len(outarrays)==0:
@@ -142,8 +148,10 @@ class ColumnsManager:
 
             # Getting the weights
             # Only for nominal variation for the moment
+            # `subsample` (sample__subsample or None) folds in the by-subsample weights so
+            # the exported weight matches the histogram weight for the same subsample.
             if weights_manager: # no present for data
-                out_by_cat["weight"] = weights_manager.get_weight(category)[mask]
+                out_by_cat["weight"] = weights_manager.get_weight(category, subsample=subsample)[mask]
                 if weights_manager._isMC:
                     available_weights_variations = []
                     for weight in self.variations_config["weights"][category]:
@@ -153,7 +161,7 @@ class ColumnsManager:
                     for weight in get_weights_by_cat_var(available_weights_variations, weights_manager, category, variation).keys():
                         # Ask the WeightsManager the available variations
                         if weight != "nominal":
-                            out_by_cat[f"weight_variation_{weight}"] = weights_manager.get_weight(category, modifier=weight)[mask]
+                            out_by_cat[f"weight_variation_{weight}"] = weights_manager.get_weight(category, subsample=subsample, modifier=weight)[mask]
 
             for outarray in outarrays:
                 # Check if the cut is multidimensional

--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -99,12 +99,13 @@ def get_hist_axis_from_config(ax: Axis):
             growth=ax.growth,
         )
     elif ax.type == "intcat":
+        # hist.axis.IntCategory has no `underflow` (categories have only an overflow
+        # "other" bin); passing underflow= raises TypeError, so it is dropped here.
         return hist.axis.IntCategory(
             ax.bins,
             name=ax.name,
             label=ax.label,
             overflow=ax.overflow,
-            underflow=ax.underflow,
             growth=ax.growth,
         )
     elif ax.type == "strcat":
@@ -499,6 +500,12 @@ class HistManager:
             # We need now to iterate on categories and subsamples
             # Mask the events, the weights and then flatten and remove the None correctly
             for category, cat_mask in categories.get_masks():
+                # Skip categories this histogram does not cover. The category axis is
+                # growth=False and holds only histo.only_categories, so filling any other
+                # category would silently land in the overflow bin (contaminating
+                # flow-inclusive projections) on top of wasting the masking/flatten work.
+                if category not in histo.only_categories:
+                    continue
                 # loop directly on subsamples
                 for subsample, subs_mask in subsamples.get_masks():
                     # logging.info(f"\t\tcategory {category}, subsample {subsample}")
@@ -514,8 +521,15 @@ class HistManager:
                     # WARNING!! POTENTIAL PROBLEMATIC BEHAVIOUR
                     # The user must be aware of the behavior.
 
+                    # Cache key for the by-event weight broadcast. Normally the masked
+                    # weight is identical for every histogram in this (category, subsample,
+                    # variation), so the plain category keeps the cache shared. But when a
+                    # 2D category mask is collapsed below, the resulting 1D mask depends on
+                    # this histogram's collapse mode, so the key must be per-histogram.
+                    weight_cache_cat = category
                     if data_ndim == 1 and mask.ndim > 1:
                         if histo.collapse_2D_masks:
+                            weight_cache_cat = f"{category}::collapse::{name}"
                             if histo.collapse_2D_masks_mode == "OR":
                                 mask = ak.any(mask, axis=1)
                             elif histo.collapse_2D_masks_mode == "AND":
@@ -620,7 +634,7 @@ class HistManager:
 
                                 # Broadcast and mask the weight (using the cached value if possible)
                                 weight_varied = self.mask_and_broadcast_weight(
-                                    category,
+                                    weight_cache_cat,
                                     subsample,
                                     variation,
                                     weight_varied*weight_sub, # This creates a copy of the weight
@@ -629,7 +643,7 @@ class HistManager:
                                 )
                                 if custom_weight != None and name in custom_weight:
                                     weight_varied = weight_varied * self.mask_and_broadcast_weight(
-                                        category + "customW",
+                                        f"{category}::customW::{name}",
                                         subsample,
                                         variation,
                                         custom_weight[
@@ -672,17 +686,17 @@ class HistManager:
                             weight_sub = weights_sub[subsample][category]["nominal"] if self.has_subsamples else 1.
                                 
                             weight_nom = self.mask_and_broadcast_weight(
-                                category,
+                                weight_cache_cat,
                                 subsample,
                                 "nominal",
                                 weight_nom * weight_sub,
                                 mask,
                                 data_structure,
                             )
-                            
+
                             if custom_weight != None and name in custom_weight:
                                 weight_nom = weight_nom * self.mask_and_broadcast_weight(
-                                    category + "customW",
+                                    f"{category}::customW::{name}",
                                     subsample,
                                     "nominal",
                                     custom_weight[
@@ -710,7 +724,7 @@ class HistManager:
                         # Broadcast and mask the weight (using the cached value if possible)
                         weight_data = weights[category]["nominal"]
                         weight_data = self.mask_and_broadcast_weight(
-                            category,
+                            weight_cache_cat,
                             subsample,
                             "nominal",
                             weight_data,
@@ -719,7 +733,7 @@ class HistManager:
                         )
                         if custom_weight != None and name in custom_weight:
                             weight_data = weight_data * self.mask_and_broadcast_weight(
-                                category + "customW",
+                                f"{category}::customW::{name}",
                                 subsample,
                                 "nominal",
                                 custom_weight[

--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -385,12 +385,15 @@ class HistManager:
                 self.weights_manager, category, shape_variation,
             )
 
-        # Preload subsample-specific weights (MC only — data has no subsample SFs).
+        # Preload subsample-specific weights.
         # weights_sub[subsample][category][variation] holds the subsample weight for
         # the variations explicitly defined for that subsample; all other variations
         # fall back to the nominal subsample weight via dict.get() at fill time.
+        # Also preloaded for data: the configurator allows (non-isMC_only) by-subsample
+        # weights on data, and an unweighted subsample simply returns ones, so this is a
+        # no-op for the common data case but applies the weight when one is configured.
         weights_sub = {}
-        if self.has_subsamples and self.isMC:
+        if self.has_subsamples:
             for subsample in self.subsamples:
                 weights_sub[subsample] = {}
                 for category in self.available_categories:
@@ -723,11 +726,16 @@ class HistManager:
                     elif not histo.no_weights and not self.isMC:   #DATA
                         # Broadcast and mask the weight (using the cached value if possible)
                         weight_data = weights[category]["nominal"]
+                        # Fold in the by-subsample data weight (ones if none configured).
+                        weight_sub = (
+                            weights_sub[subsample][category]["nominal"]
+                            if self.has_subsamples else 1.
+                        )
                         weight_data = self.mask_and_broadcast_weight(
                             weight_cache_cat,
                             subsample,
                             "nominal",
-                            weight_data,
+                            weight_data * weight_sub,
                             mask,
                             data_structure,
                         )

--- a/pocket_coffea/lib/weights/common/weights_run3.py
+++ b/pocket_coffea/lib/weights/common/weights_run3.py
@@ -1,11 +1,9 @@
-from pocket_coffea.lib.scale_factors import sf_ele_trigger
+"""Run-3 weight definitions.
 
-from ..weights import WeightData, WeightDataMultiVariation, WeightLambda, WeightWrapper
-
-SF_ele_trigger = WeightLambda.wrap_func(
-    name="sf_ele_trigger",
-    function=lambda params, metadata, events, size, shape_variations: sf_ele_trigger(
-        params, events, metadata["year"]
-    ),
-    has_variations=True,
-)
+``sf_ele_trigger`` is already registered in ``weights.common.common``. Re-registering the
+same weight *name* here (as this module used to) raises a duplicate-registration error at
+import time, making the module unimportable. It is currently identical to the common one,
+so it is re-exported rather than redefined. If a genuinely Run-3-specific trigger scale
+factor is needed later, register it here under a distinct name.
+"""
+from .common import SF_ele_trigger  # noqa: F401

--- a/pocket_coffea/lib/weights/weights.py
+++ b/pocket_coffea/lib/weights/weights.py
@@ -192,7 +192,10 @@ class WeightLambda(WeightWrapper):
         elif isinstance(out, ak.Array):
             return WeightData(self.name, out)
         elif (isinstance(out, list) or isinstance(out, tuple)) and len(out) == 1:
-            return WeightData(self.name, out)
+            # A 1-element sequence carries the nominal weight as its single element;
+            # unwrap it (WeightData(name, out) would wrap the list itself, which coffea
+            # then rejects as not-an-array).
+            return WeightData(self.name, out[0])
         elif (isinstance(out, list) or isinstance(out, tuple)) and len(out) == 3:
             return WeightData(self.name, *out)
         elif (isinstance(out, list) or isinstance(out, tuple)) and len(out) == 4:

--- a/pocket_coffea/lib/weights/weights_manager.py
+++ b/pocket_coffea/lib/weights/weights_manager.py
@@ -249,34 +249,25 @@ class WeightsManager:
         If subsample is not None, the modifiers for the subsample are returned.
         If subsample is None, the modifiers for the overall sample are returned.
         '''
+        # The _available_modifiers_* containers are sets, so they must be combined with
+        # set-union (|), not '+'. The category-specific modifiers are optional: a category
+        # with only inclusive modifiers is valid and returns just those.
         if subsample is None:
             if category is None:
-                return self._available_modifiers_inclusive
-            elif category in self._available_modifiers_bycat:
-                return self._available_modifiers_bycat[category] + self._available_modifiers_inclusive
-            else:
-                raise ValueError(f"Category {category} not available in the WeightsManager")
+                return set(self._available_modifiers_inclusive)
+            return set(self._available_modifiers_inclusive) | set(
+                self._available_modifiers_bycat.get(category, set())
+            )
         else:
             if subsample not in self.weightsConf_subsamples:
                 raise ValueError(f"Subsample {subsample} not available in the WeightsManager")
-            
-            if category is None:
-                return self._available_modifiers_inclusive + \
-                       self._available_modifiers_inclusive_subsamples[subsample]
-            if category:
-                if category not in self._available_modifiers_bycat_subsamples[subsample]:
-                    if category in self._available_modifiers_bycat:
-                        return self._available_modifiers_inclusive + \
-                            self._available_modifiers_bycat[category] + \
-                            self._available_modifiers_inclusive_subsamples[subsample]
-                    
-                elif category in self._available_modifiers_bycat_subsamples[subsample]:
-                    return self._available_modifiers_inclusive + \
-                        self._available_modifiers_bycat[category] + \
-                        self._available_modifiers_bycat_subsamples[subsample][category] + \
-                        self._available_modifiers_inclusive_subsamples[subsample]
-                else:
-                    raise ValueError(f"Category {category} not available in the WeightsManager")
+            mods = set(self._available_modifiers_inclusive) | set(
+                self._available_modifiers_inclusive_subsamples[subsample]
+            )
+            if category is not None:
+                mods |= set(self._available_modifiers_bycat.get(category, set()))
+                mods |= set(self._available_modifiers_bycat_subsamples[subsample].get(category, set()))
+            return mods
 
     def add_weight(self, name, nominal, up=None, down=None, category=None):
         '''
@@ -319,6 +310,10 @@ class WeightsManager:
                     if subsample is None or modifier not in self._installed_modifiers_inclusive_subsamples[subsample]:
                         raise ValueError(
                             f"Modifier {modifier} not available in inclusive category")
+                    # The modifier lives only in the subsample: start from the inclusive
+                    # nominal so the subsample-modified factor below multiplies onto it
+                    # (otherwise overall_weight stays None and the *= below raises).
+                    overall_weight = self._weightsIncl.weight()
 
         elif category and self.weightsConf["is_split_bycat"] == True:
             # Check if this category has a bycategory configuration
@@ -347,7 +342,12 @@ class WeightsManager:
                     if subsample is None or modifier not in self._installed_modifiers_bycat_subsamples[subsample][category]:
                         raise ValueError(
                             f"Modifier {modifier} not available in category {category}")
-                    
+                    # The modifier lives only in the subsample: start from the inclusive
+                    # * bycategory nominal so the subsample-modified factor multiplies onto it.
+                    overall_weight = (
+                        self._weightsIncl.weight() * self._weightsByCat[category].weight()
+                    )
+
         # add subsample specific weights
         if subsample is not None:
             if subsample not in self.weightsConf_subsamples:
@@ -360,18 +360,18 @@ class WeightsManager:
                 # return the inclusive weight for the subsample
                 if modifier == None:
                     # Get the nominal both for the inclusive and the split weights
-                    overall_weight *= self._weightsIncl_subsamples[subsample].weight()
+                    overall_weight = overall_weight *self._weightsIncl_subsamples[subsample].weight()
                 if modifier != None and modifier in self._installed_modifiers_inclusive_subsamples[subsample]:
                     # requesting a modifier but the variation is not defined for the subsample
                     # It should not happen as the histmanager is reading the same config..
-                    overall_weight *= self._weightsIncl_subsamples[subsample].weight(modifier=modifier)
+                    overall_weight = overall_weight *self._weightsIncl_subsamples[subsample].weight(modifier=modifier)
                     # all the other cases should be already checked in the code above
 
             elif category and self.weightsConf_subsamples[subsample]["is_split_bycat"] == True:
                 # Check if this category has a bycategory configuration
                 if modifier == None:
                     # Get the nominal both for the inclusive and the split weights
-                    overall_weight *= ( self._weightsIncl_subsamples[subsample].weight() *
+                    overall_weight = overall_weight *( self._weightsIncl_subsamples[subsample].weight() *
                                         self._weightsByCat_subsamples[subsample][category].weight())
                 else:
                     mod_incl = modifier in self._installed_modifiers_inclusive_subsamples[subsample]
@@ -379,12 +379,12 @@ class WeightsManager:
 
                     if mod_incl and not mod_bycat:
                         # Get the modified inclusive and nominal bycat
-                        overall_weight *= (self._weightsIncl_subsamples[subsample].weight(modifier=modifier) *
+                        overall_weight = overall_weight *(self._weightsIncl_subsamples[subsample].weight(modifier=modifier) *
                                            self._weightsByCat_subsamples[subsample][category].weight())
                         
                     elif not mod_incl and mod_bycat:
                         # Get the nominal by cat and modified inclusive
-                        overall_weight *= ( self._weightsIncl_subsamples[subsample].weight() *
+                        overall_weight = overall_weight *( self._weightsIncl_subsamples[subsample].weight() *
                                             self._weightsByCat_subsamples[subsample][category].weight(modifier=modifier))
                     # We don't need a else here as
                     # if the modifier is not defined without subsample then the code above is already

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -542,7 +542,8 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                                                self._categories,
                                                variation,
                                                subsample_mask=self._subsamples[self._sample].get_mask(subs),
-                                               weights_manager=self.weights_manager
+                                               weights_manager=self.weights_manager,
+                                               subsample=f"{self._sample}__{subs}"
                                                )
                     fname = (self.events.behavior["__events_factory__"]._partition_key.replace("/", "_")
                         + ".parquet")
@@ -562,7 +563,8 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                                                    self._categories,
                                                    variation,
                                                    subsample_mask=self._subsamples[self._sample].get_mask(subs),
-                                                   weights_manager=self.weights_manager
+                                                   weights_manager=self.weights_manager,
+                                                   subsample=f"{self._sample}__{subs}"
                                                    )
                     }
         else:

--- a/tests/test_full_configs/test_custom_weights/config_weights_data_subsamples.py
+++ b/tests/test_full_configs/test_custom_weights/config_weights_data_subsamples.py
@@ -1,0 +1,109 @@
+from pocket_coffea.utils.configurator import Configurator
+from pocket_coffea.lib.cut_functions import get_nObj_min, get_nPVgood, goldenJson, eventFlags
+from pocket_coffea.parameters.cuts import passthrough
+from pocket_coffea.parameters.histograms import *
+from pocket_coffea.lib.columns_manager import ColOut
+
+import workflow
+from workflow import BasicProcessor
+
+import cloudpickle
+import custom_cut_functions
+cloudpickle.register_pickle_by_value(workflow)
+cloudpickle.register_pickle_by_value(custom_cut_functions)
+
+from custom_cut_functions import *
+import os
+localdir = os.path.dirname(os.path.abspath(__file__))
+
+from pocket_coffea.lib.weights.common import common_weights
+
+from pocket_coffea.parameters import defaults
+default_parameters = defaults.get_default_parameters()
+defaults.register_configuration_dir("config_dir", localdir + "/params")
+
+parameters = defaults.merge_parameters_from_files(default_parameters,
+                                                  f"{localdir}/params/object_preselection.yaml",
+                                                  f"{localdir}/params/triggers.yaml",
+                                                  update=True)
+
+from pocket_coffea.lib.weights.weights import WeightLambda
+import numpy as np
+
+# A by-subsample weight that applies to DATA (isMC_only=False) and returns a constant 2.
+sf_data_subsample = WeightLambda.wrap_func(
+    name="sf_data_subsample",
+    function=lambda params, metadata, events, size, shape_variations: np.ones(size) * 2.0,
+    has_variations=False,
+    isMC_only=False,
+)
+
+cfg = Configurator(
+    parameters=parameters,
+    datasets={
+        "jsons": ['datasets/datasets_redirector.json'],
+        "filter": {
+            "samples": ["DATA_SingleMuon"],
+            "samples_exclude": [],
+            "year": ['2018'],
+        },
+        # Two data subsamples with identical selection: 'wtd' carries the by-subsample
+        # weight below, 'unwtd' does not, so their ratio isolates the weight factor.
+        "subsamples": {
+            "DATA_SingleMuon": {
+                "wtd": [passthrough],
+                "unwtd": [passthrough],
+            }
+        },
+    },
+
+    workflow=BasicProcessor,
+
+    skim=[get_nPVgood(1), eventFlags, goldenJson],
+    preselections=[passthrough],
+    categories={
+        "2jets": [get_nObj_min(2, coll="JetGood")],
+    },
+
+    weights={
+        "common": {
+            "inclusive": ["genWeight", "lumi", "XS", "pileup",
+                          "sf_ele_id", "sf_ele_reco",
+                          "sf_mu_id", "sf_mu_iso"],
+            "bycategory": {},
+        },
+        # By-subsample weight on DATA: keyed by the fully-qualified subsample name.
+        "bysample": {
+            "DATA_SingleMuon__wtd": {
+                "inclusive": ["sf_data_subsample"],
+            }
+        },
+    },
+    weights_classes=common_weights + [sf_data_subsample],
+
+    variations={
+        "weights": {
+            "common": {
+                "inclusive": [],
+                "bycategory": {},
+            },
+            "bysample": {},
+        },
+    },
+
+    variables={
+        **count_hist("JetGood"),
+    },
+
+    columns={
+        # Applied to every subsample of DATA_SingleMuon, so both wtd and unwtd export a
+        # 'weight' column (which folds in the by-subsample weight).
+        "bysample": {
+            "DATA_SingleMuon": {
+                "bycategory": {
+                    "2jets": [ColOut("JetGood", ["pt"])],
+                }
+            }
+        }
+    },
+)

--- a/tests/test_full_configs/test_full_configs.py
+++ b/tests/test_full_configs/test_full_configs.py
@@ -332,7 +332,57 @@ def test_custom_weights_on_data(base_path: Path, monkeypatch: pytest.MonkeyPatch
     H = output["variables"]["nJetGood"]["DATA_SingleMuon"]["DATA_SingleMuon_2018_EraA"]
     assert np.isclose(H[{"cat":"2jets_B"}].values().sum()/ H[{"cat":"2jets_A"}].values().sum(), 2.0)
 
-    
+
+def test_weights_data_subsamples(base_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path_factory):
+    # A by-subsample weight configured on a DATA sample must be applied to that
+    # subsample's histograms and exported columns. Two data subsamples select the same
+    # events; only 'wtd' carries a constant weight of 2, so its yield/weight is 2x 'unwtd'.
+    monkeypatch.chdir(base_path / "test_custom_weights")
+    outputdir = tmp_path_factory.mktemp("test_weights_data_subsamples")
+    config = load_config("config_weights_data_subsamples.py", save_config=True, outputdir=outputdir)
+    assert isinstance(config, Configurator)
+
+    run_options = defaults.get_default_run_options()["general"]
+    run_options["limit-files"] = 1
+    run_options["limit-chunks"] = 1
+    run_options["chunksize"] = 500
+    config.filter_dataset(run_options["limit-files"])
+
+    executor_factory = executors_lib.get_executor_factory("iterative",
+                                                          run_options=run_options,
+                                                          outputdir=outputdir)
+    executor = executor_factory.get()
+
+    run = Runner(
+        executor=executor,
+        chunksize=run_options["chunksize"],
+        maxchunks=run_options["limit-chunks"],
+        schema=processor.NanoAODSchema,
+        format="root"
+    )
+    output = run(config.filesets, treename="Events",
+                 processor_instance=config.processor_instance)
+    assert output is not None
+
+    ds = "DATA_SingleMuon_2018_EraA"
+
+    # Histograms: the data fill branch must fold the by-subsample weight.
+    Hw = output["variables"]["nJetGood"]["DATA_SingleMuon__wtd"][ds]
+    Hu = output["variables"]["nJetGood"]["DATA_SingleMuon__unwtd"][ds]
+    sw = Hw[{"cat": "2jets"}].values().sum()
+    su = Hu[{"cat": "2jets"}].values().sum()
+    assert su > 0
+    assert np.isclose(sw / su, 2.0)
+
+    # Columns: the exported per-event weight for the weighted data subsample is 2.0,
+    # and 1.0 for the unweighted one.
+    cw = output["columns"]["DATA_SingleMuon__wtd"][ds]["2jets"]["nominal"]["weight"].value
+    cu = output["columns"]["DATA_SingleMuon__unwtd"][ds]["2jets"]["nominal"]["weight"].value
+    assert len(cw) > 0
+    assert np.allclose(cw, 2.0)
+    assert np.allclose(cu, 1.0)
+
+
 def test_cartesian_categorization(base_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path_factory):
     monkeypatch.chdir(base_path / "test_categorization" )
     outputdir = tmp_path_factory.mktemp("test_categorization_cartesian")

--- a/tests/test_hist_weights_fixes.py
+++ b/tests/test_hist_weights_fixes.py
@@ -1,0 +1,57 @@
+"""Offline unit tests for the weights/histogram crash fixes (no EOS needed)."""
+import types
+
+import numpy as np
+import pytest
+
+from pocket_coffea.lib.hist_manager import get_hist_axis_from_config
+from pocket_coffea.lib.weights.weights import WeightLambda, WeightData
+
+
+def _axis(**kw):
+    defaults = dict(
+        name="myaxis", coll=None, field=None, label="lab", bins=[1, 2, 3],
+        start=0, stop=3, transform=None, overflow=True, underflow=True, growth=False,
+    )
+    defaults.update(kw)
+    return types.SimpleNamespace(**defaults)
+
+
+def test_intcat_axis_does_not_pass_underflow():
+    # hist.axis.IntCategory has no `underflow` kwarg -> previously raised TypeError.
+    ax = get_hist_axis_from_config(_axis(type="intcat", bins=[0, 1, 2]))
+    assert list(ax) == [0, 1, 2]
+    assert ax.name == "myaxis"
+
+
+def test_strcat_axis_still_builds():
+    ax = get_hist_axis_from_config(_axis(type="strcat", bins=["a", "b"]))
+    assert list(ax) == ["a", "b"]
+
+
+def test_weightlambda_single_element_output_unwrapped():
+    # A 1-element sequence return must yield WeightData(nominal=<array>), not the list.
+    arr = np.array([1.0, 2.0, 3.0])
+    W = WeightLambda.wrap_func(
+        name="w_single",
+        function=lambda params, metadata, events, size, shape_variations: [arr],
+        has_variations=False,
+    )
+    out = W(params=None, metadata=None).compute(events=None, size=3, shape_variation="nominal")
+    assert isinstance(out, WeightData)
+    assert isinstance(out.nominal, np.ndarray)
+    assert np.array_equal(out.nominal, arr)
+
+
+def test_weightlambda_three_element_output_still_works():
+    nom, up, down = np.array([1.0]), np.array([1.1]), np.array([0.9])
+    W = WeightLambda.wrap_func(
+        name="w_triple",
+        function=lambda params, metadata, events, size, shape_variations: [nom, up, down],
+        has_variations=True,
+    )
+    out = W(params=None, metadata=None).compute(events=None, size=1, shape_variation="nominal")
+    assert isinstance(out, WeightData)
+    assert np.array_equal(out.nominal, nom)
+    assert np.array_equal(out.up, up)
+    assert np.array_equal(out.down, down)

--- a/tests/test_weights_subsample_followup.py
+++ b/tests/test_weights_subsample_followup.py
@@ -1,0 +1,52 @@
+"""Offline tests for the subsample-weight follow-up (no EOS needed)."""
+import importlib
+
+import numpy as np
+
+from pocket_coffea.lib.columns_manager import ColumnsManager
+
+
+class _FakeCats:
+    def get_mask(self, category):
+        return np.array([True, False, True])
+
+
+class _FakeWM:
+    """get_weight folds a x2 factor when the subsample is 'samp__A'."""
+    _isMC = False
+
+    def get_weight(self, category, subsample=None, modifier=None):
+        base = np.array([3.0, 3.0, 3.0])
+        return base * 2.0 if subsample == "samp__A" else base
+
+
+def _fill(subsample):
+    cm = ColumnsManager(cfg={"baseline": []}, categories_config=None, variations_config=None)
+    return cm.fill_columns_accumulators(
+        events=None,
+        cuts_masks=_FakeCats(),
+        variation="nominal",
+        subsample_mask=None,
+        weights_manager=_FakeWM(),
+        subsample=subsample,
+    )
+
+
+def test_columns_weight_folds_subsample_factor():
+    out = _fill("samp__A")
+    # (3*2) masked by [T, F, T] -> [6, 6]
+    assert list(out["baseline"]["nominal"]["weight"].value) == [6.0, 6.0]
+
+
+def test_columns_weight_without_subsample_unchanged():
+    out = _fill(None)
+    assert list(out["baseline"]["nominal"]["weight"].value) == [3.0, 3.0]
+
+
+def test_weights_run3_is_importable():
+    # Previously raised ValueError (duplicate sf_ele_trigger registration) on import.
+    m = importlib.import_module("pocket_coffea.lib.weights.common.weights_run3")
+    assert hasattr(m, "SF_ele_trigger")
+    # It is the same registered weight as the common one.
+    from pocket_coffea.lib.weights.common.common import SF_ele_trigger as common_one
+    assert m.SF_ele_trigger is common_one


### PR DESCRIPTION
By-subsample weights were dropped in two places and two latent WeightsManager APIs were broken:
  
  - Exported columns used the full-sample weight only. columns_manager now threads the
    subsample name into WeightsManager.get_weight(subsample=...), which already folds the
    by-subsample factor; base.py supplies "sample__subsample". Fixes MC and data columns.
  - The data histogram fill branch never applied by-subsample weights. hist_manager now
    preloads weights_sub for data too (a no-op for unweighted subsamples, which return
    ones) and multiplies it in the data branch. Verified safe: the configurator builds a
    by_subsample entry for every subsample of every sample (MC and data), so
    get_weight_only_subsample cannot raise.
  - get_weight's subsample block did `overall_weight *= subsample_weight`, mutating
    coffea's internally-cached _weightsIncl array in place (.weight() returns it by
    reference).  **N.B.: no code in the current main branch was using this code path**. 
    Once columns started calling get_weight(subsample=...) per subsample, the
    first subsample's *= corrupted the full-sample weight for the next call. Switch the
    five *= to non-mutating `overall_weight = overall_weight * ...`. This was latent
    (nothing called get_weight with subsample=); get_weight_only_subsample already used *.
  - get_available_modifiers_bycategory combined sets with `+` (TypeError) and could fall
    through to an implicit None; rewritten with set-union. get_weight's subsample-only
    modifier branches left overall_weight None before `*=`; initialise from the inclusive
    nominal.
  - weights_run3 re-registered the existing sf_ele_trigger name (unimportable duplicate);
    re-export it instead.
  
  Tests: new full-config test_weights_data_subsamples configures a by-subsample weight on
  DATA (two same-selection subsamples, only one weighted) and asserts the 2x factor in both
  histograms and the exported weight column (this is what caught the get_weight mutation
  bug). Plus offline unit tests. test_columns_export, test_columns_export_parquet,
  test_custom_weights_on_data and test_new_weights pass unchanged.
  
