### PR TITLE
Unify metadata isMC loading and fix other small issues

### DIFF
--- a/pocket_coffea/utils/configurator.py
+++ b/pocket_coffea/utils/configurator.py
@@ -21,6 +21,7 @@ from ..lib.categorization import StandardSelection, CartesianSelection
 from ..parameters.cuts import passthrough
 from ..lib.hist_manager import Axis, HistConf
 from ..utils import build_jets_calibrator
+from ..utils.metadata import to_bool
 
 from pprint import PrettyPrinter
 
@@ -177,7 +178,7 @@ class Configurator:
                     if (m["era"]) not in self.eras:
                         self.eras.append(m["era"])
                 self.samples_metadata[m["sample"]] = {
-                    "isMC": m["isMC"] =="True",
+                    "isMC": to_bool(m["isMC"]),
                 }
             
         self.load_subsamples()
@@ -259,6 +260,11 @@ class Configurator:
             if self.samples_metadata[s]["isMC"]
         }
         
+        # Default both variation types symmetrically: a config may declare only
+        # shape variations (or only weight variations), and the missing key must
+        # not KeyError when it is loaded just below.
+        if "weights" not in self.variations_cfg:
+            self.variations_cfg["weights"] = {"common": {"inclusive": []}}
         if "shape" not in self.variations_cfg:
             self.variations_cfg["shape"] = {"common": {"inclusive": []}}
 
@@ -730,7 +736,20 @@ class Configurator:
         filtered_filesets = {}
         filtered_datasets = []
         for dataset_name, ds in self.filesets.items():
+            n_total_files = len(ds["files"])
             ds["files"] = ds["files"][0:nfiles]
+            # Keep the advertised event count consistent with the truncated file
+            # list (it feeds the run summary and adapt_chunksize). Exact per-file
+            # counts are not known here, so scale nevents by the fraction of files
+            # kept rather than leaving the full-dataset count in place.
+            meta = ds.get("metadata")
+            if meta is not None and "nevents" in meta and n_total_files > 0:
+                try:
+                    orig = meta["nevents"]
+                    scaled = int(int(orig) * len(ds["files"]) / n_total_files)
+                    meta["nevents"] = str(scaled) if isinstance(orig, str) else scaled
+                except (ValueError, TypeError):
+                    pass
             filtered_filesets[dataset_name] = ds
             filtered_datasets.append(dataset_name)
         self.filesets = filtered_filesets

