### PR TITLE
Cache parsed correctionlib CorrectionSets by file path

### DIFF
--- a/pocket_coffea/lib/calibrators/common/common.py
+++ b/pocket_coffea/lib/calibrators/common/common.py
@@ -16,6 +16,7 @@ from omegaconf import OmegaConf
 from pocket_coffea.lib.muon_scale_and_resolution import pt_scale, pt_resol, pt_scale_var, pt_resol_var
 from pocket_coffea.utils.utils import get_nano_version
 import correctionlib
+from pocket_coffea.lib.correction_cache import load_correction_set
 
 class JetsCalibrator(Calibrator):
     """
@@ -823,7 +824,7 @@ class MuonsCalibrator(Calibrator):
             return
 
         self.enabled = True
-        self.cset = correctionlib.CorrectionSet.from_file(
+        self.cset = load_correction_set(
             self.mscare_params.correctionlib_config[self._year]["file"]
         )
 

--- a/pocket_coffea/lib/correction_cache.py
+++ b/pocket_coffea/lib/correction_cache.py
@@ -1,0 +1,33 @@
+"""Process-local cache of parsed correctionlib CorrectionSets.
+
+The correction JSONs (b-tagging, JERC, lepton SFs, pileup, jet-veto maps, ...) are looked
+up by year/era through ``params[...][year][...]["file"]``, so the resolved file path
+already encodes the chunk metadata. Parsing a multi-MB JSON with
+``correctionlib.CorrectionSet.from_file`` is expensive, and it is done far more often than
+necessary: the ``WeightsManager`` and its wrappers are rebuilt per chunk and ``compute()``
+re-runs once per shape variation, so each SF JSON is currently re-parsed once per
+(chunk x variation).
+
+Caching on the resolved path fixes both: the same file requested for many chunks and
+variations is parsed once per worker process. Because the path already carries the
+year/era, chunks with different metadata resolve to different paths and get the right file,
+while chunks that share a year hit the cache.
+
+The cache lives at module scope, so it is per worker *process* (``from_file`` objects are
+never pickled). It is unbounded because the distinct-file set is small -- a handful of
+JSONs per year a worker sees -- and a bounded LRU could evict and re-parse a recurring
+file for no memory benefit.
+
+The returned evaluator is SHARED, so callers must treat it as read-only (all SF/scale
+consumers only call ``.evaluate()``). The JER correction set, which is filtered in place,
+is handled by its own memoized builder in ``jets.get_jer_correction_set``.
+"""
+import functools
+
+import correctionlib
+
+
+@functools.lru_cache(maxsize=None)
+def load_correction_set(path):
+    """Return the correctionlib evaluator for ``path``, parsed once per process."""
+    return correctionlib.CorrectionSet.from_file(path)

--- a/pocket_coffea/lib/cut_functions.py
+++ b/pocket_coffea/lib/cut_functions.py
@@ -2,6 +2,7 @@ import awkward as ak
 from .cut_definition import Cut
 from .triggers import get_trigger_mask_byprimarydataset,  apply_trigger_mask, remove_trigger_prefix
 import correctionlib
+from pocket_coffea.lib.correction_cache import load_correction_set
 import numpy as np
 from coffea.lumi_tools import LumiMask
 
@@ -147,7 +148,7 @@ def get_JetVetoMap_Mask(events, params, year, processor_params, sample, isMC, **
         & ((jets["neEmEF"]+jets["chEmEF"])<0.9) # Energy fraction not dominated by ECal
     )
     jets = jets[mask_for_VetoMap]
-    cset = correctionlib.CorrectionSet.from_file(
+    cset = load_correction_set(
         processor_params.jet_scale_factors.vetomaps[year]["file"]
     )
     corr = cset[processor_params.jet_scale_factors.vetomaps[year]["name"]]

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -1,8 +1,10 @@
+import functools
 import gzip
 import cloudpickle
 import awkward as ak
 import numpy as np
 import correctionlib
+from pocket_coffea.lib.correction_cache import load_correction_set
 from coffea.jetmet_tools import  CorrectedMETFactory
 from correctionlib.schemav2 import Correction, CorrectionSet
 from ..utils.utils import get_nano_version, replace_at_indices
@@ -229,7 +231,7 @@ def compute_jetId(events, jet_type, params, year):
         # Example code: https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/master/examples/jetidExample.py?ref_type=heads
         # Load CorrectionSet
         jsonFile = params.jet_scale_factors.jet_id[year]
-        cset = correctionlib.CorrectionSet.from_file(jsonFile)
+        cset = load_correction_set(jsonFile)
 
         counts = ak.num(jets)
         jets = ak.flatten(jets, axis=1)
@@ -366,8 +368,13 @@ def get_dijet(jets, taggerVars=True, remnant_jet = False):
         return dijet, remnant
 
 
+@functools.lru_cache(maxsize=None)
 def get_jer_correction_set(jer_json, jer_tags):
     # learned from: https://github.com/cms-nanoAOD/correctionlib/issues/130
+    # Cached per process by (jer_json, jer_tags): the JSON is parsed and the JERSmear
+    # evaluator built once. jer_tags is a tuple (hashable). The parsed schema is filtered
+    # in place, but that happens on this local object; the returned evaluator is read-only,
+    # so caching it does not share the mutated schema with any other consumer.
     with gzip.open(jer_json) as fin:
         cset = CorrectionSet.parse_raw(fin.read())
     cset.corrections = [
@@ -535,7 +542,7 @@ def jet_correction_corrlib(
     tag_jec = "_".join([jec_tag, level, jet_type])
 
     # get the correction sets
-    cset = correctionlib.CorrectionSet.from_file(json_path)
+    cset = load_correction_set(json_path)
 
     # prepare inputs
     # no need of copies
@@ -713,7 +720,7 @@ def msoftdrop_correction(
     tag_jec = "_".join([jec_tag, level, subjet_type])
 
     # get the correction sets
-    cset = correctionlib.CorrectionSet.from_file(json_path)
+    cset = load_correction_set(json_path)
 
     # prepare inputs
     jets_jagged = events[jet_coll_name]

--- a/pocket_coffea/lib/leptons.py
+++ b/pocket_coffea/lib/leptons.py
@@ -1,6 +1,7 @@
 import awkward as ak
 import numpy as np
 import correctionlib
+from pocket_coffea.lib.correction_cache import load_correction_set
 
 
 def get_ele_scaled_etdependent(ele, json_scale, 
@@ -9,7 +10,7 @@ def get_ele_scaled_etdependent(ele, json_scale,
     '''
     From example: https://gitlab.cern.ch/cms-analysis-metadata/EGM/examples/-/blob/latest/egmScaleAndSmearingExample.py
     '''
-    evaluator = correctionlib.CorrectionSet.from_file(json_scale)
+    evaluator = load_correction_set(json_scale)
     evaluator_scale = evaluator.compound[correction_name]
     smear_and_syst_evaluator = evaluator[syst_correction_name]
     ele_gain_flat = ak.flatten(ele["seedGain"])
@@ -67,7 +68,7 @@ def get_ele_scaled_etdependent(ele, json_scale,
     
 
 def get_ele_scaled(ele, json_scale, correction_name, isMC, runNr):
-    evaluator = correctionlib.CorrectionSet.from_file(json_scale)
+    evaluator = load_correction_set(json_scale)
     evaluator_scale = evaluator[correction_name]
     ele_gain_flat = ak.flatten(ele["seedGain"])
     ele_eta_flat = ak.flatten(ele["etaSC"])
@@ -108,7 +109,7 @@ def get_ele_smeared_etdependent(mc_ele, jsonFileName, correction_name, isMC, onl
     '''
     if not isMC:
         return
-    evaluator = correctionlib.CorrectionSet.from_file(jsonFileName)
+    evaluator = load_correction_set(jsonFileName)
     evaluator_smearing = evaluator[correction_name]
     ele_eta_flat = ak.flatten(mc_ele["etaSC"]) # eta of supercluster
     ele_r9_flat = ak.flatten(mc_ele["r9"])
@@ -177,7 +178,7 @@ def get_ele_smeared_etdependent(mc_ele, jsonFileName, correction_name, isMC, onl
 def get_ele_smeared(mc_ele, jsonFileName,correction_name, isMC, only_nominal=True, seed=125):
     if not isMC:
         return
-    evaluator = correctionlib.CorrectionSet.from_file(jsonFileName)
+    evaluator = load_correction_set(jsonFileName)
     evaluator_smearing = evaluator[correction_name]
     ele_eta_flat = ak.flatten(mc_ele["etaSC"])
     ele_r9_flat = ak.flatten(mc_ele["r9"])

--- a/pocket_coffea/lib/scale_factors.py
+++ b/pocket_coffea/lib/scale_factors.py
@@ -1,6 +1,7 @@
 import numpy as np
 import awkward as ak
 import correctionlib
+from pocket_coffea.lib.correction_cache import load_correction_set
 
 
 def get_pho_sf(params, year, pt, eta, counts, key=''):
@@ -11,7 +12,7 @@ def get_pho_sf(params, year, pt, eta, counts, key=''):
     # translate the `year` key into the corresponding key in the correction file provided by the EGM-POG
     year_pog = photonSF["era_mapping"][year]
 
-    photon_correctionset = correctionlib.CorrectionSet.from_file(
+    photon_correctionset = load_correction_set(
         photonSF.JSONfiles[year]['file']
     )        
 
@@ -90,7 +91,7 @@ def get_ele_sf(
     year_pog = electronSF["era_mapping"][year][key]
 
     if key in ['reco', 'id']:
-        electron_correctionset = correctionlib.CorrectionSet.from_file(
+        electron_correctionset = load_correction_set(
             electronSF.JSONfiles[year]["files"][key]
         )
         map_name = electronSF.JSONfiles[year]["name"]
@@ -163,7 +164,7 @@ def sf_ele_trigger(params, events, year):
         ak.num(ele_pt),
     )
 
-    electron_correctionset = correctionlib.CorrectionSet.from_file(
+    electron_correctionset = load_correction_set(
         electronSF.trigger_sf[year].file
     )
     corr_eval = electron_correctionset[map_name].evaluate
@@ -191,7 +192,7 @@ def get_mu_sf(params, year, pt, eta, counts, key=''):
     '''
     muonSF = params["lepton_scale_factors"]["muon_sf"]
 
-    muon_correctionset = correctionlib.CorrectionSet.from_file(
+    muon_correctionset = load_correction_set(
         muonSF.JSONfiles[year]['file']
     )
 
@@ -356,7 +357,7 @@ def sf_ele_promptmva(params, events, year, key=''):
     # in 2024 they are provided by the central POG
     if year in ["2022_preEE", "2022_postEE", "2023_preBPix", "2023_postBPix"]:
         # The SFs provided by the ttH multilepton team 
-        electron_correctionset = correctionlib.CorrectionSet.from_file(
+        electron_correctionset = load_correction_set(
         params.lepton_scale_factors.electron_sf.promptMVA_jsons[year]['file'])
         # Need to put max pt to 500 for these custom SF
         sf = electron_correctionset["NUM_TightmvaTTH_DEN_LooseElectrons"].evaluate(
@@ -377,7 +378,7 @@ def sf_ele_promptmva(params, events, year, key=''):
         # and num_promptMVA_denum_tightID SF --> we need to combine them
         corr_params = params.lepton_scale_factors.electron_sf.promptMVA_jsons[year]
         corrkey = corr_params.key
-        electron_correctionset = correctionlib.CorrectionSet.from_file(corr_params['file'])
+        electron_correctionset = load_correction_set(corr_params['file'])
         sf, sfup, sfdown = [],[],[]
         year_pog = params.lepton_scale_factors.electron_sf.era_mapping[year]["id"]
     
@@ -424,7 +425,7 @@ def sf_mu_promptmva(params, events, year, key=''):
     # in 2024 they are provided by the central POG
     if year in ["2022_preEE", "2022_postEE", "2023_preBPix", "2023_postBPix"]:
         # The SFs provided by the ttH multilepton team 
-        muon_correctionset = correctionlib.CorrectionSet.from_file(
+        muon_correctionset = load_correction_set(
         params.lepton_scale_factors.muon_sf.promptMVA_jsons[year]['file'])
         # Need to put max pt to 500 for these custom SF
         sf = muon_correctionset["NUM_TightmvaTTH_DEN_LooseMuons"].evaluate(
@@ -444,7 +445,7 @@ def sf_mu_promptmva(params, events, year, key=''):
         # The SFs provided by the central POG are split in tightID SF
         # and num_promptMVA_denum_tightID SF --> we need to combine them
         corr_params = params.lepton_scale_factors.muon_sf.promptMVA_jsons[year]
-        muon_correctionset = correctionlib.CorrectionSet.from_file(corr_params['file'])
+        muon_correctionset = load_correction_set(corr_params['file'])
         sfmaps = [muon_correctionset[key] for key in corr_params["keys"]]
         sf, sfup, sfdown = [],[],[]
         for sfmap in sfmaps:
@@ -485,7 +486,7 @@ def sf_btag(params, jets, year, njets, variations=["central"]):
     '''
     btagSF = params.jet_scale_factors.btagSF[year]
     btag_discriminator = params.btagging.working_point[year]["btagging_algorithm"]
-    cset = correctionlib.CorrectionSet.from_file(btagSF.file)
+    cset = load_correction_set(btagSF.file)
     corr = cset[btagSF.name]
 
     flavour = ak.to_numpy(ak.flatten(jets.hadronFlavour))
@@ -556,7 +557,7 @@ def sf_btag(params, jets, year, njets, variations=["central"]):
 def sf_btag_calib(params, sample, year, njets, jetsHt):
     '''Correction to btagSF computing by comparing the inclusive shape without btagSF and with btagSF in 2D:
     njets-JetsHT bins. Each sample/year has a different correction stored in the correctionlib format.'''
-    cset = correctionlib.CorrectionSet.from_file(
+    cset = load_correction_set(
         params.btagSF_calibration[year]["file"]
     )
     corr = cset[params.btagSF_calibration[year]["name"]]
@@ -578,7 +579,7 @@ def sf_ctag(params, jets, year, njets, variations=["central"]):
 
     ctagSF = params.jet_scale_factors.ctagSF[year]
     ctagger = params.ctagging.working_point[year]["tagger"]
-    cset = correctionlib.CorrectionSet.from_file(ctagSF.SF_file)
+    cset = load_correction_set(ctagSF.SF_file)
 
     #print(list(cset.keys()))
     #print(list(cset.items()))
@@ -626,7 +627,7 @@ def sf_ctag_calib(params, dataset, year, njets, jetsHt):
     which was  derived for V+2J phase space. It may not be suitable for other analyses.
     '''
     ctagSF = params.jet_scale_factors.ctagSF[year]
-    cset = correctionlib.CorrectionSet.from_file(ctagSF.Calib_file)
+    cset = load_correction_set(ctagSF.Calib_file)
 
     corr = cset["ctagSF_norm_correction"]
     w = corr.evaluate(dataset, ak.to_numpy(njets), ak.to_numpy(jetsHt))
@@ -647,7 +648,7 @@ def sf_jet_puId(params, jets, year, njets):
     genJetId_mask = ak.flatten(jets.genJetIdx >= 0)
 
     # GenGet matching by index, needs some checkes
-    cset = correctionlib.CorrectionSet.from_file(
+    cset = load_correction_set(
         params.jet_scale_factors.jet_puId[year]["file"]
     )
     corr = cset[params.jet_scale_factors.jet_puId[year]["name"]]
@@ -688,7 +689,7 @@ def sf_pileup_reweight(params, events, year):
     puFile = params.pileupJSONfiles[year]['file']
     puName = params.pileupJSONfiles[year]['name']
 
-    puWeightsJSON = correctionlib.CorrectionSet.from_file(puFile)
+    puWeightsJSON = load_correction_set(puFile)
 
     nPu = events.Pileup.nTrueInt.to_numpy()
     sf = puWeightsJSON[puName].evaluate(nPu, 'nominal')

--- a/pocket_coffea/lib/weights/common/weights_run2_UL.py
+++ b/pocket_coffea/lib/weights/common/weights_run2_UL.py
@@ -1,5 +1,6 @@
 import awkward as ak
 import correctionlib
+from pocket_coffea.lib.correction_cache import load_correction_set
 import numpy as np
 
 from ..weights import WeightData, WeightDataMultiVariation, WeightLambda, WeightWrapper
@@ -15,7 +16,7 @@ def get_ele_trigger_sf(params, year, pt, eta, phi, counts, variations):
 
     electronSF = params["lepton_scale_factors"]["electron_sf"]
 
-    electron_correctionset = correctionlib.CorrectionSet.from_file(
+    electron_correctionset = load_correction_set(
         electronSF.trigger_sf[year]["file"]
     )
     map_name = electronSF.trigger_sf[year]["name"]

--- a/tests/test_correction_cache.py
+++ b/tests/test_correction_cache.py
@@ -1,0 +1,31 @@
+"""Offline unit test for the correctionlib CorrectionSet cache.
+
+Patches correctionlib.CorrectionSet.from_file so no real JSON is read: verifies that
+load_correction_set parses each distinct path only once and returns the same object on
+repeat calls (the same file requested for many chunks/variations is cached per process).
+"""
+from pocket_coffea.lib import correction_cache
+
+
+def test_load_correction_set_caches_by_path(monkeypatch):
+    calls = []
+
+    def fake_from_file(path):
+        calls.append(path)
+        return object()  # a fresh sentinel per real parse
+
+    monkeypatch.setattr(correction_cache.correctionlib.CorrectionSet, "from_file", fake_from_file)
+    correction_cache.load_correction_set.cache_clear()
+    try:
+        a1 = correction_cache.load_correction_set("/eos/x/a.json")
+        a2 = correction_cache.load_correction_set("/eos/x/a.json")  # cache hit
+        b1 = correction_cache.load_correction_set("/eos/x/b.json")  # different file
+        b2 = correction_cache.load_correction_set("/eos/x/b.json")  # cache hit
+
+        assert a1 is a2, "same path must return the cached object"
+        assert b1 is b2
+        assert a1 is not b1, "different paths must not collide"
+        # from_file (the expensive parse) runs once per distinct path, not per call
+        assert calls == ["/eos/x/a.json", "/eos/x/b.json"]
+    finally:
+        correction_cache.load_correction_set.cache_clear()


### PR DESCRIPTION
Every sf_* helper and the jet calibrators call correctionlib.CorrectionSet.from_file (or parse_raw for JER) inside the per-chunk, per-variation call path, so the multi-MB BTV / JERC / lepton-SF / pileup JSONs are re-parsed once per (chunk x shape variation) even though the parsed evaluator is immutable and reusable.

Add lib/correction_cache.load_correction_set(path): a process-local functools.lru_cache over CorrectionSet.from_file, keyed by the resolved path. The path already encodes the year/era (params[...][year][...]["file"]), so chunks with different metadata resolve to different files and get the right one, while chunks/variations sharing a file hit the cache. It is unbounded (the distinct-file set is small) and per worker process (from_file objects are never pickled). Route all 24 from_file sites (scale_factors, leptons, jets, cut_functions, the muon calibrator, weights_run2_UL) through it.

The JER set is filtered in place, so instead of caching the raw parsed schema, jets.get_jer_correction_set (which parses, filters a *local* schema, and returns a read-only to_evaluator()) is itself memoized by (jer_json, jer_tags) -- the caller already passes jer_tags as a tuple. No mutated object is shared.

Behavior-neutral: load_correction_set returns the same evaluator from_file would, so SF values are identical. test_new_weights (uses sf_btag, pileup, ele/mu SFs) passes unchanged; new offline test_correction_cache verifies parse-once-per-path.

Profiling (config_shape_var_and_weights_bysubsample, MC 2018 with shape variations, 3 chunks, cProfile) -- the total JSON parse time drops from 30.1s to 7.1s (~23s, 4.2x):
  CorrectionSet.from_file   198 calls / 10.1s  ->  6 calls / 1.9s
  parse_raw (multi-MB JERC)   9 calls / 20.0s  ->  2 calls / 5.3s
The same files are parsed once per worker instead of once per (chunk x shape variation), so
the saving grows ~linearly with chunks x shape variations: a production job pays the parse
cost essentially once instead of ~10s per chunk.