### PR TITLE
New output splitting for more efficient plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ cython_debug/
 AnalysisConfigs/
 VHccPoCo/
 output*
+!pocket_coffea/utils/output_split.py
 plots*
 .pkl.gz
 myenv/

--- a/pocket_coffea/__main__.py
+++ b/pocket_coffea/__main__.py
@@ -2,7 +2,7 @@ import click
 from rich import print
 
 import pocket_coffea
-from pocket_coffea.scripts import merge_columns, merge_outputs, split_output
+from pocket_coffea.scripts import convert_output, merge_columns, merge_outputs, split_output
 from pocket_coffea.scripts.check_jobs import check_jobs
 from pocket_coffea.scripts.dataset.build_datasets import build_datasets
 from pocket_coffea.scripts.dataset.dataset_query import dataset_discovery_cli
@@ -51,6 +51,7 @@ cli.add_command(plot_cutflow, name="plot-cutflow")
 cli.add_command(hadd_skimmed_files)
 cli.add_command(merge_outputs.main, name="merge-outputs")
 cli.add_command(split_output.main, name="split-output")
+cli.add_command(convert_output.main, name="convert-output")
 cli.add_command(merge_columns.main, name="merge-columns")
 cli.add_command(print_parameters)
 cli.add_command(check_jobs)

--- a/pocket_coffea/scripts/convert_output.py
+++ b/pocket_coffea/scripts/convert_output.py
@@ -1,0 +1,111 @@
+"""Convert PocketCoffea outputs between the monolithic and split formats.
+
+The classic ``.coffea`` output is a single monolithic ``cloudpickle`` blob that
+must be fully loaded into memory to read anything. The *split* format
+(:mod:`pocket_coffea.utils.output_split`) stores each variable as its own
+member so the plotter can load one variable at a time. This CLI converts
+between the two, and can merge several monolithic outputs directly into one
+split file.
+
+Examples
+--------
+    # monolithic -> split (default)
+    convert-output out_split.coffea -i output_all.coffea
+
+    # split -> monolithic
+    convert-output out_mono.coffea -i out_split.coffea --to monolithic
+
+    # merge many per-dataset monolithic outputs into ONE split file
+    convert-output out_split.coffea -i "output_*.coffea" -n 5 -m 8
+"""
+
+import os
+from glob import glob
+
+import click
+from rich import print
+
+from pocket_coffea.utils.output_split import (
+    save_split,
+    is_split_output,
+    to_monolithic,
+)
+
+
+def _expand(inputfiles):
+    files = []
+    for pattern in inputfiles:
+        matched = glob(pattern)
+        if matched:
+            files.extend(sorted(f for f in matched if os.path.isfile(f)))
+        elif os.path.isfile(pattern):
+            files.append(pattern)
+    return files
+
+
+def convert_output(inputfiles, outputfile, target_format="split", compression="lz4",
+                   reduction=5, max_mem_gb=None, cache_dir=None, force=False, verbose=False):
+    """Convert/merge ``inputfiles`` into ``outputfile`` in ``target_format``."""
+    files = _expand(inputfiles)
+    if not files:
+        raise SystemExit(f"No valid input files found in {list(inputfiles)}.")
+    if os.path.exists(outputfile) and not force:
+        raise SystemExit(f"Output file {outputfile} already exists. Use -f to overwrite.")
+
+    if len(files) == 1:
+        print(f"[pink]Loading {files[0]}[/]")
+        data = to_monolithic(files[0])
+    else:
+        print(f"[blue]Merging {len(files)} files into one {target_format} output[/]")
+        if any(is_split_output(f) for f in files):
+            # mixed/split inputs: simple incremental accumulate (+drop)
+            from coffea.processor import accumulate
+            data = None
+            for f in files:
+                print(f"[pink]Loading {f}[/]")
+                part = to_monolithic(f)
+                data = part if data is None else accumulate([data, part])
+                del part
+        else:
+            # all monolithic: reuse the memory-batched merge (dumps to disk if huge)
+            from pocket_coffea.scripts.merge_outputs import merge_group_reduction
+            if cache_dir is None:
+                cache_dir = os.path.join(
+                    os.path.dirname(os.path.abspath(outputfile)), "convert_cache")
+            data = merge_group_reduction(files, N_reduction=reduction, cachedir=cache_dir,
+                                         max_mem_gb=max_mem_gb, verbose=verbose)
+
+    if target_format == "split":
+        save_split(data, outputfile, compression=compression)
+    else:
+        from coffea.util import save
+        save(data, outputfile)
+    print(f"[green]Wrote {target_format} output to {outputfile}[/]")
+    return outputfile
+
+
+@click.command()
+@click.argument("outputfile", type=str)
+@click.option("-i", "--inputfiles", type=str, multiple=True, required=True,
+              help="Input .coffea file(s) or glob pattern(s). Multiple inputs are merged.")
+@click.option("--to", "target_format", type=click.Choice(["split", "monolithic"]),
+              default="split", help="Output format (default: split).")
+@click.option("--compression", type=click.Choice(["lz4", "none"]), default="lz4",
+              help="Per-member compression for the split format.")
+@click.option("-n", "--reduction", type=int, default=5,
+              help="Files accumulated at a time when merging multiple monolithic inputs.")
+@click.option("-m", "--max-mem-gb", type=float, default=None,
+              help="Max memory (GB) before intermediate merge results are dumped to disk.")
+@click.option("-cd", "--cache-dir", type=str, default=None, help="Cache dir for intermediate dumps.")
+@click.option("-f", "--force", is_flag=True, help="Overwrite the output file if it exists.")
+@click.option("-v", "--verbose", is_flag=True, help="Verbose memory reporting when merging.")
+def main(outputfile, inputfiles, target_format, compression, reduction, max_mem_gb,
+         cache_dir, force, verbose):
+    """Convert a coffea output between the monolithic and split formats."""
+    convert_output(inputfiles, outputfile, target_format=target_format, compression=compression,
+                   reduction=reduction, max_mem_gb=max_mem_gb, cache_dir=cache_dir,
+                   force=force, verbose=verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/pocket_coffea/scripts/merge_outputs.py
+++ b/pocket_coffea/scripts/merge_outputs.py
@@ -17,6 +17,20 @@ import psutil, gc
 mem_threshold = 0.5 # ~50% + memory needed to dump files, is the empirical threshold on lxplus
 
 
+def _save_output(data, path, output_format="monolithic"):
+    """Save the merged output in the requested format.
+
+    - "monolithic": the classic single-blob coffea file (coffea.util.save).
+    - "split": the per-variable format that plotting can load one variable at a
+      time (pocket_coffea.utils.output_split.save_split).
+    """
+    if output_format == "split":
+        from pocket_coffea.utils.output_split import save_split
+        save_split(data, path)
+    else:
+        save(data, path)
+
+
 def merge_group_reduction(output_files, N_reduction=5, cachedir="merge_cache", max_mem_gb=8, verbose=False):
     with Progress() as progress:
         task1 = progress.add_task("[cyan]Merging...", total=len(output_files))
@@ -104,7 +118,7 @@ def append_configs(c1, c2):
             
     return c1
 
-def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace=False, N_reduction=5, max_mem_gb=None, cache_dir=None, verbose=False, skip_check=False, mark_failed=False, configurator=None, skip_initial_events_check_datasets=None):
+def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace=False, N_reduction=5, max_mem_gb=None, cache_dir=None, verbose=False, skip_check=False, mark_failed=False, configurator=None, skip_initial_events_check_datasets=None, output_format="monolithic"):
     '''Merge coffea output files'''
     # Initialised so the "no inputs and no -jc" branch below can test it without
     # NameError (it is only assigned when a jobs_config is provided).
@@ -225,8 +239,8 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace
         else:
             print("No configurators found, no postprocessing applied.")
 
-        save(total_out, outputfile)
-        print(f"[green]Output saved to {outputfile}")
+        _save_output(total_out, outputfile, output_format)
+        print(f"[green]Output saved to {outputfile} ({output_format} format)")
 
     else:
         if job_config is None:
