### PR TITLE
Vectorize muon-smearing RNG and fix per-muon seed correlation

### DIFF
--- a/pocket_coffea/lib/muon_scale_and_resolution.py
+++ b/pocket_coffea/lib/muon_scale_and_resolution.py
@@ -5,36 +5,33 @@ import math
 from scipy.special import erfinv, erf
 from random import random
 import awkward as ak
-from typing import List
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 
-class SeedSequence:
-    def __init__(self, seeds: List[int]):
-        self.seeds = [s & 0xFFFFFFFF for s in seeds]
+def _splitmix64(z):
+    """Vectorized splitmix64 finalizer: a strong avalanche mix of a uint64 array."""
+    z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
+    z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
+    return z ^ (z >> np.uint64(31))
 
-    def generate(self, n: int) -> List[int]:
-        if n<=0:
-            return []
 
-        mult = 0x9e3779b9
-        mix_const = 0x85ebca6b
-
-        buffer = [0x8b8b8b8b] * n
-        s = len(self.seeds)
-
-        for i in range(min(n, s)):
-            buffer[i] ^= (self.seeds[i] + mult * i) & 0xFFFFFFFF
-
-        for i in range(s, n):
-            buffer[i] ^= (mult * i) & 0xFFFFFFFF
-
-        for k in range(n):
-            z = (buffer[(k + n - 1) % n] ^ (buffer[k] >> 27)) & 0xFFFFFFFF
-            buffer[k] = ((z * mix_const) & 0xFFFFFFFF) ^ ((buffer[k] << 13) & 0xFFFFFFFF)
-
-        return [x & 0xFFFFFFFF for x in buffer]
+def _hashed_uniform(evtNr, lumiNr, phi_int):
+    """Reproducible uniform in [0,1) per muon, derived from (event, lumi, phi) with a fully
+    vectorized 64-bit hash. This replaces the per-muon SeedSequence + MT19937 construction
+    and mixes ALL three entropy words, so muons in the same event get independent draws
+    (the previous scalar SeedSequence.generate(1) mixed only the event word, giving every
+    muon in an event the same draw)."""
+    ev = np.asarray(evtNr).astype(np.uint64)
+    lumi = np.asarray(lumiNr).astype(np.uint64)
+    phi = np.asarray(phi_int).astype(np.uint64)
+    with np.errstate(over="ignore"):  # uint64 multiply/add wrap on purpose
+        key = _splitmix64(ev * np.uint64(0x9E3779B97F4A7C15)
+                          + lumi * np.uint64(0xC2B2AE3D27D4EB4F)
+                          + phi * np.uint64(0x165667B19E3779F9))
+        key = _splitmix64(key)
+    # top 53 bits -> double in [0, 1)
+    return (key >> np.uint64(11)) * (1.0 / (1 << 53))
 
 class CrystallBall:
 
@@ -138,20 +135,6 @@ class CrystallBall:
         return result
 
 
-def _get_rnd_func(rnd_gen):
-    if isinstance(rnd_gen, str):
-        rnd_gen = rnd_gen.lower()
-        if rnd_gen == "np":
-            rnd_func = lambda seed: np.random.Generator(np.random.MT19937(seed=seed)).random()
-        else:
-            raise ValueError(f"unknown rnd_gen string '{rnd_gen}', should either be 'root' or 'np'")
-    elif callable(rnd_gen):
-        rnd_func = rnd_gen
-    else:
-        raise TypeError(f"unsupported rnd_gen '{rnd_gen}', should be string or callable")
-    return rnd_func
-
-
 def get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested=False, rnd_gen="root"):
     # obtain parameters from correctionlib
     if nested:
@@ -168,14 +151,12 @@ def get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested=False, rnd_gen="root"):
 
     phi_int_f = (((np.asarray(phi_f, dtype=np.float64) / math.pi) * (1 << 31 - 1) ).astype(np.int64) & 0xFFF).astype(np.uint32)
 
-    seeds = [
-        SeedSequence([np.uint32(ev), np.uint32(lumi), np.uint32(phi_int)]).generate(1)[0]
-        for ev, lumi, phi_int in zip(evtNr_f, lumiNr_f, phi_int_f)
-    ]
-
-    # get random number following the CB
-    rnd_func = _get_rnd_func(rnd_gen)
-    rndm_f = [rnd_func(seed) for seed in seeds]
+    # Vectorized, reproducible per-muon uniform following the CB. Replaces the per-muon
+    # SeedSequence + MT19937 construction loops (rnd_gen is kept for backward compatibility
+    # but no longer selects the generator). NB: the drawn values differ from the old
+    # MT19937 path -- muon-smearing outputs are a different, equally valid noise realization
+    # -- and, unlike before, muons in the same event are smeared independently.
+    rndm_f = _hashed_uniform(evtNr_f, lumiNr_f, phi_int_f)
 
     cb_f = CrystallBall(mean_f, sigma_f, alpha_f, n_f)
 

