### PR TITLE
Updated JEC tags and added 2026

### DIFF
--- a/pocket_coffea/parameters/jet_scale_factors.yaml
+++ b/pocket_coffea/parameters/jet_scale_factors.yaml
@@ -137,8 +137,11 @@ jet_scale_factors:
             file: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetvetomaps.json.gz,2026-07-16}
             name: "Summer24Prompt24_RunBCDEFGHI_V1"
         '2025':
-            file: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,jetvetomaps.json.gz,2026-06-05}
-            name: "Winter25Prompt25_RunCDEFG_V1"
+            file: ${cvmfs:Run3-25Prompt-Summer24-NanoAODv15,JME,jetvetomaps.json.gz,2026-07-16}
+            name: "Summer24Prompt25_RunCDEFG_V1"
+        '2026':
+            file: ${cvmfs:Run3-26Prompt-Summer24-NanoAODv15,JME,jetvetomaps.json.gz,2026-07-15}
+            name: "Summer24Prompt26_RunBCD_V1"
 
 
     jet_id:
@@ -147,4 +150,5 @@ jet_scale_factors:
         "2023_preBPix": ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jetid.json.gz,2026-07-15}
         "2023_postBPix": ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jetid.json.gz,2026-07-15}
         "2024": ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-07-16}
-        "2025": ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-07-16}        
+        "2025": ${cvmfs:Run3-25Prompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-07-16}   
+        "2026": ${cvmfs:Run3-26Prompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-07-15}   

--- a/pocket_coffea/parameters/jet_scale_factors.yaml
+++ b/pocket_coffea/parameters/jet_scale_factors.yaml
@@ -128,13 +128,13 @@ jet_scale_factors:
             file: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,JME,jetvetomaps.json.gz,2026-06-05}
             name: "Summer22EE_23Sep2023_RunEFG_V1"
         '2023_preBPix':
-            file: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jetvetomaps.json.gz,2026-06-05}
+            file: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jetvetomaps.json.gz,2026-07-15}
             name: "Summer23Prompt23_RunC_V1"
         '2023_postBPix':
-            file: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jetvetomaps.json.gz,2026-06-05}
+            file: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jetvetomaps.json.gz,2026-07-15}
             name: "Summer23BPixPrompt23_RunD_V1"
         '2024':
-            file: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetvetomaps.json.gz,2026-06-05}
+            file: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetvetomaps.json.gz,2026-07-16}
             name: "Summer24Prompt24_RunBCDEFGHI_V1"
         '2025':
             file: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,jetvetomaps.json.gz,2026-06-05}
@@ -144,7 +144,7 @@ jet_scale_factors:
     jet_id:
         "2022_preEE": ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,JME,jetid.json.gz,2026-06-05}
         "2022_postEE": ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,JME,jetid.json.gz,2026-06-05}
-        "2023_preBPix": ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jetid.json.gz,2026-06-05}
-        "2023_postBPix": ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jetid.json.gz,2026-06-05}
-        "2024": ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-06-05}
-        "2025": ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-06-05}        
+        "2023_preBPix": ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jetid.json.gz,2026-07-15}
+        "2023_postBPix": ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jetid.json.gz,2026-07-15}
+        "2024": ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-07-16}
+        "2025": ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jetid.json.gz,2026-07-16}        

--- a/pocket_coffea/parameters/jets_calibration.yaml
+++ b/pocket_coffea/parameters/jets_calibration.yaml
@@ -60,21 +60,21 @@ default_jets_calibration:
         level: L1L2L3Res
 
       2023_preBPix:
-        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jet_jerc.json.gz,2026-06-05}
+        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jet_jerc.json.gz,2026-07-15}
         jec_mc: Summer23Prompt23_V4_MC
         jec_data: Summer23Prompt23_V4_DATA
         jer: Summer23Prompt23_RunCv1234_JRV2_MC
         level: L1L2L3Res
       
       2023_postBPix:
-        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jet_jerc.json.gz,2026-06-05}
+        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jet_jerc.json.gz,2026-07-15}
         jec_mc: Summer23BPixPrompt23_V4_MC
         jec_data: Summer23BPixPrompt23_V4_DATA
         jer: Summer23BPixPrompt23_RunD_JRV2_MC
         level: L1L2L3Res
 
       "2024":
-        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz,2026-06-05}
+        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz,2026-07-16}
         jec_mc: Summer24Prompt24_V3_MC
         jec_data: Summer24Prompt24_V3_DATA
         jer: Summer24Prompt24_JRV1_MC
@@ -132,21 +132,21 @@ default_jets_calibration:
         level: L1L2L3Res
 
       2023_preBPix:
-        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,fatJet_jerc.json.gz,2026-06-05}
+        json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,fatJet_jerc.json.gz,2026-07-15}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_preBPix.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_preBPix.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_preBPix.jer}"
         level: L1L2L3Res
 
       2023_postBPix:
-        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,fatJet_jerc.json.gz,2026-06-05}
+        json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,fatJet_jerc.json.gz,2026-07-15}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_postBPix.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_postBPix.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2023_postBPix.jer}"
         level: L1L2L3Res
 
       "2024":