@@ -340,9 +354,9 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace
                 save_skimed_dataset_definition(total_output, f"{job_config['output_dir']}/skimmed_dataset_definition.json",
                                                skip_initial_events_check_datasets=skip_initial_events_check_datasets)
 
-            # Save the output            
-            print(f"[green]Saving output to {thisoutputfile}...[/]")
-            save(total_output, thisoutputfile)
+            # Save the output
+            print(f"[green]Saving output to {thisoutputfile} ({output_format} format)...[/]")
+            _save_output(total_output, thisoutputfile, output_format)
 
             del total_output
 
@@ -446,9 +460,26 @@ def merge_outputs(inputfiles, outputfile, jobs_config=None, force=False, replace
          "when a corrupted input file had to be skipped. Repeatable.",
 )
 
-def main(inputfiles, outputfile, jobs_config, force, replace, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, skip_initial_events_check_datasets):
+@click.option(
+    "--output-format",
+    type=click.Choice(["monolithic", "split"]),
+    default="monolithic",
+    help="Output format: 'monolithic' (classic single-blob .coffea) or 'split' "
+         "(per-variable format that plotting can load one variable at a time, "
+         "for low-memory plotting of large outputs).",
+)
+@click.option(
+    "--split",
+    "split_flag",
+    is_flag=True,
+    help="Shortcut for --output-format split.",
+)
+
+def main(inputfiles, outputfile, jobs_config, force, replace, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, skip_initial_events_check_datasets, output_format, split_flag):
     '''Merge coffea output files'''
-    merge_outputs(inputfiles, outputfile, jobs_config, force, replace, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, list(skip_initial_events_check_datasets))
+    if split_flag:
+        output_format = "split"
+    merge_outputs(inputfiles, outputfile, jobs_config, force, replace, reduction, max_mem_gb, cache_dir, verbose, skip_check, mark_failed, configurator, list(skip_initial_events_check_datasets), output_format=output_format)
 
 if __name__ == "__main__":
     main()

--- a/pocket_coffea/scripts/plot/make_plots.py
+++ b/pocket_coffea/scripts/plot/make_plots.py
@@ -7,8 +7,9 @@ from omegaconf import OmegaConf
 from coffea.util import load
 
 from pocket_coffea.utils.plot_utils import PlotManager
+from pocket_coffea.utils.output_split import make_provider
 from pocket_coffea.parameters import defaults
-from coffea.processor import accumulate 
+from coffea.processor import accumulate
 import click
 import gc
 from rich import print
@@ -112,15 +113,11 @@ def make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
         all_files.extend(valid_files)
     if not all_files: sys.exit("No valid input files found.")
 
-    def load_single_file(file):
-        """Helper function to load a single file."""
-        print(f"[pink]Loading: {file}[/]")
-        return load(file)
-    # Use ThreadPoolExecutor to load files concurrently
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        files = list(executor.map(load_single_file, all_files))
-
-    if files: accumulator = accumulate(files)
+    # Build a provider over the input files. For split-format inputs this reads
+    # only the metadata/index (histograms are loaded one variable at a time when
+    # plotting). For monolithic inputs it loads and accumulates incrementally,
+    # dropping each file after adding it (no all-files + merged-copy buffer).
+    provider = make_provider(all_files)
 
     if not overwrite:
         if os.path.exists(outputdir):
