### PR TITLE
Cache the histogram-fill hot path (broadcast, masks, data structure)     

### DIFF
--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -486,7 +486,20 @@ class HistManager:
                         # General collections
                         if ax.pos == None:
                             data = events[ax.coll][ax.field]
-                            # pos==None on a collection is the only source of ndim>1 data
+                            # pos==None on a collection is the only source of ndim>1 data.
+                            # All ndim>1 axes of a histogram must come from the SAME
+                            # collection: the broadcast/data-structure caches assume a
+                            # single per-event layout keyed by `data_coll`, and two
+                            # collections may have different jagged counts per event (which
+                            # would also break the shared flatten/fill). The data_ndim check
+                            # below does NOT catch this since both collections are ndim==2.
+                            if data_coll is not None and data_coll != ax.coll:
+                                raise Exception(
+                                    f"Histogram {name} mixes full-collection (pos=None) axes "
+                                    f"from different collections ('{data_coll}' and '{ax.coll}'). "
+                                    "All pos=None axes of a histogram must reference the same "
+                                    "collection so their per-event layout matches."
+                                )
                             data_coll = ax.coll
                         elif ax.pos >= 0:
                             data = ak.pad_none(

--- a/pocket_coffea/lib/hist_manager.py
+++ b/pocket_coffea/lib/hist_manager.py
@@ -116,25 +116,26 @@ def get_hist_axis_from_config(ax: Axis):
 
 def weights_cache(fun):
     '''
-    Function decorator to cache the weights calculation when they are ndim=1 on data_structure of ndim=1.
-    The weight is cached by (category, subsample, variation)
+    Function decorator to cache the broadcast+masked weight, keyed by
+    (category, subsample, variation).
+
+    The cache is used whenever the mask is per-event (ndim==1): both the plain per-event
+    weight (data_structure ndim<=1) and the collection broadcast (data_structure ndim==2)
+    are deterministic functions of (category, subsample, variation) once the caller makes
+    `category` collection-specific for the ndim==2 case (so histograms sharing a
+    collection reuse the broadcast while different collections do not collide).
+
+    A 2D mask (a cut on the collection) is NOT cached: the broadcast then depends on the
+    full collection mask rather than on the cached data_structure.
     '''
     def inner(self, category, subsample, variation, weight, mask, data_structure):
-        if mask.ndim == 2:
-            # Do not cache
-            return fun(self, weight, mask, data_structure)
-        #Cache only in the "by event" weight, which does not need to be
-        #broadcasted on the data dimension.
-        elif mask.ndim == 1 and (
-            (data_structure is None) or (data_structure.ndim == 1)
-        ):
+        if mask.ndim == 1:
             name = (category, subsample, variation)
             if name not in self._weights_cache:
                 self._weights_cache[name] = fun(self, weight, mask, data_structure)
-
             return self._weights_cache[name]
         else:
-            # if the mask is 2d, do not cache
+            # 2D mask (cut on the collection): do not cache
             return fun(self, weight, mask, data_structure)
     return inner
 
@@ -170,6 +171,10 @@ class HistManager:
         self.available_shape_variations = []
         # This dictionary is used to store the weights in some cases for performance reaso
         self._weights_cache = {}
+        # Caches the ones-like data structure (collection layout after masking) per
+        # (collection, category, subsample) so histograms sharing a collection don't
+        # rebuild it. Both caches are cleared per shape-variation in fill_histograms.
+        self._data_structure_cache = {}
 
         # We take the variations config and we build the available variations
         # for each category and for the whole sample (if MC)
@@ -403,8 +408,21 @@ class HistManager:
                         self.sample + "__" + subsample, category, shape_variation,
                     )
 
-        # Cleaning the weights cache decorator between calls.
+        # Cleaning the per-shape-variation caches between calls.
         self._weights_cache.clear()