--- a/pocket_coffea/utils/metadata.py
+++ b/pocket_coffea/utils/metadata.py
@@ -1,0 +1,51 @@
+"""Dependency-free helpers for coercing values that arrive from
+``events.metadata`` / the datasets-definition JSON.
+
+Boolean flags such as ``isMC`` / ``isSkim`` may reach the framework either as
+native Python bools or as strings (``"True"`` / ``"true"`` / ``"1"`` / ...),
+depending on whether they came straight from the coffea metadata, from a JSON
+dump, or from a user config. Historically the processor, the ``Configurator``
+and ``utils.get_nano_version`` each coerced them differently, so the same
+dataset could be classified as MC in one place and as data in another. Route
+every such coercion through :func:`to_bool` so the classification is identical
+everywhere.
+
+This module must stay import-light (no pocket_coffea imports) so it can be used
+from ``configurator.py``, ``workflows/base.py`` and ``utils/utils.py`` without
+creating an import cycle.
+"""
+
+_TRUE_STRINGS = {"true", "1", "yes"}
+_FALSE_STRINGS = {"false", "0", "no", ""}
+
+
+def to_bool(value, default=False):
+    """Coerce a metadata boolean flag to a Python ``bool``.
+
+    Accepts native bools, integers (``0``/``1``) and the string spellings that
+    the datasets JSON / coffea metadata may carry (case-insensitive, whitespace
+    tolerant). Returns ``default`` when ``value`` is ``None`` (e.g. an absent
+    key looked up with ``.get(key)``).
+
+    Raises ``ValueError`` on an unrecognised string, so a typo like
+    ``isMC="Ture"`` fails loudly instead of being silently read as data.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):  # 0 / 1 (plain bools already handled above)
+        return bool(value)
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in _TRUE_STRINGS:
+            return True
+        if v in _FALSE_STRINGS:
+            return False
+        raise ValueError(
+            f"Cannot interpret metadata boolean value {value!r}; "
+            f"expected one of True/False/true/false/1/0."
+        )
+    raise TypeError(
+        f"Cannot interpret metadata boolean of type {type(value).__name__}: {value!r}"
+    )

--- a/pocket_coffea/utils/utils.py
+++ b/pocket_coffea/utils/utils.py
@@ -7,6 +7,7 @@ import awkward
 import pathlib
 import shutil
 from .configurator import Configurator
+from .metadata import to_bool
 import hashlib
 from numba import njit
 import awkward as ak
@@ -78,17 +79,21 @@ def load_config(cfg, do_load=True, save_config=True, outputdir=None):
     config_module =  path_import(cfg)
     try:
         config = config_module.cfg
-        # Load the configuration
-        if do_load:
-            config.load()
-        if save_config and outputdir is not None:
-            config.save_config(outputdir)
     except AttributeError as e:
         print("Error: ", e)
         raise Exception("The provided configuration module does not contain a `cfg` attribute of type Configurator. Please check your configuration!")
 
     if not isinstance(config, Configurator):
-        raise Exception("The configuration module attribute `cfg` is not of type Configurator. Please check yuor configuration!")
+        raise Exception("The configuration module attribute `cfg` is not of type Configurator. Please check your configuration!")
+
+    # Load/save the configuration OUTSIDE the AttributeError guard above: a
+    # genuine AttributeError raised inside config.load() is a real bug in the
+    # user's config and must surface with its own traceback, not be masked as a
+    # missing `cfg` attribute.
+    if do_load:
+        config.load()
+    if save_config and outputdir is not None:
+        config.save_config(outputdir)
     return config
 
 def adapt_chunksize(nevents, run_options):
@@ -161,7 +166,7 @@ def get_nano_version(events, params, year):
     if "nano_version" in events.metadata:
         nano_version = events.metadata["nano_version"]
     else:
-        if events.metadata.get("isMC", False):
+        if to_bool(events.metadata.get("isMC", False)):
             # Try to extract from the sample name
             if "NanoAODv12" in events.metadata["filename"]:
                 nano_version = 12

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -21,6 +21,7 @@ from ..lib.jets import load_jet_factory
 from ..lib.calibrators.calibrators_manager import CalibratorsManager
 from ..utils.skim import uproot_writeable, copy_file, apply_skim_sumgenweights_override
 from ..utils.utils import dump_ak_array
+from ..utils.metadata import to_bool
 from ..lib.delayed_eval import DelayedEvalBranchManager
 
 from ..utils.configurator import Configurator
@@ -130,12 +131,9 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
         self._samplePart = self.events.metadata.get("part", None) # this is the (optional) name of the part of the sample
 
         self._year = self.events.metadata["year"]
-        self._isMC = ((self.events.metadata["isMC"] in ["True", "true"])
-                      or (self.events.metadata["isMC"] == True))
+        self._isMC = to_bool(self.events.metadata["isMC"])
         # if the dataset is a skim the sumgenweights are scaled by the skim efficiency
-        self._isSkim = ("isSkim" in self.events.metadata and self.events.metadata["isSkim"] in ["True","true"]) or(
-            "isSkim" in self.events.metadata and self.events.metadata["isSkim"] == True)
-        # for some reason this get to a string WIP
+        self._isSkim = to_bool(self.events.metadata.get("isSkim", False))
         if self._isMC:
             self._era = "MC"
             self._xsec = self.events.metadata["xsec"]
@@ -393,6 +391,12 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
         also sum their nominal weights (for each sample, by chunk).
         Store the results in the `cutflow` and `sumw` outputs
         '''
+        # Subsample masks are category-independent, so reduce them once per chunk
+        # here instead of re-running storage.all() for every category below.
+        subsample_masks = (
+            list(self._subsamples[self._sample].get_masks())
+            if self._hasSubsamples else []
+        )
         for category, mask in self._categories.get_masks():
             if self._categories.is_multidim and mask.ndim > 1:
                 # The Selection object can be multidim but returning some mask 1-d
@@ -409,7 +413,7 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
 
             # If subsamples are defined we also save their metadata
             if self._hasSubsamples:
-                for subs, subsam_mask in self._subsamples[self._sample].get_masks():
+                for subs, subsam_mask in subsample_masks:
                     # get the subsample specific weight
                     mask_withsub = mask_on_events & subsam_mask
                     self.output["cutflow"][category].setdefault(self._dataset, {}).setdefault(f"{self._sample}__{subs}", {})[variation] = ak.sum(mask_withsub)
@@ -536,7 +540,10 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                 if self.workflow_options is not None and self.workflow_options.get("dump_columns_as_arrays_per_chunk", None) is not None:
                     # filling awkward arrays to be dumped per chunk
                     if self.column_managers[subs].ncols == 0:
-                        break
+                        # this subsample has no columns to dump; skip it but keep
+                        # processing the remaining subsamples (a `break` here would
+                        # silently drop every later subsample's columns)
+                        continue
                     out_arrays = self.column_managers[subs].fill_ak_arrays(
                                                self.events,
                                                self._categories,
@@ -556,7 +563,10 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
                     # Filling columns to be accumulated for all the chunks
                     # Calling hist manager with a subsample mask
                     if self.column_managers[subs].ncols == 0:
-                        break
+                        # this subsample has no columns to dump; skip it but keep
+                        # processing the remaining subsamples (a `break` here would
+                        # silently drop every later subsample's columns)
+                        continue
                     outcols[f"{self._sample}__{subs}"] = {
                         self._dataset: self.column_managers[subs].fill_columns_accumulators(
                                                    self.events,
@@ -618,10 +628,13 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
         # Filling the special histograms for processing metadata if they are present
         total_processing_time = self.stop_time - self.start_time # in seconds
         add_axes = {"variation":"nominal"} if self._isMC else {}
+        # nEvents_after_presel is per-variation; use the value captured on the
+        # nominal pass so this "nominal"-axis metadata is not the last variation's.
+        n_presel = getattr(self, "_nEvents_after_presel_nominal", self.nEvents_after_presel)
         if self._hasSubsamples:
             for subs in self._subsamples[self._sample].keys():
                 for k, n in zip(["initial", "skim","presel"],
-                                [self.nEvents_initial, self.nEvents_after_skim, self.nEvents_after_presel ]):
+                                [self.nEvents_initial, self.nEvents_after_skim, n_presel ]):
                     if hepc := self.hists_manager.get_histogram(subs, f"events_per_chunk_{k}"):
                         hepc.hist_obj.fill(
                             cat=hepc.only_categories[0],
@@ -896,6 +909,13 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
             # from further processing
             self.apply_preselections(variation)
 
+            # nEvents_after_presel is overwritten by every variation; remember the
+            # nominal one so save_processing_metadata (run once after this loop)
+            # records the nominal preselection count under the "nominal" axis
+            # instead of whichever variation happened to run last.
+            if variation == "nominal":
+                self._nEvents_after_presel_nominal = self.nEvents_after_presel
+
             # If not events remains after the preselection we skip the chunk
             if not self.has_events:
                 continue
@@ -1075,9 +1095,9 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
         for var, vardata in accumulator["variables"].items():
             for samplename, dataset_in_sample in vardata.items():
                 for dataset, histo in dataset_in_sample.items():
-                    if any(np.isnan(histo.values().flatten())):
+                    if not np.all(np.isfinite(histo.values().flatten())):
                         raise Exception(
-                            f"NaN values in the histogram {var} for dataset {dataset} after rescaling"
+                            f"NaN or Inf values in the histogram {var} for dataset {dataset} after rescaling"
                         )
 
         return accumulator

--- a/tests/test_metadata_coercion.py
+++ b/tests/test_metadata_coercion.py
@@ -1,0 +1,46 @@
+"""Unit tests for pocket_coffea.utils.metadata.to_bool.
+
+to_bool is the single coercion helper that keeps isMC/isSkim classification
+identical across the processor (base.py), the Configurator and
+utils.get_nano_version, which previously coerced the same metadata three
+different (and mutually inconsistent) ways.
+"""
+import pytest
+
+from pocket_coffea.utils.metadata import to_bool
+
+
+@pytest.mark.parametrize("value", [True, "True", "true", "TRUE", " true ", "1", 1, "yes"])
+def test_to_bool_truthy(value):
+    assert to_bool(value) is True
+
+
+@pytest.mark.parametrize("value", [False, "False", "false", "FALSE", " false ", "0", 0, "no", ""])
+def test_to_bool_falsy(value):
+    assert to_bool(value) is False
+
+
+def test_to_bool_none_uses_default():
+    assert to_bool(None) is False
+    assert to_bool(None, default=True) is True
+
+
+def test_to_bool_unknown_string_raises():
+    # a typo must fail loudly instead of being silently read as data/MC
+    with pytest.raises(ValueError):
+        to_bool("Ture")
+
+
+def test_to_bool_unknown_type_raises():
+    with pytest.raises(TypeError):
+        to_bool(1.5)
+
+
+def test_to_bool_agrees_on_the_old_divergent_cases():
+    # the exact spellings that used to be classified differently by the three
+    # former coercions must now all agree
+    for v in ["True", "true", True]:
+        assert to_bool(v) is True
+    # utils.get_nano_version used truthiness, so the *string* "False" was wrongly
+    # truthy -> treated as MC; it must now be False
+    assert to_bool("False") is False


### PR DESCRIPTION
A single dependency-free  helper (utils/metadata.to_bool) replaces three divergent isMC config loaders that could classify the same dataset inconsistently:
  - configurator.py used `m["isMC"] == "True"` (only the exact string "True"),
  - base.py used `in ["True","true"] or == True`,
  - utils.get_nano_version used `metadata.get("isMC", False)` truthiness, so the string "False" was truthy and data was treated as MC. All three now route through to_bool (accepts bool / "true"/"false"/"1"/"0"/..., case-insensitive; raises on an unrecognised spelling instead of silently defaulting). isSkim is coerced the same way. Kept import-light in a new leaf module so configurator.py can use it without an import cycle.

Correctness fixes:
- base.py fill_column_accumulators: `break` -> `continue` when a subsample has no columns, so a 0-column subsample no longer silently drops every later subsample's columns (A6).
- base.py postprocess histogram sanity check: `isnan` -> `~isfinite`, so Inf bins are caught, not only NaN.
- base.py save_processing_metadata: nEvents_after_presel is per-variation and is overwritten by the last variation before this runs; capture the nominal value on its pass and record that under the "nominal" axis.
- configurator variations: default a missing "weights" key symmetrically with "shape", so a config declaring only shape (or only weight) variations no longer KeyErrors on load.
- utils.load_config: narrow the `except AttributeError` to the `cfg` attribute lookup only, so a genuine AttributeError raised inside config.load() surfaces with its real traceback instead of being masked as a missing `cfg`.

Performance:
- count_events: subsample masks are category-independent, so reduce them once per chunk instead of re-running storage.all() for every category.
- configurator.filter_dataset: scale the advertised nevents to the kept-file fraction instead of leaving the full-dataset count (feeds the run summary and adapt_chunksize).

