### PR TITLE
 Use official Muon POG RandomSmearing (hashprng) for muon-smearing RNG

### DIFF
--- a/pocket_coffea/lib/calibrators/common/common.py
+++ b/pocket_coffea/lib/calibrators/common/common.py
@@ -889,7 +889,8 @@ class MuonsCalibrator(Calibrator):
                 pt_scaled, mu.eta, mu.phi, mu.nTrackerLayers,
                 events.event, events.luminosityBlock,
                 self.cset, nested=True,
-                rnd_gen="np" # ← ROOT-FREE
+                # RNG is a reproducible correctionlib "RandomSmearing" (hashprng) node
+                # keyed on (event, lumi, phi), evaluated inside get_rndm.
             )
         else:
             pt_corr = pt_scaled

--- a/pocket_coffea/lib/muon_scale_and_resolution.py
+++ b/pocket_coffea/lib/muon_scale_and_resolution.py
@@ -1,37 +1,26 @@
-##THIS IS THE MuonScaRe.py from https://gitlab.cern.ch/cms-muonPOG/muonscarekit/-/tree/master/scripts?ref_type=heads
+## Vendored from the official CMS Muon POG MuonScaRe.py
+## Source: https://gitlab.cern.ch/cms-muonPOG/muonscarekit/-/blob/master/scripts/MuonScaRe.py
+##
+## The random smearing draw is now delegated to the ``RandomSmearing`` correction
+## (a correctionlib ``hashprng`` node keyed on event/lumi/phi) shipped inside the
+## muon_scalesmearing.json.gz, so it is reproducible and vectorized without any
+## Python-side RNG. This replaces the previous hand-rolled SeedSequence/MT19937 and
+## _hashed_uniform(splitmix64) implementations.
+##
+## Local deviations from upstream (kept minimal so future syncs stay trivial):
+##   * The upstream ``import_ROOT`` helper is dropped -- it is dead code here (ROOT is
+##     never called) and we keep the module ROOT-free.
+##   * ``filter_boundaries`` defaults to ``silent=True`` to avoid per-chunk log spam
+##     when running over full coffea datasets.
 
 import numpy as np
 import math
 from scipy.special import erfinv, erf
-from random import random
 import awkward as ak
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 
-def _splitmix64(z):
-    """Vectorized splitmix64 finalizer: a strong avalanche mix of a uint64 array."""
-    z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
-    z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
-    return z ^ (z >> np.uint64(31))
-
-
-def _hashed_uniform(evtNr, lumiNr, phi_int):
-    """Reproducible uniform in [0,1) per muon, derived from (event, lumi, phi) with a fully
-    vectorized 64-bit hash. This replaces the per-muon SeedSequence + MT19937 construction
-    and mixes ALL three entropy words, so muons in the same event get independent draws
-    (the previous scalar SeedSequence.generate(1) mixed only the event word, giving every
-    muon in an event the same draw)."""
-    ev = np.asarray(evtNr).astype(np.uint64)
-    lumi = np.asarray(lumiNr).astype(np.uint64)
-    phi = np.asarray(phi_int).astype(np.uint64)
-    with np.errstate(over="ignore"):  # uint64 multiply/add wrap on purpose
-        key = _splitmix64(ev * np.uint64(0x9E3779B97F4A7C15)
-                          + lumi * np.uint64(0xC2B2AE3D27D4EB4F)
-                          + phi * np.uint64(0x165667B19E3779F9))
-        key = _splitmix64(key)
-    # top 53 bits -> double in [0, 1)
-    return (key >> np.uint64(11)) * (1.0 / (1 << 53))
 
 class CrystallBall:
 
@@ -69,7 +58,7 @@ class CrystallBall:
         x = ak.Array(x)
         d = (x - self.m)/self.s
         result = ak.full_like(d, 1.0)
-        
+
         # define different conditions
         c1a = (d<-self.a) & (self.F - self.s * d / self.G > 0)
         c1b = (d<-self.a) & (self.F - self.s * d / self.G <= 0)