-        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,fatJet_jerc.json.gz,2026-06-05}
+        json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,fatJet_jerc.json.gz,2026-07-16}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jer}"

--- a/pocket_coffea/parameters/jets_calibration.yaml
+++ b/pocket_coffea/parameters/jets_calibration.yaml
@@ -63,28 +63,35 @@ default_jets_calibration:
         json_path: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,JME,jet_jerc.json.gz,2026-07-15}
         jec_mc: Summer23Prompt23_V4_MC
         jec_data: Summer23Prompt23_V4_DATA
-        jer: Summer23Prompt23_RunCv1234_JRV2_MC
+        jer: Summer23Prompt23_RunCv1234_JRV3_MC
         level: L1L2L3Res
       
       2023_postBPix:
         json_path: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,JME,jet_jerc.json.gz,2026-07-15}
         jec_mc: Summer23BPixPrompt23_V4_MC
         jec_data: Summer23BPixPrompt23_V4_DATA
-        jer: Summer23BPixPrompt23_RunD_JRV2_MC
+        jer: Summer23BPixPrompt23_RunD_JRV3_MC
         level: L1L2L3Res
 
       "2024":
         json_path: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz,2026-07-16}
-        jec_mc: Summer24Prompt24_V3_MC
-        jec_data: Summer24Prompt24_V3_DATA
-        jer: Summer24Prompt24_JRV1_MC
+        jec_mc: Summer24Prompt24_V5_MC
+        jec_data: Summer24Prompt24_V5_DATA
+        jer: Summer24Prompt24_JRV2_MC
         level: L1L2L3Res
 
       "2025":
-        json_path: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,jet_jerc.json.gz,2026-06-05}
-        jec_mc: Winter25Prompt25_V3_MC
-        jec_data: Winter25Prompt25_V3_DATA
-        jer: Summer24Prompt25_JRV1_MC
+        json_path: ${cvmfs:Run3-25Prompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz,2026-07-16}
+        jec_mc: Summer24Prompt25_V3_MC
+        jec_data: Summer24Prompt25_V3_DATA
+        jer: Summer24Prompt25_JRV2_MC
+        level: L1L2L3Res
+
+      "2026":
+        json_path: ${cvmfs:Run3-26Prompt-Summer24-NanoAODv15,JME,jet_jerc.json.gz,2026-07-15}
+        jec_mc: Summer24Prompt26_V1_MC
+        jec_data: Summer24Prompt26_V1_DATA
+        jer: Summer24Prompt26_JRV1_MC
         level: L1L2L3Res
 
 
@@ -151,11 +158,19 @@ default_jets_calibration:
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2024.jer}"
         level: L1L2L3Res
+      
       "2025":
-        json_path: ${cvmfs:Run3-25Prompt-Winter25-NanoAODv15,JME,fatJet_jerc.json.gz,2026-06-05}
+        json_path: ${cvmfs:Run3-25Prompt-Summer24-NanoAODv15,JME,fatJet_jerc.json.gz,2026-07-16}
         jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2025.jec_mc}"
         jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2025.jec_data}"
         jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2025.jer}"
+        level: L1L2L3Res  
+
+      "2026":
+        json_path: ${cvmfs:Run3-26Prompt-Summer24-NanoAODv15,JME,fatJet_jerc.json.gz,2026-07-15}
+        jec_mc: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2026.jec_mc}"
+        jec_data: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2026.jec_data}"
+        jer: "${default_jets_calibration.factory_config_clib.AK4PFPuppi.2026.jer}"
         level: L1L2L3Res        
 
   # factory available variations
@@ -292,7 +307,21 @@ default_jets_calibration:
           - JES_Regrouped_BBEC1_2025
           - JES_Regrouped_RelativeBal
           - JES_Regrouped_RelativeSample_2025
+          - JER   
+        "2026":      
+          - JES_Regrouped_Absolute
+          - JES_Regrouped_Absolute_2026
+          - JES_Regrouped_FlavorQCD
+          - JES_Regrouped_EC2
+          - JES_Regrouped_EC2_2026
+          - JES_Regrouped_HF
+          - JES_Regrouped_HF_2026
+          - JES_Regrouped_BBEC1
+          - JES_Regrouped_BBEC1_2026
+          - JES_Regrouped_RelativeBal
+          - JES_Regrouped_RelativeSample_2026
           - JER          
+          
       AK8PFPuppi: 
         2016_PreVFP: "${default_jets_calibration.variations.full_variations.AK4PFchs.2016_PreVFP}"
         2016_PostVFP: "${default_jets_calibration.variations.full_variations.AK4PFchs.2016_PostVFP}"
@@ -304,6 +333,7 @@ default_jets_calibration:
         2023_postBPix: "${default_jets_calibration.variations.full_variations.AK4PFPuppi.2023_postBPix}"
         "2024": "${default_jets_calibration.variations.full_variations.AK4PFPuppi.2024}"
         "2025": "${default_jets_calibration.variations.full_variations.AK4PFPuppi.2025}"
