### PR TITLE
fix(split-output): handle variables with restricted category axes

### DIFF
--- a/pocket_coffea/utils/filter_output.py
+++ b/pocket_coffea/utils/filter_output.py
@@ -50,7 +50,12 @@ def filter_output_by_category(o, categories):
             for s, _dict in val.items():
                 o_filtered[key][k][s] = {}
                 for sam, hist in _dict.items():
-                    o_filtered[key][k][s][sam] = hist[{'cat' : categories}]
+                    # Variables may be configured for only a subset of the
+                    # analysis categories.  Select the intersection so a
+                    # category block can retain an empty histogram when none
+                    # of its categories apply to this variable.
+                    selected_categories = [cat for cat in categories if cat in hist.axes['cat']]
+                    o_filtered[key][k][s][sam] = hist[{'cat' : selected_categories}]
 
     for key in allkeys:
         o_filtered[key] = o[key]


### PR DESCRIPTION
split-output --by category builds category blocks from the global categories stored in sumw. However, individual histograms can be configured for only a subset of analysis categories, for example region-specific variables that only contain NAMEa_* categories.

Previously, filter_output_by_category() applied the complete requested block directly to every histogram:

`hist[{"cat": categories}]`

If a block included a category absent from a histogram axis, this raised:

`KeyError: "'<category>' not in axis"`

This prevented category splitting of otherwise valid outputs.

The fix intersects the requested categories with the histogram's available cat axis before slicing. If none of the block categories apply to a histogram, the result is a valid empty histogram with an empty category axis. This preserves the output structure without inventing or dropping valid content.

Please check.
Thanks,
Licheng