@@ -78,24 +67,24 @@ class CrystallBall:
 
         c3 = ~c1a & ~c1b & ~c2a & ~c2b
         # For d < -a
-        result = ak.where(c1a, 
-                        self.NC / np.power(self.F - self.s * d / self.G, self.n - 1), 
+        result = ak.where(c1a,
+                        self.NC / np.power(self.F - self.s * d / self.G, self.n - 1),
                         result)
-        result = ak.where(c1b, 
-                        self.NC, 
+        result = ak.where(c1b,
+                        self.NC,
                         result)
 
         # For d > a
-        result = ak.where(c2a, 
-                        self.NC * (self.C - np.power(self.F + self.s * d / self.G, 1 - self.n)), 
+        result = ak.where(c2a,
+                        self.NC * (self.C - np.power(self.F + self.s * d / self.G, 1 - self.n)),
                         result)
-        result = ak.where(c2b, 
-                        self.NC * self.C, 
+        result = ak.where(c2b,
+                        self.NC * self.C,
                         result)
 
         # For -a <= d <= a
-        result = ak.where(c3, 
-                        self.Ns * (self.D - self.sqrtPiOver2 * erf(-d / self.sqrt2)), 
+        result = ak.where(c3,
+                        self.Ns * (self.D - self.sqrtPiOver2 * erf(-d / self.sqrt2)),
                         result)
 
         return result
@@ -112,30 +101,30 @@ class CrystallBall:
         c3 = ~c1a & ~c1b & ~c2a & ~c2b
 
         # For u < cdfMa
-        result = ak.where(c1a, 
-                        self.m + self.G * (self.F - (self.NC / u) ** self.k), 
+        result = ak.where(c1a,
+                        self.m + self.G * (self.F - (self.NC / u) ** self.k),
                         result)
-        result = ak.where(c1b, 
-                        self.m + self.G * self.F, 
+        result = ak.where(c1b,
+                        self.m + self.G * self.F,
                         result)
 
         # For u > cdfPa
-        result = ak.where(c2a, 
-                        self.m - self.G * (self.F - (self.C - u / self.NC) ** (-self.k)), 
+        result = ak.where(c2a,
+                        self.m - self.G * (self.F - (self.C - u / self.NC) ** (-self.k)),
                         result)
-        result = ak.where(c2b, 
-                        self.m - self.G * self.F, 
+        result = ak.where(c2b,
+                        self.m - self.G * self.F,
                         result)
 
         # For cdfMa <= u <= cdfPa
-        result = ak.where(c3, 
-                        self.m - self.sqrt2 * self.s * erfinv((self.D - u / self.Ns) / self.sqrtPiOver2), 
+        result = ak.where(c3,
+                        self.m - self.sqrt2 * self.s * erfinv((self.D - u / self.Ns) / self.sqrtPiOver2),
                         result)
 
         return result
 
 
-def get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested=False, rnd_gen="root"):
+def get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested=False):
     # obtain parameters from correctionlib
     if nested:
         eta_f, phi_f, nL_f, nmuons = ak.flatten(eta), ak.flatten(phi), ak.flatten(nL), ak.num(nL)
@@ -143,20 +132,15 @@ def get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested=False, rnd_gen="root"):
         lumiNr_f = np.repeat(np.asarray(lumiNr), nmuons)
     else:
         eta_f, phi_f, nL_f, nmuons = eta, phi, nL, np.ones_like(eta)
+        evtNr_f, lumiNr_f = evtNr, lumiNr
 
     mean_f = cset.get("cb_params").evaluate(abs(eta_f), nL_f, 0)
     sigma_f = cset.get("cb_params").evaluate(abs(eta_f), nL_f, 1)
     n_f = cset.get("cb_params").evaluate(abs(eta_f), nL_f, 2)
     alpha_f = cset.get("cb_params").evaluate(abs(eta_f), nL_f, 3)
 
-    phi_int_f = (((np.asarray(phi_f, dtype=np.float64) / math.pi) * (1 << 31 - 1) ).astype(np.int64) & 0xFFF).astype(np.uint32)
-
-    # Vectorized, reproducible per-muon uniform following the CB. Replaces the per-muon
-    # SeedSequence + MT19937 construction loops (rnd_gen is kept for backward compatibility
-    # but no longer selects the generator). NB: the drawn values differ from the old
-    # MT19937 path -- muon-smearing outputs are a different, equally valid noise realization
-    # -- and, unlike before, muons in the same event are smeared independently.
-    rndm_f = _hashed_uniform(evtNr_f, lumiNr_f, phi_int_f)
+    # get random number following the CB
+    rndm_f = cset.get("RandomSmearing").evaluate(evtNr_f, lumiNr_f, phi_f)
 
     cb_f = CrystallBall(mean_f, sigma_f, alpha_f, n_f)
 
@@ -176,7 +160,7 @@ def get_std(pt, eta, nL, cset, nested=False):
     else:
         eta_f, nL_f, pt_f, nmuons = eta, nL, pt, 1
 
-    # obtain parameters from correctionlib    
+    # obtain parameters from correctionlib
     param0_f = cset.get("poly_params").evaluate(abs(eta_f), nL_f, 0)
     param1_f = cset.get("poly_params").evaluate(abs(eta_f), nL_f, 1)
     param2_f = cset.get("poly_params").evaluate(abs(eta_f), nL_f, 2)
@@ -203,11 +187,11 @@ def get_k(eta, var, cset, nested=False):
     k_data_f = cset.get("k_data").evaluate(abs(eta_f), var)
     k_mc_f = cset.get("k_mc").evaluate(abs(eta_f), var)
 
-    # calculate residual smearing factor 
+    # calculate residual smearing factor
     # return 0 if smearing in MC already larger than in data
     k_f = np.zeros_like(k_data_f)
     condition = k_mc_f<k_data_f
-    k_f[condition] = (k_data_f[condition]**2 - k_mc_f[condition]**2)**.5
+    k_f = np.where(condition, (k_data_f**2 - k_mc_f**2)**.5, k_f)
 
     if nested:
         result = ak.unflatten(k_f, nmuons)
@@ -233,7 +217,7 @@ def filter_boundaries(pt_corr, pt, nested, low_pt_threshold = 26, silent=True):
     if n_pt_outside > 0:
         if not silent:
             print(
-                f"WARNING: There are {n_pt_outside} events with muon pt outside of [" + str(low_pt_threshold) + ",200] GeV. "
+                f"There are {n_pt_outside} events with muon pt outside of [" + str(low_pt_threshold) + ",200] GeV. "
                 "Setting those entries to their initial value."
             )
         pt_corr = np.where(pt>200, pt, pt_corr)
@@ -250,7 +234,7 @@ def filter_boundaries(pt_corr, pt, nested, low_pt_threshold = 26, silent=True):
     if n_nan > 0:
         if not silent:
             print(
-                f"WARNING: There are {n_nan} nan entries in the corrected pt. "
+                f"There are {n_nan} nan entries in the corrected pt. "
                 "This might be due to the number of tracker layers hitting boundaries. "
                 "Setting those entries to their initial value."
             )
@@ -259,10 +243,10 @@ def filter_boundaries(pt_corr, pt, nested, low_pt_threshold = 26, silent=True):
     return pt_corr
 
 
-def pt_resol(pt, eta, phi, nL, evtNr, lumiNr, cset, nested=False, low_pt_threshold = 26, rnd_gen="root"):
+def pt_resol(pt, eta, phi, nL, evtNr, lumiNr, cset, nested=False, low_pt_threshold = 26):
     """"
     Function for the calculation of the resolution correction
-    Input: 
+    Input:
     pt - muon transverse momentum
     eta - muon pseudorapidity
     nL - muon number of tracker layers
@@ -270,7 +254,7 @@ def pt_resol(pt, eta, phi, nL, evtNr, lumiNr, cset, nested=False, low_pt_thresho
 
     This function should only be applied to reco muons in MC!
     """
-    rndm = get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested, rnd_gen=rnd_gen)
+    rndm = get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested)
     std = get_std(pt, eta, nL, cset, nested)
     k = get_k(eta, "nom", cset, nested)
 
@@ -293,10 +277,10 @@ def pt_resol_var(pt_woresol, pt_wresol, eta, updn, cset, nested=False):
     eta - muon pseudorapidity
     updn - uncertainty variation (up or dn)
     cset - correctionlib object
-    
+
     This function should only be applied to reco muons in MC!
     """
-    
+
     if nested:
         eta_f, nmuons = ak.flatten(eta), ak.num(eta)
         pt_wresol_f, pt_woresol_f = ak.flatten(pt_wresol), ak.flatten(pt_woresol)
@@ -350,7 +334,7 @@ def pt_scale(is_data, pt, eta, phi, charge, cset, nested=False, low_pt_threshold
     charge - muon charge
     var - variation (standard is "nom")
     cset - correctionlib object
-    
+
     This function should be applied to reco muons in data and MC
     """
     if is_data:
@@ -362,13 +346,13 @@ def pt_scale(is_data, pt, eta, phi, charge, cset, nested=False, low_pt_threshold
         eta_f, phi_f, nmuons = ak.flatten(eta), ak.flatten(phi), ak.num(eta)
     else:
         eta_f, phi_f, nmuons = eta, phi, 1
-    
+
     a_f = cset.get("a_"+dtmc).evaluate(eta_f, phi_f, "nom")
     m_f = cset.get("m_"+dtmc).evaluate(eta_f, phi_f, "nom")
 
     if nested:
         a, m = ak.unflatten(a_f, nmuons), ak.unflatten(m_f, nmuons)
-    else: 
+    else:
         a, m = a_f, m_f
 
     pt_corr = 1. / (m/pt + charge * a)
@@ -403,6 +387,8 @@ def pt_scale_var(pt, eta, phi, charge, updn, cset, nested=False):
 
     if nested:
         stat_a, stat_m, stat_rho = ak.unflatten(stat_a_f, nmuons), ak.unflatten(stat_m_f, nmuons), ak.unflatten(stat_rho_f, nmuons)
+    else:
+        stat_a, stat_m, stat_rho = stat_a_f, stat_m_f, stat_rho_f
 
     unc = pt*pt * (stat_m*stat_m / (pt*pt) + stat_a*stat_a + 2*charge*stat_rho*stat_m/pt*stat_a)**.5
 
@@ -414,4 +400,3 @@ def pt_scale_var(pt, eta, phi, charge, updn, cset, nested=False):
         pt_var = pt_var - unc
 
     return pt_var
-

--- a/pocket_coffea/lib/muon_scale_and_resolution.py
+++ b/pocket_coffea/lib/muon_scale_and_resolution.py
@@ -5,36 +5,33 @@ import math
 from scipy.special import erfinv, erf
 from random import random
 import awkward as ak
-from typing import List
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 
-class SeedSequence:
-    def __init__(self, seeds: List[int]):
-        self.seeds = [s & 0xFFFFFFFF for s in seeds]
+def _splitmix64(z):
+    """Vectorized splitmix64 finalizer: a strong avalanche mix of a uint64 array."""
+    z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
+    z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
+    return z ^ (z >> np.uint64(31))
 
-    def generate(self, n: int) -> List[int]:
-        if n<=0:
-            return []
 
-        mult = 0x9e3779b9
-        mix_const = 0x85ebca6b
-
-        buffer = [0x8b8b8b8b] * n
-        s = len(self.seeds)
-
-        for i in range(min(n, s)):
-            buffer[i] ^= (self.seeds[i] + mult * i) & 0xFFFFFFFF
-
-        for i in range(s, n):
-            buffer[i] ^= (mult * i) & 0xFFFFFFFF
-
-        for k in range(n):
-            z = (buffer[(k + n - 1) % n] ^ (buffer[k] >> 27)) & 0xFFFFFFFF
-            buffer[k] = ((z * mix_const) & 0xFFFFFFFF) ^ ((buffer[k] << 13) & 0xFFFFFFFF)
-
-        return [x & 0xFFFFFFFF for x in buffer]
+def _hashed_uniform(evtNr, lumiNr, phi_int):
+    """Reproducible uniform in [0,1) per muon, derived from (event, lumi, phi) with a fully
+    vectorized 64-bit hash. This replaces the per-muon SeedSequence + MT19937 construction
+    and mixes ALL three entropy words, so muons in the same event get independent draws
+    (the previous scalar SeedSequence.generate(1) mixed only the event word, giving every
+    muon in an event the same draw)."""
+    ev = np.asarray(evtNr).astype(np.uint64)
+    lumi = np.asarray(lumiNr).astype(np.uint64)
+    phi = np.asarray(phi_int).astype(np.uint64)
+    with np.errstate(over="ignore"):  # uint64 multiply/add wrap on purpose
+        key = _splitmix64(ev * np.uint64(0x9E3779B97F4A7C15)
+                          + lumi * np.uint64(0xC2B2AE3D27D4EB4F)
+                          + phi * np.uint64(0x165667B19E3779F9))
+        key = _splitmix64(key)
+    # top 53 bits -> double in [0, 1)
+    return (key >> np.uint64(11)) * (1.0 / (1 << 53))
 
 class CrystallBall:
 
@@ -138,20 +135,6 @@ class CrystallBall:
         return result
 
 
-def _get_rnd_func(rnd_gen):
-    if isinstance(rnd_gen, str):
-        rnd_gen = rnd_gen.lower()
-        if rnd_gen == "np":
-            rnd_func = lambda seed: np.random.Generator(np.random.MT19937(seed=seed)).random()
-        else:
-            raise ValueError(f"unknown rnd_gen string '{rnd_gen}', should either be 'root' or 'np'")
-    elif callable(rnd_gen):
-        rnd_func = rnd_gen
-    else:
-        raise TypeError(f"unsupported rnd_gen '{rnd_gen}', should be string or callable")
-    return rnd_func
-
-
 def get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested=False, rnd_gen="root"):
     # obtain parameters from correctionlib
     if nested:
@@ -168,14 +151,12 @@ def get_rndm(eta, phi, nL, evtNr, lumiNr, cset, nested=False, rnd_gen="root"):
 
     phi_int_f = (((np.asarray(phi_f, dtype=np.float64) / math.pi) * (1 << 31 - 1) ).astype(np.int64) & 0xFFF).astype(np.uint32)
 
-    seeds = [
-        SeedSequence([np.uint32(ev), np.uint32(lumi), np.uint32(phi_int)]).generate(1)[0]
-        for ev, lumi, phi_int in zip(evtNr_f, lumiNr_f, phi_int_f)
-    ]
-
-    # get random number following the CB
-    rnd_func = _get_rnd_func(rnd_gen)
-    rndm_f = [rnd_func(seed) for seed in seeds]
+    # Vectorized, reproducible per-muon uniform following the CB. Replaces the per-muon
+    # SeedSequence + MT19937 construction loops (rnd_gen is kept for backward compatibility
+    # but no longer selects the generator). NB: the drawn values differ from the old
+    # MT19937 path -- muon-smearing outputs are a different, equally valid noise realization
+    # -- and, unlike before, muons in the same event are smeared independently.
+    rndm_f = _hashed_uniform(evtNr_f, lumiNr_f, phi_int_f)
 
     cb_f = CrystallBall(mean_f, sigma_f, alpha_f, n_f)
 

--- a/tests/test_muon_rng.py
+++ b/tests/test_muon_rng.py
@@ -1,0 +1,70 @@
+"""Offline unit tests for the vectorized muon-smearing RNG.
+
+These guard the bug fix in ``muon_scale_and_resolution.get_rndm``: the per-muon
+uniform used for the Crystal-Ball smearing is now derived from a fully vectorized
+64-bit hash of (event, lumi, phi) instead of a per-muon ``SeedSequence`` +
+``MT19937`` construction. The old scalar ``SeedSequence.generate(1)`` mixed only
+the first entropy word (the event number), so every muon in the same event drew
+the *same* uniform -- the tests below assert the draws are now independent.
+
+No EOS / grid proxy needed.
+"""
+import numpy as np
+from pocket_coffea.lib.muon_scale_and_resolution import _hashed_uniform, _splitmix64
+
+
+def test_hashed_uniform_range_and_dtype():
+    n = 5000
+    ev = np.arange(n, dtype=np.uint64)
+    lumi = (np.arange(n) % 1000).astype(np.uint64)
+    phi = (np.arange(n) % 4096).astype(np.uint64)
+    u = _hashed_uniform(ev, lumi, phi)
+    assert u.dtype == np.float64
+    assert np.all(u >= 0.0) and np.all(u < 1.0)
+
+
+def test_hashed_uniform_reproducible():
+    # Identical (event, lumi, phi) must give identical draws (determinism across
+    # chunks / re-processing -- the smearing must be reproducible).
+    ev = np.array([12345, 12345], dtype=np.uint64)
+    lumi = np.array([7, 7], dtype=np.uint64)
+    phi = np.array([100, 100], dtype=np.uint64)
+    u = _hashed_uniform(ev, lumi, phi)
+    assert u[0] == u[1]
+
+
+def test_hashed_uniform_independent_per_muon():
+    # THE BUG FIX. Two muons in the same event (same event & lumi) but different
+    # phi must get DIFFERENT draws. Previously they were identical.
+    u_phi = _hashed_uniform(
+        np.array([999, 999], dtype=np.uint64),
+        np.array([5, 5], dtype=np.uint64),
+        np.array([10, 3000], dtype=np.uint64),
+    )
+    assert u_phi[0] != u_phi[1]
+
+    # Different lumi (same event & phi) must also decorrelate.
+    u_lumi = _hashed_uniform(
+        np.array([999, 999], dtype=np.uint64),
+        np.array([5, 6], dtype=np.uint64),
+        np.array([10, 10], dtype=np.uint64),
+    )
+    assert u_lumi[0] != u_lumi[1]
+
+
+def test_hashed_uniform_uniformity():
+    n = 200000
+    ev = np.arange(n, dtype=np.uint64)
+    lumi = (np.arange(n) % 1000).astype(np.uint64)
+    phi = (np.arange(n) * 7 % 4096).astype(np.uint64)
+    u = _hashed_uniform(ev, lumi, phi)
+    assert abs(float(u.mean()) - 0.5) < 0.01
+    assert abs(float(u.std()) - 1.0 / np.sqrt(12.0)) < 0.01
+
+
+def test_splitmix64_avalanche():
+    # A one-bit input change should flip roughly half the output bits.
+    a = _splitmix64(np.array([0x0123456789ABCDEF], dtype=np.uint64))[0]
+    b = _splitmix64(np.array([0x0123456789ABCDEE], dtype=np.uint64))[0]
+    flipped = bin(int(a) ^ int(b)).count("1")
+    assert 16 < flipped < 48  # ~32 of 64 bits differ

--- a/tests/test_muon_rng.py
+++ b/tests/test_muon_rng.py
@@ -1,70 +1,99 @@
-"""Offline unit tests for the vectorized muon-smearing RNG.
+"""Unit tests for the muon-smearing RNG wiring.
 
-These guard the bug fix in ``muon_scale_and_resolution.get_rndm``: the per-muon
-uniform used for the Crystal-Ball smearing is now derived from a fully vectorized
-64-bit hash of (event, lumi, phi) instead of a per-muon ``SeedSequence`` +
-``MT19937`` construction. The old scalar ``SeedSequence.generate(1)`` mixed only
-the first entropy word (the event number), so every muon in the same event drew
-the *same* uniform -- the tests below assert the draws are now independent.
+The per-muon uniform used for the Crystal-Ball smearing is now drawn by the
+``RandomSmearing`` correction shipped in ``muon_scalesmearing.json.gz`` -- a
+correctionlib ``hashprng`` node keyed on ``(event, lumi, phi)``. These tests
+guard the PocketCoffea-side wiring in ``muon_scale_and_resolution.get_rndm``:
 
-No EOS / grid proxy needed.
+  * the draw is *reproducible* (same event/lumi/phi -> same value across chunks
+    / re-processing), and
+  * two muons in the same event (same event & lumi) but different phi get
+    *independent* draws -- the historical per-muon correlation bug, where every
+    muon in an event drew the same uniform, must not reappear.
+
+The RNG itself lives in the correction JSON on cvmfs, so these tests skip when
+that file is not mounted (e.g. a bare runner without cvmfs).
 """
+import os
+
 import numpy as np
-from pocket_coffea.lib.muon_scale_and_resolution import _hashed_uniform, _splitmix64
+import awkward as ak
+import pytest
+
+from pocket_coffea.lib.muon_scale_and_resolution import get_rndm
+
+# Candidate scale&smearing JSONs (any works -- RandomSmearing is the same node).
+_CANDIDATE_JSONS = [
+    "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/"
+    "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-06-18/muon_scalesmearing.json.gz",
+    "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/"
+    "Run3-22CDSep23-Summer22-NanoAODv12/2026-06-18/muon_scalesmearing.json.gz",
+]
 
 
-def test_hashed_uniform_range_and_dtype():
-    n = 5000
-    ev = np.arange(n, dtype=np.uint64)
-    lumi = (np.arange(n) % 1000).astype(np.uint64)
-    phi = (np.arange(n) % 4096).astype(np.uint64)
-    u = _hashed_uniform(ev, lumi, phi)
-    assert u.dtype == np.float64
-    assert np.all(u >= 0.0) and np.all(u < 1.0)
+@pytest.fixture(scope="module")
+def cset():
+    path = next((p for p in _CANDIDATE_JSONS if os.path.exists(p)), None)
+    if path is None:
+        pytest.skip("muon_scalesmearing.json.gz not available (cvmfs not mounted)")
+    import correctionlib
+
+    return correctionlib.CorrectionSet.from_file(path)
 
 
-def test_hashed_uniform_reproducible():
-    # Identical (event, lumi, phi) must give identical draws (determinism across
-    # chunks / re-processing -- the smearing must be reproducible).
-    ev = np.array([12345, 12345], dtype=np.uint64)
-    lumi = np.array([7, 7], dtype=np.uint64)
-    phi = np.array([100, 100], dtype=np.uint64)
-    u = _hashed_uniform(ev, lumi, phi)
-    assert u[0] == u[1]
+def _nested(pt, eta, phi, nL, counts):
+    """Build a jagged (per-event) muon collection from flat arrays."""
+    return {
+        "pt": ak.unflatten(np.asarray(pt, dtype=np.float64), counts),
+        "eta": ak.unflatten(np.asarray(eta, dtype=np.float64), counts),
+        "phi": ak.unflatten(np.asarray(phi, dtype=np.float64), counts),
+        "nL": ak.unflatten(np.asarray(nL, dtype=np.int64), counts),
+    }
 
 
-def test_hashed_uniform_independent_per_muon():
-    # THE BUG FIX. Two muons in the same event (same event & lumi) but different
-    # phi must get DIFFERENT draws. Previously they were identical.
-    u_phi = _hashed_uniform(
-        np.array([999, 999], dtype=np.uint64),
-        np.array([5, 5], dtype=np.uint64),
-        np.array([10, 3000], dtype=np.uint64),
-    )
-    assert u_phi[0] != u_phi[1]
-
-    # Different lumi (same event & phi) must also decorrelate.
-    u_lumi = _hashed_uniform(
-        np.array([999, 999], dtype=np.uint64),
-        np.array([5, 6], dtype=np.uint64),
-        np.array([10, 10], dtype=np.uint64),
-    )
-    assert u_lumi[0] != u_lumi[1]
+def test_get_rndm_reproducible(cset):
+    # One event, two muons; identical inputs on two calls must agree exactly.
+    counts = [2]
+    mu = _nested([40.0, 55.0], [0.3, -1.1], [0.5, 2.0], [12, 11], counts)
+    ev = np.array([12345], dtype=np.uint64)
+    lu = np.array([7], dtype=np.uint32)
+    r1 = get_rndm(mu["eta"], mu["phi"], mu["nL"], ev, lu, cset, nested=True)
+    r2 = get_rndm(mu["eta"], mu["phi"], mu["nL"], ev, lu, cset, nested=True)
+    assert ak.all(ak.flatten(r1) == ak.flatten(r2))
+    # nested structure preserved and finite
+    assert ak.to_list(ak.num(r1)) == counts
+    assert not ak.any(np.isnan(ak.flatten(r1)))
 
 
-def test_hashed_uniform_uniformity():
+def test_get_rndm_independent_per_muon(cset):
+    # THE BUG FIX: two muons in the same event & lumi but different phi must get
+    # different draws (they are decorrelated by the phi entropy word).
+    counts = [2]
+    mu = _nested([40.0, 40.0], [0.3, 0.3], [10.0, 3000.0 * np.pi / 4096], [12, 12], counts)
+    ev = np.array([999], dtype=np.uint64)
+    lu = np.array([5], dtype=np.uint32)
+    r = get_rndm(mu["eta"], mu["phi"], mu["nL"], ev, lu, cset, nested=True)
+    r = ak.flatten(r)
+    assert r[0] != r[1]
+
+
+def test_get_rndm_independent_across_events(cset):
+    # Same muon kinematics but different event numbers -> different draws.
+    counts = [1, 1]
+    mu = _nested([40.0, 40.0], [0.3, 0.3], [0.5, 0.5], [12, 12], counts)
+    ev = np.array([1, 2], dtype=np.uint64)
+    lu = np.array([5, 5], dtype=np.uint32)
+    r = ak.flatten(get_rndm(mu["eta"], mu["phi"], mu["nL"], ev, lu, cset, nested=True))
+    assert r[0] != r[1]
+
+
+def test_randomsmearing_uniform(cset):
+    # The underlying hashprng draw must be a uniform in [0,1).
     n = 200000
     ev = np.arange(n, dtype=np.uint64)
-    lumi = (np.arange(n) % 1000).astype(np.uint64)
-    phi = (np.arange(n) * 7 % 4096).astype(np.uint64)
-    u = _hashed_uniform(ev, lumi, phi)
+    lu = (np.arange(n) % 1000).astype(np.uint32)
+    phi = ((np.arange(n) * 7 % 4096) / 4096.0 * np.pi).astype(np.float64)
+    u = np.asarray(cset["RandomSmearing"].evaluate(ev, lu, phi))
+    assert np.all(u >= 0.0) and np.all(u < 1.0)
     assert abs(float(u.mean()) - 0.5) < 0.01
     assert abs(float(u.std()) - 1.0 / np.sqrt(12.0)) < 0.01
-
-
-def test_splitmix64_avalanche():
-    # A one-bit input change should flip roughly half the output bits.
-    a = _splitmix64(np.array([0x0123456789ABCDEF], dtype=np.uint64))[0]
-    b = _splitmix64(np.array([0x0123456789ABCDEE], dtype=np.uint64))[0]
-    flipped = bin(int(a) ^ int(b)).count("1")
-    assert 16 < flipped < 48  # ~32 of 64 bits differ


### PR DESCRIPTION
Replace the hand-rolled muon-smearing RNG in muon_scale_and_resolution.py with
the current official upstream MuonScaRe.py, which draws the per-muon uniform
from the "RandomSmearing" correction (a correctionlib hashprng node keyed on
event/lumi/phi) shipped inside muon_scalesmearing.json.gz. 

MuonsCalibrator drops the now-removed rnd_gen="np" argument. Scale/resolution
ordering and variation wiring already matched the official example.

Rewrite tests/test_muon_rng.py to guard the same properties (reproducibility,
per-muon and per-event independence, uniformity) through the new correctionlib
path