+        "2026": "${default_jets_calibration.variations.full_variations.AK4PFPuppi.2026}"
 
     total_variation: 
       AK4PFchs:
@@ -330,6 +360,7 @@ default_jets_calibration:
         2023_postBPix: "${default_jets_calibration.variations.total_variation.AK4PFPuppi.2023_postBPix}"
         "2024": "${default_jets_calibration.variations.total_variation.AK4PFPuppi.2024}"
         "2025": "${default_jets_calibration.variations.total_variation.AK4PFPuppi.2025}"
+        "2026": "${default_jets_calibration.variations.total_variation.AK4PFPuppi.2026}"
       AK4PFPuppi:
         2022_preEE:  
         - JES_Total
@@ -347,6 +378,9 @@ default_jets_calibration:
         - JES_Total
         - JER
         "2025": 
+        - JES_Total
+        - JER
+        "2026":
         - JES_Total
         - JER
 #####################################################################################
@@ -417,6 +451,12 @@ jets_calibration:
       #AK4PFPuppiPNetRegression: "Jet"
       #AK4PFPuppiPNetRegressionPlusNeutrino: "Jet"
       AK8PFPuppi: "FatJet"
+    "2026":
+      AK4PFPuppi: "Jet"
+      AK4CorrT1METJetPuppi: "CorrT1METJet"
+      #AK4PFPuppiPNetRegression: "Jet"
+      #AK4PFPuppiPNetRegressionPlusNeutrino: "Jet"
+      AK8PFPuppi: "FatJet"
 
   collection_name_alias:
     2016_PreVFP:
@@ -439,6 +479,9 @@ jets_calibration:
       AK4CorrT1METJetPuppi: AK4PFPuppi
     "2025": 
       AK4CorrT1METJetPuppi: AK4PFPuppi
+    "2026":
+      AK4CorrT1METJetPuppi: AK4PFPuppi
+
   merge_collections_for_variations:
     2016_PreVFP:
       AK4PFchs: 
@@ -477,6 +520,10 @@ jets_calibration:
         - AK4PFPuppi
         - AK4CorrT1METJetPuppi
     "2025":
+      AK4PFPuppi: 
+        - AK4PFPuppi
+        - AK4CorrT1METJetPuppi
+    "2026":
       AK4PFPuppi: 
         - AK4PFPuppi
         - AK4CorrT1METJetPuppi
@@ -520,6 +567,11 @@ jets_calibration:
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True
     "2025":
+      AK4PFPuppi: True
+      AK8PFPuppi: True
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
+    "2026":
       AK4PFPuppi: True
       AK8PFPuppi: True
       AK4PFPuppiPNetRegression: True
@@ -568,6 +620,11 @@ jets_calibration:
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True
       AK8PFPuppi: True      
+    "2026":
+      AK4PFPuppi: True
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
+      AK8PFPuppi: True
 
   apply_jer_MC:  # this is needed to know which collection is corrected with which jet factory
     2016_PreVFP: 
@@ -612,6 +669,11 @@ jets_calibration:
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True
       AK8PFPuppi: True
+    "2026":
+      AK4PFPuppi: True
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
+      AK8PFPuppi: True
 
   apply_jec_Data:  # this is needed to know which collection is corrected with which jet factory
     2016_PreVFP: 
@@ -652,6 +714,11 @@ jets_calibration:
       AK4PFPuppiPNetRegressionPlusNeutrino: True
       AK8PFPuppi: True
     "2025": 
+      AK4PFPuppi: True
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
+      AK8PFPuppi: True
+    "2026":
       AK4PFPuppi: True
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True
@@ -711,6 +778,12 @@ jets_calibration:
       AK4CorrT1METJetPuppi: False
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True      
+    "2026": 
+      AK4PFPuppi: False
+      AK8PFPuppi: False
+      AK4CorrT1METJetPuppi: False
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
 
   apply_pt_regr_Data:
     2016_PreVFP: 
@@ -765,6 +838,12 @@ jets_calibration:
       AK4CorrT1METJetPuppi: False
       AK4PFPuppiPNetRegression: True
       AK4PFPuppiPNetRegressionPlusNeutrino: True      
+    "2026":
+      AK4PFPuppi: False
+      AK8PFPuppi: False
+      AK4CorrT1METJetPuppi: False
+      AK4PFPuppiPNetRegression: True
+      AK4PFPuppiPNetRegressionPlusNeutrino: True
 
   apply_jec_msoftdrop_MC:
     2016_PreVFP: 
@@ -785,6 +864,7 @@ jets_calibration:
       AK8PFPuppi: True
     "2024": 
       AK8PFPuppi: True
+
 
   apply_jec_msoftdrop_Data:
     2016_PreVFP: 


### PR DESCRIPTION
- Updated 2025 JME era to:  `Run3-25Prompt-Summer24-NanoAODv15`
- Updated JEC and JER to the latest tags for Run3 eras
- Updated JetID and veto maps and added 2026 keys