@@ -129,19 +126,21 @@ def make_plots_core(input_dir, cfg, overwrite_parameters, outputdir, inputfiles,
     if not os.path.exists(outputdir):
         os.makedirs(outputdir)
 
-    variables = accumulator['variables'].keys()
+    variables = list(provider.variables)
 
     if exclude_hist:
         variables_to_exclude = [s for s in variables if any([re.search(p, s) for p in exclude_hist])]
         variables = [s for s in variables if s not in variables_to_exclude]
     if only_hist:
         variables = [s for s in variables if any([re.search(p, s) for p in only_hist])]
-    hist_objs = { v : accumulator['variables'][v] for v in variables }
+
+    # Free the histograms of unrequested variables early (monolithic only;
+    # a no-op for the lazy split provider).
+    provider.restrict_variables(variables)
 
     plotter = PlotManager(
         variables=variables,
-        hist_objs=hist_objs,
-        datasets_metadata=accumulator['datasets_metadata'],
+        provider=provider,
         plot_dir=outputdir,
         style_cfg=style_cfg,
         only_cat=only_cat,

--- a/pocket_coffea/scripts/split_output.py
+++ b/pocket_coffea/scripts/split_output.py
@@ -1,41 +1,59 @@
 import os
-from coffea.util import load, save
+from coffea.util import save
 import click
 from rich import print
 from pocket_coffea.utils.filter_output import filter_output_by_year, filter_output_by_category
+from pocket_coffea.utils.output_split import load_output_auto, save_split
 
-def split_output(inputfile, outputfile, by, ncategory_per_file, overwrite):
+
+def _save_output(data, path, output_format="monolithic"):
+    """Save an output dict in the requested format.
+
+    - "monolithic": the classic single-blob coffea file (coffea.util.save).
+    - "split": the per-variable low-memory format (output_split.save_split) that
+      plotting can load one variable at a time.
+    """
+    if output_format == "split":
+        save_split(data, path)
+    else:
+        save(data, path)
+
+
+def split_output(inputfile, outputfile, by, ncategory_per_file, overwrite, output_format="monolithic"):
     '''Split coffea output files'''
     if outputfile is None:
         outputfile = inputfile.replace(".coffea", "_{}.coffea")
     else:
         outputfile = outputfile.replace(".coffea", "_{}.coffea")
     print(f"[blue]Reading input file: {inputfile}")
-    out_all = load(inputfile)
+    # load_output_auto transparently reads either the monolithic or the split
+    # format, so a file already written in the low-memory split format can also
+    # be re-split here.
+    out_all = load_output_auto(inputfile)
 
     if by == "year":
         years = list(out_all["datasets_metadata"]["by_datataking_period"].keys())
         outputfiles = {year : outputfile.format(year) for year in years}
-        print(f"[blue]Splitting output by year. {len(years)} output files will be saved:[/]")
+        print(f"[blue]Splitting output by year. {len(years)} output files will be saved ({output_format} format):[/]")
         print(sorted(outputfiles.values()))
         for year, outputfile in outputfiles.items():
             out = filter_output_by_year(out_all, year)
             if os.path.exists(outputfile) and not overwrite:
                 raise FileExistsError(f"Output file {outputfile} already exists. Use --overwrite to overwrite the output files.")
-            save(out, outputfile)
+            _save_output(out, outputfile, output_format)
             print(f"[green]Output saved to {outputfile}")
 
     elif by == "category" or by == "categories":
         allcategories = sorted(list(out_all["sumw"].keys()))
         ncats = len(allcategories)
         categoryblocks = [allcategories[i:i+ncategory_per_file] for i in range(0, ncats, ncategory_per_file)]
-        print(f"[blue]Splitting output by category: into {len(categoryblocks)} files, each with {ncategory_per_file} categories, totalling {ncats} categories.[/]")
+        print(f"[blue]Splitting output by category: into {len(categoryblocks)} files, each with {ncategory_per_file} categories, totalling {ncats} categories ({output_format} format).[/]")
         for ib, block in enumerate(categoryblocks):
             out = filter_output_by_category(out_all, block)
             thisoutput = outputfile.format(f"category{ib}")
             if os.path.exists(thisoutput) and not overwrite:
                 raise FileExistsError(f"Output file {thisoutput} already exists. Use --overwrite to overwrite the output files.")
-            save(out, thisoutput)
+            _save_output(out, thisoutput, output_format)
             print(f"[green]Output {ib+1}/{len(categoryblocks)} saved to {thisoutput}")
 
 @click.command()
@@ -70,14 +88,22 @@ def split_output(inputfile, outputfile, by, ncategory_per_file, overwrite):
     help="If splitting by category, specify how many categories go into one output.",
 )
 @click.option(
+    "--output-format",
+    required=False,
+    default="monolithic",
+    type=click.Choice(["monolithic", "split"]),
+    help="Output format: 'monolithic' (classic single-blob .coffea) or 'split' "
+         "(per-variable low-memory format that plotting can stream one variable at a time).",
+)
+@click.option(
     "--overwrite",
     is_flag=True,
     help="Overwrite output file if it already exists",
 )
 
-def main(inputfile, outputfile, by, ncategory_per_file, overwrite):
+def main(inputfile, outputfile, by, ncategory_per_file, output_format, overwrite):
     '''Split coffea output files'''
-    split_output(inputfile, outputfile, by, ncategory_per_file, overwrite)
+    split_output(inputfile, outputfile, by, ncategory_per_file, overwrite, output_format)
 
 if __name__ == "__main__":
     main()

--- a/pocket_coffea/utils/load_output.py
+++ b/pocket_coffea/utils/load_output.py
@@ -1,10 +1,12 @@
 import sys
 from pprint import pprint
-from coffea.util import load
+from pocket_coffea.utils.output_split import load_output_auto
 
 
 def load_output(file):
-    return load(file)
+    # Auto-detects the on-disk format: returns the classic monolithic dict for
+    # either a monolithic .coffea or a split-format file.
+    return load_output_auto(file)
 
 
 if __name__ == "__main__":

--- a/pocket_coffea/utils/output_split.py
+++ b/pocket_coffea/utils/output_split.py
@@ -1,0 +1,437 @@
+"""Split-histogram output format for low-memory plotting.
+
+The default PocketCoffea/coffea output is a single monolithic ``cloudpickle``
+blob (``coffea.util.save``): opening it with ``coffea.util.load`` always
+deserialises *every* histogram into memory at once, because pickle has no index
+and no random access.  For large analyses (many variables x many systematic
+variations) this costs gigabytes of RAM just to plot a handful of variables.
+
+This module defines an alternative **split** on-disk format that stores each
+variable in its own, independently loadable member so that consumers (e.g. the
+plotter) can read **one variable at a time** and never hold the whole file.
+
+Layout (a single ``.zip`` container, kept with the ``.coffea`` name so it is a
+drop-in replacement; it is auto-detected by its magic bytes)::
+
+    output_all.coffea                # a zip (magic PK\\x03\\x04)
+    |-- format.json                  # human-readable index (see below)
+    |-- metadata                     # cloudpickle of the output dict WITHOUT
+    |                                #  'variables'/'columns' (small; datasets_metadata,
+    |                                #  cutflow, sumw, sumw2, sum_genweights, ...)
+    |-- variables/<var>              # cloudpickle of {sample:{dataset:hist.Hist}}
+    `-- columns/<sample>             # optional; cloudpickle of the per-sample columns
+
+``format.json`` carries the format name/version, the list of variables, columns
+and categories, and the per-member compression used.  Member file names are
+``urllib.parse.quote``-encoded so any character in a variable/sample name is
+safe.
+
+Public API
+----------
+- :func:`save_split`      -- write an output dict to the split format.
+- :class:`SplitOutput`    -- lazy reader (``.metadata``, ``.variables``,
+                             ``.categories``, ``.get_variable(name)``).
+- :func:`is_split_output` -- sniff whether a path is a split file.
+- :func:`load_metadata`   -- read the metadata (no histograms) of either format.
+- :func:`to_monolithic`   -- reconstruct the full in-memory dict (compat).
+
+The code uses ``cloudpickle`` / ``zipfile`` directly (no coffea-version-specific
+API) so it works across coffea versions (validated against coffea 0.7.x).
+"""
+
+import io
+import json
+import os
+import zipfile
+from urllib.parse import quote, unquote
+
+import cloudpickle
+
+try:  # lz4 is a coffea dependency; fall back gracefully if unavailable
+    import lz4.frame as _lz4frame
+except Exception:  # pragma: no cover - environment without lz4
+    _lz4frame = None
+
+__all__ = [
+    "save_split",
+    "SplitOutput",
+    "is_split_output",
+    "load_metadata",
+    "to_monolithic",
+    "load_output_auto",
+    "MonolithicProvider",
+    "SplitProvider",
+    "make_provider",
+    "FORMAT_NAME",
+    "FORMAT_VERSION",
+]
+
+FORMAT_NAME = "pocketcoffea-split"
+FORMAT_VERSION = 1
+
+# Keys of the output dict that are stored as their own (per-entry) members
+# instead of being lumped into the small `metadata` member.
+_SPLIT_KEYS = ("variables", "columns")
+
+_ZIP_MAGIC = b"PK\x03\x04"
+_FORMAT_MEMBER = "format.json"
+_METADATA_MEMBER = "metadata"
+_VARIABLES_PREFIX = "variables/"
+_COLUMNS_PREFIX = "columns/"
+
+
+# ---------------------------------------------------------------------------
+# compression helpers
+# ---------------------------------------------------------------------------
+def _resolve_compression(compression):
+    """Return (member_compression, zip_compression).
+
+    - "lz4"  -> lz4-compress each member, store uncompressed in the zip.
+    - "none" -> raw cloudpickle members, let the zip deflate them.
+    Falls back to "none"+DEFLATED if lz4 is requested but unavailable.
+    """
+    if compression == "lz4" and _lz4frame is None:
+        compression = "none"
+    if compression == "lz4":
+        return "lz4", zipfile.ZIP_STORED
+    if compression in (None, "none"):
+        return "none", zipfile.ZIP_DEFLATED
+    raise ValueError(f"Unknown compression {compression!r}. Use 'lz4' or 'none'.")
+
+
+def _encode_member(obj, member_compression):
+    data = cloudpickle.dumps(obj)
+    if member_compression == "lz4":
+        return _lz4frame.compress(data)
+    return data
+
+
+def _decode_member(raw, member_compression):
+    if member_compression == "lz4":
+        raw = _lz4frame.decompress(raw)
+    return cloudpickle.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# introspection helpers
+# ---------------------------------------------------------------------------
+def _extract_categories(variables):
+    """Read the list of categories from the 'cat' axis of any one histogram."""
+    for samples in variables.values():
+        for datasets in samples.values():
+            for h in datasets.values():
+                for ax in h.axes:
+                    if getattr(ax, "name", None) == "cat":
+                        return list(ax)
+                return []
+    return []
+
+
+# ---------------------------------------------------------------------------
+# writing
+# ---------------------------------------------------------------------------
+def save_split(output, path, compression="lz4"):
+    """Write an accumulator ``output`` dict to the split format at ``path``.
+
+    ``output`` is the usual PocketCoffea output dict
+    (``{'variables': {var: {sample: {dataset: hist.Hist}}}, 'datasets_metadata': ..., ...}``).
+    Only ``variables`` and ``columns`` are split into per-entry members; every
+    other key goes into the small ``metadata`` member.
+    """
+    member_compression, zip_compression = _resolve_compression(compression)
+
+    variables = output.get("variables", {}) or {}
+    columns = output.get("columns", {}) or {}
+    present_split_keys = [k for k in _SPLIT_KEYS if k in output]
+    metadata = {k: v for k, v in output.items() if k not in _SPLIT_KEYS}
+
+    fmt = {
+        "format": FORMAT_NAME,
+        "version": FORMAT_VERSION,
+        "compression": member_compression,
+        "split_keys_present": present_split_keys,
+        "variables": list(variables.keys()),
+        "columns": list(columns.keys()),
+        "categories": _extract_categories(variables),
+    }
+
+    # write to a temporary path then atomically replace, so an interrupted
+    # write never leaves a half-written file that looks valid.
+    tmp_path = f"{path}.tmp-{os.getpid()}"
+    try:
+        with zipfile.ZipFile(tmp_path, "w", compression=zip_compression, allowZip64=True) as zf:
+            zf.writestr(_FORMAT_MEMBER, json.dumps(fmt, indent=2))
+            zf.writestr(_METADATA_MEMBER, _encode_member(metadata, member_compression))
+            for var, h_dict in variables.items():
+                zf.writestr(_VARIABLES_PREFIX + quote(var, safe=""),
+                            _encode_member(h_dict, member_compression))
+            for sample, c_dict in columns.items():
+                zf.writestr(_COLUMNS_PREFIX + quote(sample, safe=""),
+                            _encode_member(c_dict, member_compression))
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# reading
+# ---------------------------------------------------------------------------
+def is_split_output(path):
+    """Return True if ``path`` is a split-format file (a zip container).
+
+    Monolithic coffea files are lz4 frames (magic ``\\x04\\x22\\x4d\\x18``);
+    split files are zips (magic ``PK\\x03\\x04``), so the first bytes are a
+    reliable discriminator.
+    """
+    try:
+        with open(path, "rb") as f:
+            return f.read(4) == _ZIP_MAGIC
+    except OSError:
+        return False
+
+
+class SplitOutput:
+    """Lazy reader for a split-format output file.
+
+    Only ``format.json`` is read at construction. ``metadata`` is read (and
+    cached) on first access; each ``get_variable`` opens its own read-only
+    ``ZipFile`` handle, which makes the reader safe to use from forked worker
+    processes (no shared file descriptor).
+    """
+
+    def __init__(self, path):
+        self.path = path
+        with zipfile.ZipFile(path) as zf:
+            self._format = json.loads(zf.read(_FORMAT_MEMBER).decode("utf-8"))
+        if self._format.get("format") != FORMAT_NAME:
+            raise ValueError(
+                f"{path} is not a {FORMAT_NAME} file (format={self._format.get('format')!r})."
+            )
+        self._member_compression = self._format.get("compression", "lz4")
+        self._metadata = None
+
+    # -- index (cheap, from format.json) --
+    @property
+    def variables(self):
+        return list(self._format.get("variables", []))
+
+    @property
+    def columns(self):
+        return list(self._format.get("columns", []))
+
+    @property
+    def categories(self):
+        return list(self._format.get("categories", []))
+
+    @property
+    def version(self):
+        return self._format.get("version")
+
+    # -- payloads --
+    @property
+    def metadata(self):
+        """The output dict without 'variables'/'columns' (loaded once, cached)."""
+        if self._metadata is None:
+            with zipfile.ZipFile(self.path) as zf:
+                raw = zf.read(_METADATA_MEMBER)
+            self._metadata = _decode_member(raw, self._member_compression)
+        return self._metadata
+
+    def get_variable(self, name):
+        """Return ``{sample: {dataset: hist.Hist}}`` for a single variable."""
+        member = _VARIABLES_PREFIX + quote(name, safe="")
+        with zipfile.ZipFile(self.path) as zf:
+            raw = zf.read(member)
+        return _decode_member(raw, self._member_compression)
+
+    def get_columns(self, sample):
+        """Return the columns subtree for a single sample."""
+        member = _COLUMNS_PREFIX + quote(sample, safe="")
+        with zipfile.ZipFile(self.path) as zf:
+            raw = zf.read(member)
+        return _decode_member(raw, self._member_compression)
+
+    def to_monolithic(self):
+        """Reconstruct the full in-memory output dict (loads everything)."""
+        out = dict(self.metadata)
+        present = self._format.get("split_keys_present", list(_SPLIT_KEYS))
+        if "variables" in present:
+            out["variables"] = {v: self.get_variable(v) for v in self.variables}
+        if "columns" in present:
+            out["columns"] = {s: self.get_columns(s) for s in self.columns}
+        return out
+
+
+# ---------------------------------------------------------------------------
+# format-agnostic convenience helpers
+# ---------------------------------------------------------------------------
+def load_metadata(path):
+    """Return the output metadata (everything except variables/columns).
+
+    Cheap for split files (reads the small ``metadata`` member only). For a
+    monolithic file this must fall back to a full ``coffea.util.load`` and then
+    strip the histograms, so it is *not* cheap there.
+    """
+    if is_split_output(path):
+        return SplitOutput(path).metadata
+    from coffea.util import load
+    out = load(path)
+    return {k: v for k, v in out.items() if k not in _SPLIT_KEYS}
+
+
+def to_monolithic(source):
+    """Return a full monolithic output dict from a split file/reader or a path.
+
+    Accepts a :class:`SplitOutput`, or a path to either a split or a monolithic
+    file (a monolithic path is simply loaded as-is).
+    """
+    if isinstance(source, SplitOutput):
+        return source.to_monolithic()
+    if isinstance(source, (str, os.PathLike)):
+        if is_split_output(source):
+            return SplitOutput(source).to_monolithic()
+        from coffea.util import load
+        return load(source)
+    raise TypeError(f"Cannot convert {type(source)!r} to a monolithic output.")
+
+
+def load_output_auto(path):
+    """Load either format, always returning a full monolithic dict.
+
+    Provided for ad-hoc scripts that expect the classic dict. Prefer
+    :class:`SplitOutput` / providers when you want the low-memory behaviour.
+    """
+    return to_monolithic(path)
+
+
+# ---------------------------------------------------------------------------
+# variable providers (the low-memory plotting abstraction)
+# ---------------------------------------------------------------------------
+# A provider exposes a uniform interface over the two on-disk formats so the
+# plotter can pull histograms one variable at a time:
+#   .variables          -> list[str]
+#   .categories         -> list[str]
+#   .datasets_metadata  -> dict
+#   .get_variable(name) -> {sample: {dataset: hist.Hist}}
+# MonolithicProvider keeps the full dict in memory (loaded once); SplitProvider
+# reads each variable from disk on demand, so peak memory is bounded to the
+# variables currently being plotted.
+
+class MonolithicProvider:
+    """Provider backed by a fully-loaded monolithic output dict."""
+
+    kind = "monolithic"
+
+    def __init__(self, output):
+        self._output = output
+
+    @property
+    def variables(self):
+        return list(self._output["variables"].keys())
+
+    @property
+    def datasets_metadata(self):
+        return self._output["datasets_metadata"]
+
+    @property
+    def categories(self):
+        return _extract_categories(self._output["variables"])
+
+    def get_variable(self, name):
+        return self._output["variables"][name]
+
+    def restrict_variables(self, keep):
+        """Drop the histograms of variables not in ``keep`` to free memory."""
+        keep = set(keep)
+        vd = self._output["variables"]
+        for v in [v for v in vd if v not in keep]:
+            del vd[v]
+
+
+class SplitProvider:
+    """Provider backed by one or more split-format files (read per variable).
+
+    With several input files (e.g. plotting multiple split outputs) a variable
+    is read from each file that contains it and accumulated on the fly, mirroring
+    the old ``accumulate(files)`` behaviour but only one variable at a time.
+    """
+
+    kind = "split"
+
+    def __init__(self, paths):
+        if isinstance(paths, (str, os.PathLike)):
+            paths = [paths]
+        self._readers = [SplitOutput(p) for p in paths]
+        self._reader_var_sets = [set(r.variables) for r in self._readers]
+        # ordered union of variable names across files
+        self._variables = list(dict.fromkeys(
+            v for r in self._readers for v in r.variables
+        ))
+        self._datasets_metadata = None
+
+    @property
+    def variables(self):
+        return list(self._variables)
+
+    @property
+    def categories(self):
+        return list(dict.fromkeys(
+            c for r in self._readers for c in r.categories
+        ))
+
+    @property
+    def datasets_metadata(self):
+        if self._datasets_metadata is None:
+            mds = [r.metadata.get("datasets_metadata", {}) for r in self._readers]
+            if len(mds) == 1:
+                self._datasets_metadata = mds[0]
+            else:
+                from coffea.processor import accumulate
+                self._datasets_metadata = accumulate(mds)
+        return self._datasets_metadata
+
+    def get_variable(self, name):
+        parts = [
+            r.get_variable(name)
+            for r, vset in zip(self._readers, self._reader_var_sets)
+            if name in vset
+        ]
+        if not parts:
+            raise KeyError(name)
+        if len(parts) == 1:
+            return parts[0]
+        from coffea.processor import accumulate
+        return accumulate(parts)
+
+    def restrict_variables(self, keep):
+        """No-op: variables are read lazily from disk, nothing to free."""
+        return
+
+
+def make_provider(paths):
+    """Build the right provider for a list of input files.
+
+    If *every* input is a split file, returns a :class:`SplitProvider` (lazy,
+    low-memory). Otherwise loads/accumulates the monolithic inputs incrementally
+    (dropping each file after adding it) and returns a :class:`MonolithicProvider`.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        paths = [paths]
+    paths = list(paths)
+    if paths and all(is_split_output(p) for p in paths):
+        return SplitProvider(paths)
+
+    # monolithic (or mixed) path: incremental accumulate + drop to avoid the
+    # "all files + a merged copy" double-buffer of the old loader.
+    from coffea.util import load
+    from coffea.processor import accumulate
+    accumulator = None
+    for p in paths:
+        part = to_monolithic(p) if is_split_output(p) else load(p)
+        accumulator = part if accumulator is None else accumulate([accumulator, part])
+        del part
+    if accumulator is None:
+        raise ValueError("No input files provided to make_provider.")
+    return MonolithicProvider(accumulator)

--- a/pocket_coffea/utils/plot_utils.py
+++ b/pocket_coffea/utils/plot_utils.py
@@ -1,5 +1,6 @@
 import os
 from copy import deepcopy
+import multiprocessing
 from multiprocessing import Pool
 from collections import defaultdict
 from functools import partial
@@ -144,16 +145,53 @@ class Style:
                 "era" : "eras"
             }
 
+# ---------------------------------------------------------------------------
+# Multiprocessing workers.
+#
+# The plot dispatch is parallelised with a multiprocessing Pool. To avoid
+# pickling the whole PlotManager (and all its histograms) once per task, the
+# worker functions live at module scope and read the manager from a module
+# global that is set *before* the Pool forks. On Linux the default start method
+# is `fork`, so the child processes inherit the manager (and, for the monolithic
+# format, its in-memory accumulator) via copy-on-write; the only thing pickled
+# per task is the shape name (a string).
+# ---------------------------------------------------------------------------
+_PLOT_MANAGER = None
+
+
+def _fork_available():
+    '''True if the `fork` start method is available (Linux, macOS).
+
+    The copy-on-write worker mechanism requires fork; otherwise we fall back to
+    a serial loop rather than pay a full pickle of the manager per task.'''
+    try:
+        return "fork" in multiprocessing.get_all_start_methods()
+    except Exception:
+        return False
+
+
+def _worker_plot_datamc(name, *, ratio, syst, spliteras, format):
+    _PLOT_MANAGER.plot_datamc(name, ratio=ratio, syst=syst, spliteras=spliteras, format=format)
+
+
+def _worker_plot_comparison(name, *, ratio, format):
+    _PLOT_MANAGER.plot_comparison(name, ratio=ratio, format=format)
+
+
+def _worker_plot_systematic_shifts(name, *, ratio, format):
+    _PLOT_MANAGER.plot_systematic_shifts(name, ratio=ratio, format=format)
+
+
 class PlotManager:
     '''This class manages multiple Shape objects and their plotting.'''
 
     def __init__(
         self,
         variables,
-        hist_objs,
-        datasets_metadata,
-        plot_dir,
-        style_cfg,
+        hist_objs=None,
+        datasets_metadata=None,
+        plot_dir=None,
+        style_cfg=None,
         has_mcstat=True,
         toplabel=None,
         only_cat=None,
@@ -165,10 +203,10 @@ class PlotManager:
         verbose=1,
         save=True,
         index_file=None,
-        cache=True
+        cache=True,
+        provider=None,
     ) -> None:
 
-        self.shape_objects = {}
         self.plot_dir = plot_dir
         self.only_cat = only_cat
         self.only_year = only_year
@@ -178,61 +216,40 @@ class PlotManager:
         self.density = density
         self.save = save
         self.index_file = index_file
-        self.nhists = len(variables)
         self.toplabel = toplabel
-        self.verbose=verbose
+        self.verbose = verbose
         self.cache = cache
+        self.has_mcstat = has_mcstat
+        self.style_cfg = style_cfg
 
-        # Reading the datasets_metadata to
-        # build the correct shapes for each datataking year
-        # taking histo objects from hist_objs
-        self.hists_to_plot = {}
-        for variable in variables:
-            vs = {}
-            for year, samples in datasets_metadata["by_datataking_period"].items():
+        # A "provider" yields histograms one variable at a time (see
+        # pocket_coffea.utils.output_split). For backward compatibility we also
+        # accept the classic `hist_objs` dict {var:{sample:{dataset:Hist}}} plus
+        # `datasets_metadata`, wrapping them in an in-memory MonolithicProvider.
+        if provider is None:
+            from pocket_coffea.utils.output_split import MonolithicProvider
+            provider = MonolithicProvider(
+                {"variables": hist_objs, "datasets_metadata": datasets_metadata}
+            )
+        self.provider = provider
+        self.datasets_metadata = provider.datasets_metadata
+
+        self._variables = list(variables)
+        self.nhists = len(self._variables)
+
+        # Lightweight specs only: {f"{variable}_{year}": (variable, year)}.
+        # Shape objects (and their derived/copied histograms + caches) are built
+        # lazily, one at a time, right before plotting and dropped right after,
+        # so peak memory stays ~O(workers) shapes instead of O(all shapes).
+        self._shape_specs = {}
+        years = list(self.datasets_metadata["by_datataking_period"].keys())
+        for variable in self._variables:
+            for year in years:
                 if self.only_year and year not in self.only_year:
                     continue
-                hs = {}
-                for sample, datasets in samples.items():
-                    hs[sample] = {}
-                    for dataset in datasets:
-                        try:
-                            hs[sample][dataset] = hist_objs[variable][sample][dataset]
-                        except:
-                            print(f"Warning: missing dataset {dataset} for variable {variable}, year {year}")
-                    if len(hs[sample].keys()) == 0:
-                        del hs[sample]
-                vs[year] = hs
-            self.hists_to_plot[variable] = vs
-        
-        for variable, histoplot in self.hists_to_plot.items():
-            for year, h_dict in histoplot.items():
-                if self.only_year and year not in self.only_year:
-                    continue
-                name = '_'.join([variable, year])
-                # If toplabel is overwritten we use that, if not we take the lumi from the year
-                if self.toplabel:
-                    toplabel_to_use = self.toplabel
-                else:
-                    toplabel_to_use = f"$\mathcal{{L}}$ = {style_cfg.plot_upper_label.by_year[year]:.2f}/fb"
+                self._shape_specs['_'.join([variable, year])] = (variable, year)
 
-                self.shape_objects[name] = Shape(
-                    h_dict,
-                    datasets_metadata["by_dataset"],
-                    name,
-                    plot_dir,
-                    style_cfg=style_cfg,
-                    only_cat=self.only_cat,
-                    log_x=self.log_x,
-                    log_y=self.log_y,
-                    density=self.density,
-                    has_mcstat=has_mcstat,
-                    toplabel=toplabel_to_use,
-                    year=year,
-                    verbose=self.verbose,
-                    cache=self.cache
-                )
-        del self.hists_to_plot
+        self._shape_objects_cache = None  # populated lazily by the compat property
 
         if self.save:
             self.make_dirs()
@@ -240,34 +257,89 @@ class PlotManager:
                 self.copy_index_file()
             matplotlib.use('agg')
 
+    def _build_shape(self, name):
+        '''Build a single Shape on demand from the provider, for the given
+        f"{variable}_{year}" name. The Shape is meant to be plotted and then
+        dropped so its derived histograms / caches are reclaimed.'''
+        variable, year = self._shape_specs[name]
+        var_hists = self.provider.get_variable(variable)  # {sample:{dataset:Hist}}
+        samples = self.datasets_metadata["by_datataking_period"][year]
+        # Fresh {sample: {dataset: Hist}} dict (references to the Hist objects).
+        # The fresh outer/inner dicts protect the provider's data from
+        # Shape.group_samples' in-place key reassignment.
+        h_dict = {}
+        for sample, datasets in samples.items():
+            hs = {}
+            for dataset in datasets:
+                try:
+                    hs[dataset] = var_hists[sample][dataset]
+                except (KeyError, TypeError):
+                    if self.verbose > 0:
+                        print(f"Warning: missing dataset {dataset} for variable {variable}, year {year}")
+            if hs:
+                h_dict[sample] = hs
+
+        # If toplabel is overwritten we use that, if not we take the lumi from the year
+        if self.toplabel:
+            toplabel_to_use = self.toplabel
+        else:
+            toplabel_to_use = f"$\\mathcal{{L}}$ = {self.style_cfg.plot_upper_label.by_year[year]:.2f}/fb"
+
+        return Shape(
+            h_dict,
+            self.datasets_metadata["by_dataset"],
+            name,
+            self.plot_dir,
+            style_cfg=self.style_cfg,
+            only_cat=self.only_cat,
+            log_x=self.log_x,
+            log_y=self.log_y,
+            density=self.density,
+            has_mcstat=self.has_mcstat,
+            toplabel=toplabel_to_use,
+            year=year,
+            verbose=self.verbose,
+            cache=self.cache,
+        )
+
+    @property
+    def shape_objects(self):
+        '''Backward-compatible access to all Shape objects.
+
+        WARNING: this eagerly builds and retains every Shape (the old behaviour),
+        defeating the low-memory streaming. It exists only for external callers
+        such as trigger_efficiency.py; the main plotting paths use the lazy
+        _build_shape() instead.'''
+        if self._shape_objects_cache is None:
+            self._shape_objects_cache = {
+                name: self._build_shape(name) for name in self._shape_specs
+            }
+        return self._shape_objects_cache
+
     def make_dirs(self):
-        '''Create directories recursively before saving plots with multiprocessing
-        to avoid conflicts between different processes.'''
-        for name, shape in self.shape_objects.items():
-            for cat in shape.categories:
-                if self.only_cat and cat not in self.only_cat:
-                    continue
-                plot_dir = os.path.join(self.plot_dir, cat)
-                if not os.path.exists(plot_dir):
-                    os.makedirs(plot_dir)
+        '''Create the per-category output directories up front (before the Pool
+        forks) so worker processes never race to create them.'''
+        for cat in self.provider.categories:
+            if self.only_cat and cat not in self.only_cat:
+                continue
+            os.makedirs(os.path.join(self.plot_dir, cat), exist_ok=True)
 
     def copy_index_file(self):
         '''Copy the specified index file to the plot directory and each of the subdirectories.'''
         if not os.path.exists(self.index_file):
             raise Exception(f"Index file {self.index_file} not found.")
         os.system(f"cp {self.index_file} {self.plot_dir}")
-        for name, shape in self.shape_objects.items():
-            for cat in shape.categories:
-                if self.only_cat and cat not in self.only_cat:
-                    continue
-                plot_dir = os.path.join(self.plot_dir, cat)
-                os.system(f"cp {self.index_file} {plot_dir}")
+        for cat in self.provider.categories:
+            if self.only_cat and cat not in self.only_cat:
+                continue
+            plot_dir = os.path.join(self.plot_dir, cat)
+            os.system(f"cp {self.index_file} {plot_dir}")
 
     def plot_datamc(self, name, ratio=True, syst=True, spliteras=False, format="png"):
         '''Plots one histogram, for all years and categories.'''
         if self.verbose>0:
             print("Plotting: ", name)
-        shape = self.shape_objects[name]
+        shape = self._build_shape(name)
         if shape.dense_dim > 1:
             if self.verbose>0:
                 print(f"WARNING: cannot plot data/MC for histogram {shape.name} with dimension {shape.dense_dim}.")
@@ -282,21 +354,15 @@ class PlotManager:
 
     def plot_datamc_all(self, ratio=True, syst=True,  spliteras=False, format="png"):
         '''Plots all the histograms contained in the dictionary, for all years and categories.'''
-        shape_names = list(self.shape_objects.keys())
-        if self.workers > 1:
-            with Pool(processes=self.workers) as pool:
-                # Parallel calls of plot_datamc() on different shape objects
-                pool.map(partial(self.plot_datamc, ratio=ratio, syst=syst, spliteras=spliteras, format=format), shape_names)
-                pool.close()
-        else:
-            for shape in shape_names:
-                self.plot_datamc(shape, ratio=ratio, syst=syst, spliteras=spliteras, format=format)
+        self._run_parallel(_worker_plot_datamc,
+                           dict(ratio=ratio, syst=syst, spliteras=spliteras, format=format),
+                           lambda name: self.plot_datamc(name, ratio=ratio, syst=syst, spliteras=spliteras, format=format))
 
     def plot_comparison(self, name, ratio=True, format="png"):
         '''Plots one histogram, for all years and categories.'''
         if self.verbose>0:
             print("Plotting: ", name)
-        shape = self.shape_objects[name]
+        shape = self._build_shape(name)
         if shape.dense_dim > 1:
             if self.verbose>0:
                 print(f"WARNING: cannot plot histogram {shape.name} with dimension {shape.dense_dim}. It will be skipped")
@@ -304,20 +370,15 @@ class PlotManager:
 
         shape.plot_comparison_all(ratio,  save=self.save, format=format)
 
-    def plot_comparison_all(self, ratio=True, format=format):
+    def plot_comparison_all(self, ratio=True, format="png"):
         '''Plots all the histograms contained in the dictionary, for all years and categories.'''
-        shape_names = list(self.shape_objects.keys())
-        if self.workers > 1:
-            with Pool(processes=self.workers) as pool:
-                pool.map(partial(self.plot_comparison, ratio=ratio, format=format), shape_names)
-                pool.close()
-        else:
-            for shape in shape_names:
-                self.plot_comparison(shape, ratio=ratio, format=format)
+        self._run_parallel(_worker_plot_comparison,
+                           dict(ratio=ratio, format=format),
+                           lambda name: self.plot_comparison(name, ratio=ratio, format=format))
 
-
-    def plot_systematic_shifts(self, shape, format="png", ratio=True):
+    def plot_systematic_shifts(self, name, format="png", ratio=True):
         """Plots the systematic shifts for all the variations."""
+        shape = self._build_shape(name)
         if self.verbose > 0:
             print("Plotting systematic shifts for:", shape.name)
         if shape.dense_dim > 1:
@@ -335,17 +396,31 @@ class PlotManager:
 
     def plot_systematic_shifts_all(self, format="png", ratio=True):
         """Plots the systematic shifts for all the shape objects."""
-        if self.workers > 1:
-            with Pool(processes=self.workers) as pool:
-                # Parallel calls of plot_systematic_shifts() on different shape objects
-                pool.map(
-                    partial(self.plot_systematic_shifts, format=format, ratio=ratio),
-                    self.shape_objects.values(),
-                )
-                pool.close()
+        self._run_parallel(_worker_plot_systematic_shifts,
+                           dict(ratio=ratio, format=format),
+                           lambda name: self.plot_systematic_shifts(name, format=format, ratio=ratio))
+
+    def _run_parallel(self, worker, worker_kwargs, serial_fn):
+        '''Dispatch a per-shape plotting `worker` across all shape specs.
+
+        Sets the module-global _PLOT_MANAGER before forking a Pool so workers
+        read it via copy-on-write (only the shape name is pickled per task).
+        Falls back to a serial loop when workers<=1 or fork is unavailable.'''
+        global _PLOT_MANAGER
+        shape_names = list(self._shape_specs.keys())
+        if self.workers > 1 and _fork_available():
+            _PLOT_MANAGER = self
+            try:
+                ctx = multiprocessing.get_context("fork")
+                with ctx.Pool(processes=self.workers) as pool:
+                    pool.map(partial(worker, **worker_kwargs), shape_names)
+                    pool.close()
+                    pool.join()
+            finally:
+                _PLOT_MANAGER = None
         else:
-            for shape in self.shape_objects.values():
-                self.plot_systematic_shifts(shape, format=format, ratio=ratio)
+            for name in shape_names:
+                serial_fn(name)
 
 class Shape:
     '''This class handles the plotting of 1D data/MC histograms.
@@ -876,6 +951,12 @@ class Shape:
             if self.cache:
                 self._stacksCache[cat] = stacks
             if not self.is_data_only:
+                # Honour --no-cache for the systematics cache too: keep only the
+                # current category so syst_dict does not grow to O(#categories).
+                # (Each category is fully consumed before the next, so dropping
+                # prior categories is safe.)
+                if not self.cache:
+                    self.syst_manager.syst_dict.clear()
                 self.syst_manager.update(cat, stacks)
         else:
             stacks = self._stacksCache[cat]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dataset-discovery-cli="pocket_coffea.scripts.dataset.dataset_query:dataset_disco
 hadd-skimmed-files="pocket_coffea.scripts.hadd_skimmed_files:hadd_skimmed_files"
 merge-outputs="pocket_coffea.scripts.merge_outputs:main"
 split-output="pocket_coffea.scripts.split_output:main"
+convert-output="pocket_coffea.scripts.convert_output:main"
 print-parameters="pocket_coffea.scripts.print_parameters:print_parameters"
 make-config="pocket_coffea.scripts.make_config:make_config"
 check-jobs="pocket_coffea.scripts.check_jobs:check_jobs"

--- a/tests/test_output_split.py
+++ b/tests/test_output_split.py
@@ -7,6 +7,7 @@ exposes the index and metadata without loading histograms, and that the
 convert-output / merge --split write paths agree with the monolithic format.
 """
 
+import glob
 import os
 
 import numpy as np
@@ -170,3 +171,42 @@ def test_merge_save_split(mono, tmp_path):
     _save_output(mono, str(tmp_path / "m_mono.coffea"), "monolithic")
     assert not is_split_output(str(tmp_path / "m_mono.coffea"))
     _deep_equal(to_monolithic(sp), mono, "root")
+
+
+def test_split_output_by_category_all_formats(mono, split_path, tmp_path):
+    """split-output must read BOTH a monolithic and a split input and write
+    EITHER format when splitting by category. Regression: it was monolithic-only
+    (hardcoded coffea load/save), so it crashed on a split input and could never
+    emit the low-memory split format."""
+    from pocket_coffea.scripts.split_output import split_output
+
+    cats = set(mono["sumw"].keys())
+    for inp, in_label in [(FIXTURE, "mono_in"), (split_path, "split_in")]:
+        for out_fmt in ("monolithic", "split"):
+            tmpl = str(tmp_path / f"{in_label}_{out_fmt}.coffea")
+            split_output(inp, tmpl, by="category", ncategory_per_file=1,
+                         overwrite=True, output_format=out_fmt)
+            produced = sorted(glob.glob(str(tmp_path / f"{in_label}_{out_fmt}_category*.coffea")))
+            assert len(produced) == len(cats), (in_label, out_fmt, produced)
+            seen = set()
+            for p in produced:
+                assert is_split_output(p) == (out_fmt == "split"), (p, out_fmt)
+                d = to_monolithic(p)  # loads back regardless of format
+                seen.update(d["sumw"].keys())
+            # the union of per-category files reconstructs every category
+            assert seen == cats, (in_label, out_fmt)
+
+
+def test_split_output_by_year_reads_and_writes_split(mono, split_path, tmp_path):
+    """The by-year branch must also accept a split input and honour output_format."""
+    from pocket_coffea.scripts.split_output import split_output
+
+    years = set(mono["datasets_metadata"]["by_datataking_period"].keys())
+    tmpl = str(tmp_path / "yr.coffea")
+    split_output(split_path, tmpl, by="year", ncategory_per_file=8,
+                 overwrite=True, output_format="split")
+    produced = sorted(glob.glob(str(tmp_path / "yr_*.coffea")))
+    assert len(produced) == len(years)
+    for p in produced:
+        assert is_split_output(p)
+        to_monolithic(p)  # loads back

--- a/tests/test_output_split.py
+++ b/tests/test_output_split.py
@@ -1,0 +1,172 @@
+"""Unit tests for the split-histogram output format
+(:mod:`pocket_coffea.utils.output_split`).
+
+These use a committed reference coffea output as fixture and check that the
+split format round-trips histograms/metadata/columns exactly, that the reader
+exposes the index and metadata without loading histograms, and that the
+convert-output / merge --split write paths agree with the monolithic format.
+"""
+
+import os
+
+import numpy as np
+import hist
+import pytest
+from coffea.util import load
+
+from pocket_coffea.utils.output_split import (
+    save_split,
+    SplitOutput,
+    is_split_output,
+    load_metadata,
+    to_monolithic,
+    make_provider,
+)
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FIXTURE = os.path.join(
+    REPO, "tests/test_full_configs/test_new_weights/output_3b6cf6c/output_all.coffea"
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(FIXTURE), reason="reference coffea fixture not available"
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers / fixtures
+# ---------------------------------------------------------------------------
+def _deep_equal(a, b, path=""):
+    """Assert two output object graphs are equal, comparing hist.Hist by their
+    bin values/variances and coffea accumulators by their ``.value``."""
+    if isinstance(a, hist.Hist) or isinstance(b, hist.Hist):
+        assert type(a) == type(b), f"{path}: type mismatch {type(a)} vs {type(b)}"
+        assert [ax.name for ax in a.axes] == [ax.name for ax in b.axes], f"{path}: axes"
+        assert np.array_equal(a.values(flow=True), b.values(flow=True)), f"{path}: values"
+        va, vb = a.variances(flow=True), b.variances(flow=True)
+        if va is None or vb is None:
+            assert va is vb, f"{path}: variances presence"
+        else:
+            assert np.array_equal(va, vb), f"{path}: variances"
+        return
+    if isinstance(a, dict):
+        assert isinstance(b, dict) and a.keys() == b.keys(), f"{path}: dict keys"
+        for k in a:
+            _deep_equal(a[k], b[k], f"{path}.{k}")
+        return
+    if isinstance(a, (list, tuple)):
+        assert len(a) == len(b), f"{path}: length"
+        for i, (x, y) in enumerate(zip(a, b)):
+            _deep_equal(x, y, f"{path}[{i}]")
+        return
+    if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
+        assert np.array_equal(a, b), f"{path}: ndarray"
+        return
+    if hasattr(a, "value") and hasattr(b, "value"):  # coffea column_accumulator etc.
+        _deep_equal(a.value, b.value, f"{path}.value")
+        return
+    assert a == b or (isinstance(a, float) and np.isclose(a, b)), f"{path}: {a!r} != {b!r}"
+
+
+@pytest.fixture(scope="module")
+def mono():
+    return load(FIXTURE)
+
+
+@pytest.fixture(scope="module")
+def split_path(tmp_path_factory, mono):
+    p = str(tmp_path_factory.mktemp("split") / "out_split.coffea")
+    save_split(mono, p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+def test_is_split_output(split_path):
+    assert is_split_output(split_path)
+    assert not is_split_output(FIXTURE)
+
+
+def test_variable_index(mono, split_path):
+    r = SplitOutput(split_path)
+    assert set(r.variables) == set(mono["variables"].keys())
+    assert r.version is not None
+
+
+def test_categories_present(split_path):
+    assert len(SplitOutput(split_path).categories) > 0
+
+
+def test_metadata_without_histograms(split_path):
+    md = load_metadata(split_path)
+    assert "variables" not in md
+    assert "datasets_metadata" in md
+    assert "cutflow" in md and "sumw" in md
+
+
+def test_get_variable_structure(mono, split_path):
+    r = SplitOutput(split_path)
+    v = r.variables[0]
+    sub = r.get_variable(v)
+    assert set(sub.keys()) == set(mono["variables"][v].keys())
+    for sample in sub:
+        assert set(sub[sample].keys()) == set(mono["variables"][v][sample].keys())
+
+
+def test_roundtrip_lz4(mono, split_path):
+    _deep_equal(to_monolithic(split_path), mono, "root")
+
+
+def test_roundtrip_no_compression(mono, tmp_path):
+    p = str(tmp_path / "nc.coffea")
+    save_split(mono, p, compression="none")
+    assert is_split_output(p)
+    _deep_equal(to_monolithic(p), mono, "root")
+
+
+def test_providers_agree(split_path):
+    mp = make_provider([FIXTURE])
+    sp = make_provider([split_path])
+    assert mp.kind == "monolithic" and sp.kind == "split"
+    assert set(mp.variables) == set(sp.variables)
+    assert mp.categories == SplitOutput(split_path).categories
+    for v in mp.variables:
+        _deep_equal(mp.get_variable(v), sp.get_variable(v), f"var:{v}")
+
+
+def test_restrict_variables_monolithic():
+    mp = make_provider([FIXTURE])
+    keep = list(mp.variables)[:1]
+    mp.restrict_variables(keep)
+    assert set(mp.variables) == set(keep)
+
+
+def test_restrict_variables_split_is_noop(split_path):
+    sp = make_provider([split_path])
+    before = set(sp.variables)
+    sp.restrict_variables(list(before)[:1])  # no-op for lazy provider
+    assert set(sp.variables) == before
+
+
+def test_convert_output_roundtrip(mono, tmp_path):
+    from pocket_coffea.scripts.convert_output import convert_output
+
+    sp = str(tmp_path / "c_split.coffea")
+    mo = str(tmp_path / "c_mono.coffea")
+    convert_output([FIXTURE], sp, target_format="split", force=True)
+    assert is_split_output(sp)
+    convert_output([sp], mo, target_format="monolithic", force=True)
+    assert not is_split_output(mo)
+    _deep_equal(load(mo), mono, "root")
+
+
+def test_merge_save_split(mono, tmp_path):
+    from pocket_coffea.scripts.merge_outputs import _save_output
+
+    sp = str(tmp_path / "m_split.coffea")
+    _save_output(mono, sp, "split")
+    assert is_split_output(sp)
+    _save_output(mono, str(tmp_path / "m_mono.coffea"), "monolithic")
+    assert not is_split_output(str(tmp_path / "m_mono.coffea"))
+    _deep_equal(to_monolithic(sp), mono, "root")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,118 @@
+"""Unit tests for the plotting code (:mod:`pocket_coffea.utils.plot_utils`
+and :mod:`pocket_coffea.scripts.plot.make_plots`).
+
+They check that:
+- the low-memory redesign produces the *same* plots from a monolithic output and
+  from its split-format equivalent,
+- serial and multiprocessing (fork) dispatch agree,
+- ``--no-cache`` and ``--only-hist`` behave,
+- the PlotManager is lazy (it does not eagerly build every Shape at construction).
+"""
+
+import glob
+import importlib
+import os
+import time
+
+import pytest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FIXDIR = os.path.join(REPO, "tests/test_full_configs/test_new_weights/output_3b6cf6c")
+MONO = os.path.join(FIXDIR, "output_all.coffea")
+CFG = os.path.join(FIXDIR, "parameters_dump.yaml")
+
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(MONO), reason="reference coffea fixture not available"
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _warm_imports():
+    """Pre-import lazily-loaded plotting modules.
+
+    The CVMFS-unpacked apptainer image occasionally raises ``OSError(5)`` on the
+    first read of a lazily-imported module file; importing them up front (with a
+    short retry) makes the plotting runs deterministic. Harmless on a normal
+    install.
+    """
+    for m in [
+        "hist", "hist.plot", "hist.stack", "mplhep",
+        "mplhep.error_estimation", "matplotlib.pyplot",
+    ]:
+        for _ in range(8):
+            try:
+                importlib.import_module(m)
+                break
+            except OSError:
+                time.sleep(1)
+
+
+@pytest.fixture(scope="module")
+def split_path(tmp_path_factory):
+    from coffea.util import load
+    from pocket_coffea.utils.output_split import save_split
+
+    p = str(tmp_path_factory.mktemp("split") / "out_split.coffea")
+    save_split(load(MONO), p)
+    return p
+
+
+def _run(outdir, inputfile, workers=1, no_cache=False, only_hist=()):
+    from pocket_coffea.scripts.plot.make_plots import make_plots_core
+
+    make_plots_core(
+        input_dir=FIXDIR, cfg=CFG, overwrite_parameters=(), outputdir=outdir,
+        inputfiles=(inputfile,), workers=workers, only_cat=(), only_year=(), only_syst=(),
+        exclude_hist=(), only_hist=only_hist, split_systematics=False, partial_unc_band=False,
+        no_syst=False, overwrite=True, log_x=False, log_y=False, density=False, verbose=0,
+        format="png", systematics_shifts=False, no_ratio=False, no_systematics_ratio=False,
+        compare=False, index_file=None, no_cache=no_cache,
+        split_by_category=False,
+    )
+    return sorted(os.path.relpath(p, outdir) for p in glob.glob(f"{outdir}/**/*.png", recursive=True))
+
+
+def test_plotmanager_is_lazy(split_path):
+    from omegaconf import OmegaConf
+    from pocket_coffea.utils.output_split import make_provider
+    from pocket_coffea.utils.plot_utils import PlotManager
+
+    prov = make_provider([split_path])
+    pm = PlotManager(
+        variables=list(prov.variables), provider=prov, plot_dir="/tmp/_pc_lazychk",
+        style_cfg=OmegaConf.load(CFG)["plotting_style"], workers=1, save=False, verbose=0,
+    )
+    # No Shape objects are built at construction ...
+    assert pm._shape_objects_cache is None
+    assert len(pm._shape_specs) > 0
+    # ... and building one on demand does not populate the eager cache.
+    name = next(iter(pm._shape_specs))
+    assert pm._build_shape(name) is not None
+    assert pm._shape_objects_cache is None
+
+
+def test_plots_mono_vs_split(tmp_path, split_path):
+    mono_plots = _run(str(tmp_path / "mono"), MONO, workers=1)
+    split_plots = _run(str(tmp_path / "split"), split_path, workers=1)
+    assert len(mono_plots) > 0
+    assert mono_plots == split_plots
+
+
+def test_plots_parallel_matches_serial(tmp_path, split_path):
+    serial = _run(str(tmp_path / "j1"), split_path, workers=1, only_hist=("JetGood_pt", "ElectronGood_pt"))
+    forked = _run(str(tmp_path / "j2"), split_path, workers=2, only_hist=("JetGood_pt", "ElectronGood_pt"))
+    assert len(serial) > 0
+    assert serial == forked
+
+
+def test_plots_no_cache_matches(tmp_path, split_path):
+    cached = _run(str(tmp_path / "cache"), split_path, workers=1, only_hist=("JetGood_pt",))
+    uncached = _run(str(tmp_path / "nocache"), split_path, workers=1, no_cache=True, only_hist=("JetGood_pt",))
+    assert len(cached) > 0
+    assert cached == uncached
+
+
+def test_only_hist_filter(tmp_path, split_path):
+    got = _run(str(tmp_path / "only"), split_path, workers=1, only_hist=("JetGood_pt",))
+    assert len(got) > 0
+    assert all("JetGood_pt" in p for p in got)


### PR DESCRIPTION
Addresses:  #537 

Plotting large outputs consumed gigabytes of RAM: coffea's monolithic cloudpickle .coffea must be fully deserialized to read anything, and the plotter then eagerly built and retained a Shape (with deepcopies + per-category stack/systematic caches) for every (variable, year), while multiprocessing re-pickled the whole PlotManager per task.

This introduces an alternative *on-disk format* that stores each variable in its own member so histograms can be loaded one variable at a time, plus a lazy, streaming PlotManager that builds/plots/drops one Shape at a time. Peak plotting memory becomes ~O(workers) shapes instead of O(all shapes).

- output_split.py: split-format writer/reader (zip container, .coffea name, auto-detected by magic bytes) with format.json index + a small metadata member (readable without histograms) + per-variable members. 
- convert-output CLI: convert monolithic <-> split (and merge several inputs into one split file).
- merge-outputs: --split / --output-format to export the split format directly.
- plot_utils.PlotManager: consume a provider and build Shapes lazily via _build_shape(); module-level workers + a pre-fork copy-on-write global instead of pickling the manager per task; --no-cache now also bounds the systematics cache. Constructor stays backward compatible (hist_objs=/datasets_metadata=).
- make_plots: build a provider, drop the load double-buffer, prune to requested variables early. load_output: auto-detect either format.
- Existing monolithic .coffea files **still plot unchanged**.
- Tests: tests/test_output_split.py (format round-trip, metadata-only reads, providers, convert/merge) and tests/test_plotting.py (mono-vs-split plot equivalence, serial-vs-fork, --no-cache, --only-hist, lazy construction).