--- a/tests/test_muon_rng.py
+++ b/tests/test_muon_rng.py
@@ -1,0 +1,70 @@
+"""Offline unit tests for the vectorized muon-smearing RNG.
+
+These guard the bug fix in ``muon_scale_and_resolution.get_rndm``: the per-muon
+uniform used for the Crystal-Ball smearing is now derived from a fully vectorized
+64-bit hash of (event, lumi, phi) instead of a per-muon ``SeedSequence`` +
+``MT19937`` construction. The old scalar ``SeedSequence.generate(1)`` mixed only
+the first entropy word (the event number), so every muon in the same event drew
+the *same* uniform -- the tests below assert the draws are now independent.
+
+No EOS / grid proxy needed.
+"""
+import numpy as np
+from pocket_coffea.lib.muon_scale_and_resolution import _hashed_uniform, _splitmix64
+
+
+def test_hashed_uniform_range_and_dtype():
+    n = 5000
+    ev = np.arange(n, dtype=np.uint64)
+    lumi = (np.arange(n) % 1000).astype(np.uint64)
+    phi = (np.arange(n) % 4096).astype(np.uint64)
+    u = _hashed_uniform(ev, lumi, phi)
+    assert u.dtype == np.float64
+    assert np.all(u >= 0.0) and np.all(u < 1.0)
+
+
+def test_hashed_uniform_reproducible():
+    # Identical (event, lumi, phi) must give identical draws (determinism across
+    # chunks / re-processing -- the smearing must be reproducible).
+    ev = np.array([12345, 12345], dtype=np.uint64)
+    lumi = np.array([7, 7], dtype=np.uint64)
+    phi = np.array([100, 100], dtype=np.uint64)
+    u = _hashed_uniform(ev, lumi, phi)
+    assert u[0] == u[1]
+
+
+def test_hashed_uniform_independent_per_muon():
+    # THE BUG FIX. Two muons in the same event (same event & lumi) but different
+    # phi must get DIFFERENT draws. Previously they were identical.
+    u_phi = _hashed_uniform(
+        np.array([999, 999], dtype=np.uint64),
+        np.array([5, 5], dtype=np.uint64),
+        np.array([10, 3000], dtype=np.uint64),
+    )
+    assert u_phi[0] != u_phi[1]
+
+    # Different lumi (same event & phi) must also decorrelate.
+    u_lumi = _hashed_uniform(
+        np.array([999, 999], dtype=np.uint64),
+        np.array([5, 6], dtype=np.uint64),
+        np.array([10, 10], dtype=np.uint64),
+    )
+    assert u_lumi[0] != u_lumi[1]
+
+
+def test_hashed_uniform_uniformity():
+    n = 200000
+    ev = np.arange(n, dtype=np.uint64)
+    lumi = (np.arange(n) % 1000).astype(np.uint64)
+    phi = (np.arange(n) * 7 % 4096).astype(np.uint64)
+    u = _hashed_uniform(ev, lumi, phi)
+    assert abs(float(u.mean()) - 0.5) < 0.01
+    assert abs(float(u.std()) - 1.0 / np.sqrt(12.0)) < 0.01
+
+
+def test_splitmix64_avalanche():
+    # A one-bit input change should flip roughly half the output bits.
+    a = _splitmix64(np.array([0x0123456789ABCDEF], dtype=np.uint64))[0]
+    b = _splitmix64(np.array([0x0123456789ABCDEE], dtype=np.uint64))[0]
+    flipped = bin(int(a) ^ int(b)).count("1")
+    assert 16 < flipped < 48  # ~32 of 64 bits differ


### PR DESCRIPTION
get_rndm previously built one numpy MT19937 generator per muon inside two Python list comprehensions, seeded by a scalar custom SeedSequence. This was both a per-event hot spot and, more importantly, it had a small issue: SeedSequence.generate(1) used only the event number,  so every muon in the same event drew the *same* uniform for the Crystal-Ball inverse-CDF smearing.

Replace the loops with a fully vectorized 64-bit hash (_hashed_uniform, built on a vectorized splitmix64 finalizer) that mixes all three words -- event, lumi and phi_int -- so each muon gets an independent, reproducible uniform in [0,1). The dead SeedSequence class and _get_rnd_func helper are removed; the rnd_gen argument is kept for backward compatibility but no longer selects a generator.

Muons in the same event are now smeared independently.  Added offline unit tests (tests/test_muon_rng.py) asserting range, reproducibility, per-muon independence (the bug fix), uniformity and splitmix64 avalanche.