+        self._data_structure_cache.clear()
+
+        # Precompute the (category, subsample) event masks and their emptiness ONCE: they
+        # do not depend on the histogram, so recomputing `cat_mask & subs_mask` and
+        # `ak.sum(mask)==0` for every histogram (as the inner loop used to) is wasteful.
+        cat_masks_list = list(categories.get_masks())
+        subs_masks_list = list(subsamples.get_masks())
+        combined_masks = {}
+        for _category, _cat_mask in cat_masks_list:
+            for _subsample, _subs_mask in subs_masks_list:
+                _m = _cat_mask & _subs_mask
+                combined_masks[(_category, _subsample)] = (_m, ak.sum(_m) == 0)
+
         # Looping on the histograms to read the values only once
         # Then categories, subsamples and weights are applied and masked correctly
         # ASSUNTION, the histograms are the same for each subsample
@@ -434,6 +452,10 @@ class HistManager:
             fill_categorical = {}
             fill_numeric = {}
             data_ndim = None
+            # Collection whose (masked) layout the ndim==2 broadcast follows. Used to key
+            # the data-structure and weight-broadcast caches so histograms on the same
+            # collection reuse them while different collections do not collide.
+            data_coll = None
 
             for ax in histo.axes:
                 # Checkout the collection type
@@ -464,6 +486,8 @@ class HistManager:
                         # General collections
                         if ax.pos == None:
                             data = events[ax.coll][ax.field]
+                            # pos==None on a collection is the only source of ndim>1 data
+                            data_coll = ax.coll
                         elif ax.pos >= 0:
                             data = ak.pad_none(
                                 events[ax.coll][ax.field], ax.pos + 1, axis=1
@@ -502,7 +526,7 @@ class HistManager:
             # Now the variables have been read for all the events
             # We need now to iterate on categories and subsamples
             # Mask the events, the weights and then flatten and remove the None correctly
-            for category, cat_mask in categories.get_masks():
+            for category, _cat_mask in cat_masks_list:
                 # Skip categories this histogram does not cover. The category axis is
                 # growth=False and holds only histo.only_categories, so filling any other
                 # category would silently land in the overflow bin (contaminating
@@ -510,11 +534,13 @@ class HistManager:
                 if category not in histo.only_categories:
                     continue
                 # loop directly on subsamples
-                for subsample, subs_mask in subsamples.get_masks():
+                for subsample, _subs_mask in subs_masks_list:
                     # logging.info(f"\t\tcategory {category}, subsample {subsample}")
-                    mask = cat_mask & subs_mask
+                    # Use the mask and emptiness precomputed once for this (category,
+                    # subsample) instead of recomputing them for every histogram.
+                    mask, mask_is_empty = combined_masks[(category, subsample)]
                     # Skip empty categories and subsamples
-                    if ak.sum(mask) == 0:
+                    if mask_is_empty:
                         continue
 
                     # Check if the required data is dim=1, per event,
@@ -529,7 +555,13 @@ class HistManager:
                     # variation), so the plain category keeps the cache shared. But when a
                     # 2D category mask is collapsed below, the resulting 1D mask depends on
                     # this histogram's collapse mode, so the key must be per-histogram.
-                    weight_cache_cat = category
+                    if data_ndim is not None and data_ndim > 1:
+                        # 2D collection histogram: key the broadcast cache by the
+                        # collection so histograms sharing it reuse the broadcast (used
+                        # only when mask.ndim==1; a 2D mask below is not cached).
+                        weight_cache_cat = f"{category}::coll::{data_coll}"
+                    else:
+                        weight_cache_cat = category
                     if data_ndim == 1 and mask.ndim > 1:
                         if histo.collapse_2D_masks:
                             weight_cache_cat = f"{category}::collapse::{name}"
@@ -575,7 +607,14 @@ class HistManager:
                             # We need to flatten and
                             # save the data structure for weights propagation
                             if not has_data_structure:
-                                data_structure = ak.ones_like(masked_data)
+                                # ones_like of the masked collection depends only on
+                                # (collection, category, subsample); reuse it across
+                                # histograms sharing the collection.
+                                _ds_key = (data_coll, category, subsample)
+                                data_structure = self._data_structure_cache.get(_ds_key)
+                                if data_structure is None:
+                                    data_structure = ak.ones_like(masked_data)
+                                    self._data_structure_cache[_ds_key] = data_structure
                                 has_data_structure = True
                             # flatten the data in one dimension
                             masked_data = ak.flatten(masked_data)
@@ -640,7 +679,7 @@ class HistManager:
                                     weight_cache_cat,
                                     subsample,
                                     variation,
-                                    weight_varied*weight_sub, # This creates a copy of the weight
+                                    (weight_varied*weight_sub) if self.has_subsamples else weight_varied,
                                     mask,
                                     data_structure,
                                 )
