### PR TITLE
JEC split by level - testing fix for 2024

### DIFF
--- a/pocket_coffea/lib/calibrators/common/common.py
+++ b/pocket_coffea/lib/calibrators/common/common.py
@@ -3,7 +3,7 @@ import numpy as np
 import vector
 import awkward as ak
 import cachetools
-from pocket_coffea.lib.jets import met_correction_after_jec, jet_correction_corrlib, msoftdrop_correction
+from pocket_coffea.lib.jets import met_correction_after_jec, jet_correction_corrlib, jet_correction_corrlib_bylevel, msoftdrop_correction
 from pocket_coffea.lib.leptons import (
     get_ele_scaled, 
     get_ele_smeared, 
@@ -98,8 +98,18 @@ class JetsCalibrator(Calibrator):
             # register also a new entry which is storing the order of the jets
             self.calibrated_collections.append(f"{jet_coll_name}_sortidx")
 
-            corrected_jets = jet_correction_corrlib(
-                calib_params=self.jet_calib_param.jet_types[jet_type_alias][self._year],
+            calib_params = self.jet_calib_param.jet_types[jet_type_alias][self._year]
+            # Select the JEC application method:
+            #  - by_level=True  -> `level` is a list of single JEC levels, applied one by
+            #                      one (allows customizations spliced between levels)
+            #  - by_level=False -> `level` is the single compound correction name (default)
+            jec_func = (
+                jet_correction_corrlib_bylevel
+                if calib_params.get("by_level", False)
+                else jet_correction_corrlib
+            )
+            corrected_jets = jec_func(
+                calib_params=calib_params,
                 variations=self.jet_calib_param.variations[jet_type_alias][self._year],
                 events=events,
                 jet_type = jet_type_alias,

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -498,6 +498,7 @@ def jet_correction_corrlib(
     apply_jer=True,
     jec_syst=True,
 ):    
+
     isMC = chunk_metadata["isMC"]
     year = chunk_metadata["year"]
     era = chunk_metadata["era"]
@@ -669,6 +670,265 @@ def jet_correction_corrlib(
     return jets_jagged
 
 
+def jet_correction_corrlib_bylevel(
+    calib_params,
+    variations,
+    events,
+    jet_type,
+    jet_coll_name,
+    chunk_metadata,
+    nano_version,
+    apply_jer=True,
+    jec_syst=True,
+):
+    """By-level variant of :func:`jet_correction_corrlib`.
+
+    Instead of applying the single *compound* JEC correction (e.g. ``L1L2L3Res``),
+    this function expects ``calib_params['level']`` to be a **list** of single JEC
+    levels (e.g. ``['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']``) and
+    applies them one after the other. This reproduces exactly the chaining performed
+    internally by the compound correction (``input_op='*'``, ``inputs_update=['JetPt']``,
+    ``output_op='*'``): each level is evaluated on the running, partially-corrected jet
+    pt, its factor is multiplied into the cumulative correction, and the updated pt is
+    fed to the next level.
+
+    Applying the levels explicitly leaves a place to splice in a custom correction right
+    after any given level: see the CUSTOMIZATION SEAM inside the per-level loop.
+
+    JER and JES-systematic handling are identical to :func:`jet_correction_corrlib`.
+    """
+    isMC = chunk_metadata["isMC"]
+    year = chunk_metadata["year"]
+    era = chunk_metadata["era"]
+
+    json_path = calib_params["json_path"]
+    jer_tag = None
+    if isMC:
+        jec_tag = calib_params['jec_mc']
+        jer_tag = calib_params['jer']
+    else:
+        if type(calib_params['jec_data']) == str:
+            jec_tag = calib_params['jec_data']
+        else:
+            jec_tag = calib_params['jec_data'][chunk_metadata["era"]]
+
+    # 'level' is a LIST of single JEC levels applied in order, e.g.
+    # ['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']
+    levels = calib_params['level']
+    if isinstance(levels, str):
+        raise Exception(
+            f"[jet_correction_corrlib_bylevel] 'level' must be a list of single JEC levels "
+            f"(e.g. ['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), got the "
+            f"string '{levels}'. Use jet_correction_corrlib for the compound correction."
+        )
+
+    # no jer and variations applied on data
+    apply_jes = True
+    jes_syst = jer_syst = False
+    if isMC:
+        if jec_syst:
+            jes_syst = True
+            if "JER" in variations:
+                jer_syst = True
+    else:
+        apply_jer = False
+
+    if jer_syst and not apply_jer:
+        raise Exception(
+            f"JER systematics can only be applied, "
+            "if nominal JER shifts are applied aswell, "
+            "which is turned off for collection {jet_coll_name}")
+
+    # get the correction sets
+    cset = correctionlib.CorrectionSet.from_file(json_path)
+
+    # prepare inputs
+    # no need of copies
+    jets_jagged = events[jet_coll_name]
+    counts = ak.num(jets_jagged)
+
+    nano_version = chunk_metadata.get("nano_version", 9)
+    rho = get_rho(events, nano_version)
+    # Add variables needed for JEC and JER corrections (e.g. pt_raw, mass_raw, pt_gen, event_rho)
+    jets_jagged = add_jec_variables(jets_jagged, rho, isMC)
+
+    if ("event_id" not in jets_jagged.fields) and (apply_jer or jer_syst):
+        jets_jagged["event_id"] = ak.ones_like(jets_jagged.pt) * events.event
+    if ("run_nr" not in jets_jagged.fields):
+        jets_jagged["run_nr"] = ak.ones_like(jets_jagged.pt) * events.run
+
+    # flatten
+    jets = ak.flatten(jets_jagged)
+    # evaluate dictionary
+    eval_dict = {
+        "JetPt": jets.pt_raw,
+        "JetEta": jets.eta,
+        "JetPhi": jets.phi,
+        "Rho": jets.event_rho,
+        "JetA": jets.area,
+        "run": jets.run_nr
+    }
+
+    # jes central: apply the single JEC levels one by one
+    if apply_jes:
+        # Two distinct running pt quantities are tracked:
+        #   jet_pt_prop : the PROPAGATION pt = pt_raw * (cumulative factor so far). This is
+        #                 the physical, partially-corrected pt carried from level to level.
+        #   corr_total  : the cumulative multiplicative JEC correction, applied to
+        #                 pt_raw/mass_raw at the very end.
+        # The pt used to *evaluate* each level (jet_pt_eval) defaults to jet_pt_prop, but it
+        # can be adjusted at the EVALUATION-PT SEAM to change only the pt at which a level's
+        # correction is looked up, WITHOUT changing the pt the correction propagates on.
+        jet_pt_prop = jets.pt_raw
+        corr_total = ak.ones_like(jets.pt_raw)
+
+        for level in levels:
+            tag_jec_level = "_".join([jec_tag, level, jet_type])
+            # single JEC levels live among the regular corrections; keep a compound
+            # fallback in case a configured "level" is itself a compound correction
+            if tag_jec_level in list(cset.keys()):
+                sf = cset[tag_jec_level]
+            elif tag_jec_level in list(cset.compound.keys()):
+                sf = cset.compound[tag_jec_level]
+            else:
+                print("CONFIG ERROR: No JEC correction for level!")
+                print("Tag=", tag_jec_level, "\n cset keys:", list(cset.keys()),
+                      "\n compound keys:", list(cset.compound.keys()))
+                raise Exception(
+                    f"[No JEC correction: {tag_jec_level} - Year: {year} - Era: {era} - Level: {level}]")
+
+            # by default, evaluate this level at the running propagation pt
+            jet_pt_eval = jet_pt_prop
+
+            # =================================================================
+            # === EVALUATION-PT SEAM — runs BEFORE level `level` is evaluated ==
+            # -----------------------------------------------------------------
+            # Adjust `jet_pt_eval` here to change ONLY the pt at which this level's
+            # correction is looked up. `jet_pt_prop` / `corr_total` are left untouched,
+            # so the correction still propagates on the real (unadjusted) pt.
+            # e.g. evaluate a level at a clipped 30 GeV in the 2.0 < |eta| < 2.5 region:
+            #   if level == "<level>":
+            #       jet_pt_eval = ak.where(
+            #           (np.abs(jets.eta) < 2.5) & (np.abs(jets.eta) > 2.0) & (jet_pt_prop < 30.0),
+            #           30., jet_pt_eval)
+            # =================================================================
+            if level == "L2L3Residual" and year == "2024" and not isMC:
+                # 2024: if pt_L3corr < 30. GeV, evaluate L2L3Residual at 30 GeV instead of the real pt.
+                # only in [2.0, 2.5] eta region, to avoid the large L2L3Residual correction at low pt
+                jet_pt_eval = ak.where((np.abs(jets.eta) < 2.5) & (np.abs(jets.eta) > 2.0) & (jet_pt_prop < 30.0), 30., jet_pt_prop)
+
+            # evaluate this level on the (possibly adjusted) evaluation pt
+            eval_dict["JetPt"] = jet_pt_eval
+            inputs = [eval_dict[input.name] for input in sf.inputs]
+            factor = sf.evaluate(*inputs)
+
+            # propagate the correction: the factor (computed from jet_pt_eval) is applied to
+            # the real running pt and accumulated. jet_pt_prop is updated with the factor,
+            # NOT with the adjusted jet_pt_eval, so an evaluation-pt tweak never leaks into
+            # the propagated pt.
+            corr_total = corr_total * factor
+            jet_pt_prop = jet_pt_prop * factor
+
+            # =================================================================
+            # === POST-LEVEL SEAM — extra propagating correction ==============
+            # To splice in an extra factor that behaves like another JEC layer
+            # (seen by later levels AND the final pt/mass), multiply both:
+            #   if level == "<level>":
+            #       extra = my_custom_factor(jets, eval_dict)   # flat awkward array
+            #       corr_total  = corr_total  * extra
+            #       jet_pt_prop = jet_pt_prop * extra
+            # =================================================================
+
+        # update the nominal pt and mass with the accumulated correction
+        jets["pt"] = corr_total * jets["pt_raw"]
+        jets["mass"] = corr_total * jets["mass_raw"]
+
+    # jer central and systematics
+    if apply_jer or jer_syst:
+        # learned from: https://github.com/cms-nanoAOD/correctionlib/issues/130
+
+        jer_ptres_tag = f"{jer_tag}_PtResolution_{jet_type}"
+        jer_sf_tag = f"{jer_tag}_ScaleFactor_{jet_type}"
+
+        jer_sfunc_tag = jer_sf_tag.replace("ScaleFactor", "SFUncertainty")
+        ceval_jer = get_jer_correction_set(json_path, (jer_ptres_tag, jer_sf_tag, jer_sfunc_tag))
+
+        # update evaluate dictionary
+        eval_dict.update(
+            {
+                "JetPt": jets.pt,
+                "GenPt": jets.pt_gen,
+                "EventID": jets.event_id,
+            }
+        )
+        # get jer pt resolution
+        inputs_jer_ptres = [
+            eval_dict[input.name] for input in ceval_jer[jer_ptres_tag].inputs
+        ]
+        jer_ptres = ceval_jer[jer_ptres_tag].evaluate(*inputs_jer_ptres)
+        # update evaluate dictionary
+        eval_dict.update({"JER": jer_ptres})
+        # adjust pt gen
+        eval_dict.update(
+            {
+                "GenPt": np.where(
+                    np.abs(eval_dict["JetPt"] - eval_dict["GenPt"])
+                    < 3 * eval_dict["JetPt"] * eval_dict["JER"],
+                    eval_dict["GenPt"],
+                    -1.0,
+                ),
+            }
+        )
+        if apply_jer:
+            if jer_syst:
+                jersmear, jersmear_up, jersmear_down = get_jersmear_SFunc(eval_dict, ceval_jer, jer_sf_tag, syst_tag=jer_sfunc_tag)
+                # jer nominal
+                jets["pt_jer"] = jets.pt * jersmear
+                jets["mass_jer"] = jets.mass * jersmear
+                # jer up
+                jets["pt_JER_up"] = jets.pt * jersmear_up
+                jets["mass_JER_up"] = jets.mass * jersmear_up
+                # jer down
+                jets["pt_JER_down"] = jets.pt * jersmear_down
+                jets["mass_JER_down"] = jets.mass * jersmear_down
+            else:
+                jersmear = get_jersmear_SFunc(eval_dict, ceval_jer, jer_sf_tag)
+                jets["pt_jer"] = jets.pt * jersmear
+                jets["mass_jer"] = jets.mass * jersmear
+
+            # to avoid the sf: jer*jer_up or jer*jer_down, update the jer pt/mass after calculation of the jer up/down
+            jets["pt"] = jets["pt_jer"]
+            jets["mass"] = jets["mass_jer"]
+
+    # jes systematics
+    if jes_syst:
+        # update evaluate dictionary
+        eval_dict.update({"JetPt": jets.pt})
+        # loop over all JES variations
+        jes_strings = [s[4:] for s in variations if s.startswith("JES")]
+        for jes_vari in jes_strings:
+            # If Regrouped variations are wanted, the Regrouped_ name must be used in the config
+            tag_jec_syst = "_".join([jec_tag, jes_vari, jet_type])
+            try:
+                sf = cset[tag_jec_syst]
+            except:
+                raise Exception(
+                    f"[ jerc_jet ] No JEC systematic: {tag_jec_syst} - Year: {year} - Era: {era}"
+                )
+            # systematics
+            inputs = [eval_dict[input.name] for input in sf.inputs]
+            sf_delta = sf.evaluate(*inputs)
+
+            # divide by correction since it is already applied before
+            corr_up_variation = 1 + sf_delta
+            corr_down_variation = 1 - sf_delta
+
+            jets[f"pt_JES_{jes_vari}_up"] = jets.pt * corr_up_variation
+            jets[f"pt_JES_{jes_vari}_down"] = jets.pt * corr_down_variation
+            jets[f"mass_JES_{jes_vari}_up"] = jets.mass * corr_up_variation
+            jets[f"mass_JES_{jes_vari}_down"] = jets.mass * corr_down_variation
+    jets_jagged = ak.unflatten(jets, counts)
+    return jets_jagged
 
 
 def msoftdrop_correction(

--- a/pocket_coffea/scripts/runner.py
+++ b/pocket_coffea/scripts/runner.py
@@ -159,7 +159,7 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
     for arg in ctx.args:
         if arg.startswith("--"):
             if "=" in arg:
-                key, value = arg.split("=")
+                key, value = arg.split("=", 1)
                 run_options[key[2:]] = value
             else:
                 next_arg = ctx.args[ctx.args.index(arg)+1] if ctx.args.index(arg)+1 < len(ctx.args) else None
@@ -167,6 +167,14 @@ def run(cfg,  custom_run_options, outputdir, test, limit_files,
                     run_options[arg[2:]] = next_arg
                 else:
                     run_options[arg[2:]] = True
+
+    # custom-setup-commands is consumed by the executors as a list of shell
+    # commands (env_worker += run_options["custom-setup-commands"]). When it is
+    # provided from the command line it arrives as a single string, which would
+    # be iterated character-by-character by list.__iadd__. Normalize a string to
+    # a one-element list so both the CLI and the YAML (list) forms behave.
+    if isinstance(run_options.get("custom-setup-commands"), str):
+        run_options["custom-setup-commands"] = [run_options["custom-setup-commands"]]
 
 
     ## Default config for testing: iterative executor, with 2 file and 2 chunks


### PR DESCRIPTION
This PR implements evaluation of JEC by correction level, instead of using the compounded tag. 

This allow custom fixed for specific eras/eta regions. 

For example: 
- 2 < eta < 2.5 pT correction for L2L3 residuals in data [slides](https://indico.cern.ch/event/1624984/contributions/6896120/attachments/3208048/5713070/20260127_JetMET_PerformanceRun3_HIGMeeting.pdf)

Under testing