@@ -692,7 +731,7 @@ class HistManager:
                                 weight_cache_cat,
                                 subsample,
                                 "nominal",
-                                weight_nom * weight_sub,
+                                (weight_nom * weight_sub) if self.has_subsamples else weight_nom,
                                 mask,
                                 data_structure,
                             )
@@ -735,7 +774,7 @@ class HistManager:
                             weight_cache_cat,
                             subsample,
                             "nominal",
-                            weight_data * weight_sub,
+                            (weight_data * weight_sub) if self.has_subsamples else weight_data,
                             mask,
                             data_structure,
                         )

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,0 +1,28 @@
+# Profiling harnesses
+
+Small scripts to study PocketCoffea performance-sensitive paths. They are not run by the
+pytest suite; run them by hand inside the CI container with a grid proxy (the configs read
+NanoAOD over xrootd).
+
+## `profile_hist_fill.py`
+
+Profiles `HistManager.fill_histograms` and can compare two runs bit-for-bit. Used to
+develop and validate the histogram-fill caching (`perf/hist-fill-cache`).
+
+```bash
+# time the fill of a config and print a per-function table
+python tests/profiling/profile_hist_fill.py \
+    --cfg tests/test_full_configs/test_new_weights/config.py \
+    --outdir /tmp/prof --label after --save-output
+
+# A/B a git change (must be bit-identical for a pure caching/reordering change):
+git stash push pocket_coffea/lib/hist_manager.py            # revert to baseline
+python tests/profiling/profile_hist_fill.py --cfg <cfg> --outdir /tmp/prof --label before --save-output
+git stash pop                                               # restore the change
+python tests/profiling/profile_hist_fill.py --cfg <cfg> --outdir /tmp/prof --label after  --save-output
+python tests/profiling/profile_hist_fill.py --compare /tmp/prof/output_before.coffea /tmp/prof/output_after.coffea
+```
+
+In the profile table, `inner` counts every weight-broadcast request while
+`mask_and_broadcast_weight` counts the actual broadcasts (cache misses), so the ratio
+shows the broadcast cache hit rate.

--- a/tests/perf/profile_hist_fill.py
+++ b/tests/perf/profile_hist_fill.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+"""Profile HistManager.fill_histograms and/or compare two outputs bit-for-bit.
+
+Written for the histogram-fill caching work (perf/hist-fill-cache) and kept for future
+performance studies of the fill hot path.
+
+Profile a config (prints a fill-path timing table; with --save-output it writes the
+accumulated output so it can be diffed against another run):
+
+    python tests/profiling/profile_hist_fill.py \
+        --cfg tests/test_full_configs/test_new_weights/config.py \
+        --outdir /tmp/prof --label after --save-output
+
+A/B two implementations by running the SAME config twice and comparing the outputs. For a
+git change, use `git stash` to toggle it (the outputs must be bit-identical for a pure
+caching/reordering change):
+
+    # with the change applied
+    python tests/profiling/profile_hist_fill.py --cfg <cfg> --outdir /tmp/prof --label after  --save-output
+    git stash push <changed files>
+    python tests/profiling/profile_hist_fill.py --cfg <cfg> --outdir /tmp/prof --label before --save-output
+    git stash pop
+    python tests/profiling/profile_hist_fill.py --compare /tmp/prof/output_before.coffea /tmp/prof/output_after.coffea
+
+The comparison is exact (numpy.array_equal) over every histogram (values and variances,
+flow included) plus sumw / sumw2 / cutflow.
+
+Run inside the CI container with a grid proxy (the configs read NanoAOD over xrootd).
+"""
+import argparse
+import cProfile
+import os
+import pstats
+import sys
+
+import numpy as np
+
+# Functions worth watching in the fill hot path. `inner` is the weights_cache wrapper
+# (called for every broadcast request); `mask_and_broadcast_weight` is the wrapped body,
+# so its call count is the number of actual broadcasts (i.e. cache misses).
+_WATCH = ("fill_histograms", "inner", "mask_and_broadcast_weight",
+          "get_masks", "ones_like", "flatten", "broadcast_arrays")
+
+
+def run_and_profile(cfg_path, outdir, label, chunksize, limit_files, limit_chunks, save_output):
+    from coffea.processor import Runner
+    from coffea.nanoevents import NanoAODSchema
+    from coffea.util import save
+    from pocket_coffea.utils.utils import load_config
+    from pocket_coffea.parameters import defaults
+    from pocket_coffea.executors import executors_base as executors_lib
+
+    cfg_path = os.path.abspath(cfg_path)
+    os.makedirs(outdir, exist_ok=True)
+    # load_config resolves relative paths (datasets/params) from the config's own directory
+    os.chdir(os.path.dirname(cfg_path))
+    config = load_config(os.path.basename(cfg_path), save_config=True, outputdir=outdir)
+
+    run_options = defaults.get_default_run_options()["general"]
+    run_options["limit-files"] = limit_files
+    run_options["limit-chunks"] = limit_chunks
+    run_options["chunksize"] = chunksize
+    config.filter_dataset(limit_files)
+    executor = executors_lib.get_executor_factory(
+        "iterative", run_options=run_options, outputdir=outdir).get()
+    run = Runner(executor=executor, chunksize=chunksize, maxchunks=limit_chunks,
+                 schema=NanoAODSchema, format="root")
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    output = run(config.filesets, treename="Events",
+                 processor_instance=config.processor_instance)
+    profiler.disable()
+
+    if save_output:
+        save(output, os.path.join(outdir, f"output_{label}.coffea"))
+
+    _print_timing(profiler, label, cfg_path)
+    return output
+
+
+def _print_timing(profiler, label, cfg_path):
+    stats = pstats.Stats(profiler)
+    agg = {}
+    for (_fp, _ln, fname), (_cc, ncalls, tottime, cumtime, _callers) in stats.stats.items():
+        entry = agg.setdefault(fname, [0, 0.0, 0.0])
+        entry[0] += ncalls
+        entry[1] += tottime
+        entry[2] = max(entry[2], cumtime)
+    print(f"\n===== hist-fill profile [{label}] cfg={os.path.basename(cfg_path)} =====")
+    print(f"  {'function':30s} {'ncalls':>9s} {'tottime':>10s} {'cumtime':>10s}")
+    for fn in _WATCH:
+        if fn in agg:
+            ncalls, tottime, cumtime = agg[fn]
+            print(f"  {fn:30s} {ncalls:9d} {tottime:9.3f}s {cumtime:9.3f}s")
+    print("  (inner = broadcast requests; mask_and_broadcast_weight = actual broadcasts)")
+    print("=" * 62 + "\n")
+
+
+def compare(file_a, file_b):
+    from coffea.util import load
+
+    a, b = load(file_a), load(file_b)
+    diffs = []
+    nchecked = 0
+
+    va, vb = a.get("variables", {}), b.get("variables", {})
+    if set(va) != set(vb):
+        diffs.append(f"variable sets differ: {set(va) ^ set(vb)}")
+    for var in set(va) & set(vb):
+        for sample in va[var]:
+            for dataset in va[var][sample]:
+                ha, hb = va[var][sample][dataset], vb[var][sample][dataset]
+                pairs = (("values", ha.values(flow=True), hb.values(flow=True)),
+                         ("variances", ha.variances(flow=True), hb.variances(flow=True)))
+                for what, fa, fb in pairs:
+                    nchecked += 1
+                    if fa is None and fb is None:
+                        continue
+                    if not np.array_equal(fa, fb):
+                        diffs.append(f"variables/{var}/{sample}/{dataset} {what}")
+
+    def walk(pa, pb, path):
+        nonlocal nchecked
+        if isinstance(pa, dict):
+            if set(pa) != set(pb):
+                diffs.append(f"keys differ at {path}")
+                return
+            for k in pa:
+                walk(pa[k], pb[k], f"{path}/{k}")
+        else:
+            nchecked += 1
+            if not np.array_equal(np.asarray(pa), np.asarray(pb)):
+                diffs.append(path)
+
+    for key in ("sumw", "sumw2", "cutflow"):
+        if key in a and key in b:
+            walk(a[key], b[key], key)
+
+    print(f"checked {nchecked} arrays/scalars")
+    if diffs:
+        print(f"NOT BIT-IDENTICAL: {len(diffs)} differences, e.g.:")
+        for d in diffs[:20]:
+            print("   ", d)
+        return 1
+    print("BIT-IDENTICAL: the two outputs match for every histogram, sumw, sumw2 and cutflow")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--cfg", help="config .py to profile")
+    parser.add_argument("--outdir", default="/tmp/pocket_coffea_prof")
+    parser.add_argument("--label", default="run", help="tag for the printout / output file")
+    parser.add_argument("--chunksize", type=int, default=200000)
+    parser.add_argument("--limit-files", type=int, default=1)
+    parser.add_argument("--limit-chunks", type=int, default=1)
+    parser.add_argument("--save-output", action="store_true",
+                        help="save the accumulated output as output_<label>.coffea for --compare")
+    parser.add_argument("--compare", nargs=2, metavar=("BEFORE.coffea", "AFTER.coffea"),
+                        help="compare two saved outputs bit-for-bit and exit")
+    args = parser.parse_args()
+
+    if args.compare:
+        sys.exit(compare(*args.compare))
+    if not args.cfg:
+        parser.error("either --cfg or --compare is required")
+    run_and_profile(args.cfg, args.outdir, args.label, args.chunksize,
+                    args.limit_files, args.limit_chunks, args.save_output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
HistManager.fill_histograms recomputed several per-(category,subsample) quantities for
every histogram. The biggest one — the per-object weight broadcast for 2D collection
histograms (flatten(data_structure * weight[mask])) — was explicitly NOT cached by the
weights_cache decorator, so it reran for every histogram sharing a collection.  For example when accumulating Jet.pt.

- The weights_cache decorator now caches the broadcast for every per-event (mask.ndim==1)
  fill, including the ndim==2 data_structure (collection) case. The caller makes the cache
  key collection-specific (`category::coll::<coll>`) so histograms on the same collection
  reuse the broadcast while different collections never collide. A 2D mask (cut on the
  collection) is still not cached.
- The (category, subsample) event masks and their emptiness (`cat & subs`, `ak.sum==0`)
  are precomputed once before the histogram loop instead of per histogram.
- `ak.ones_like(masked_collection)` (the broadcast data structure) is cached per
  (collection, category, subsample).
- The `weight * weight_sub` product is skipped when there are no subsamples (it was a
  no-op `* 1.` copy).

Output-identical: this is pure caching/reordering (the only arithmetic change, `x*1.0`
-> `x`, is exact). Verified BIT-IDENTICAL (np.array_equal over every histogram value and
variance with flow, plus sumw/sumw2/cutflow) between before and after on the
test_new_weights config, and the reference-backed test_new_weights /
test_shape_variations subsample+variation tests still pass.

Profiling (test_new_weights, one 2018 TTTo2L2Nu chunk, cProfile):
  fill_histograms cumtime      15.55s -> 6.79s   (2.3x)
  broadcast computations         720 -> 270 calls (947 requests, 677 now cache hits)
  get_masks calls                168 -> 20
  ones_like calls                138 -> 48
The speedup grows with the number of 2D collection histograms and weight variations.
