### PR TITLE
Add 2018 HEM jet response calibrator

### DIFF
--- a/pocket_coffea/lib/calibrators/common/common.py
+++ b/pocket_coffea/lib/calibrators/common/common.py
@@ -534,6 +534,137 @@ class JetsSoftdropMassCalibrator(Calibrator):
    
         return out
 
+
+###########################################
+class HEM2018Calibrator(Calibrator):
+    """Apply the one-sided 2018 HEM jet-response variation to simulated events."""
+
+    name = "HEM2018"
+    has_variations = True
+    isMC_only = True
+    calibrated_collections = ["Jet"]
+
+    def __init__(self, params, metadata, do_variations, **kwargs):
+        super().__init__(
+            params,
+            metadata,
+            do_variations,
+            **kwargs,
+        )
+
+        self._year = metadata["year"]
+        self._isMC = metadata["isMC"]
+
+        if self.do_variations and self._isMC and self._year == "2018":
+            self._variations = [
+                "HEM2018Up",
+                "HEM2018Down",
+            ]
+        else:
+            self._variations = []
+
+    def initialize(self, events):
+        pass
+
+    def calibrate(
+        self,
+        events,
+        orig_colls,
+        variation,
+        already_applied_calibrators=None,
+    ):
+        jets = copy.copy(events.Jet)
+
+        if JET_SORTIDX_FIELD in jets.fields:
+            original_sortidx = jets[JET_SORTIDX_FIELD]
+        else:
+            original_sortidx = ak.local_index(jets.pt, axis=1)
+
+        if (
+            not self._isMC
+            or self._year != "2018"
+            or variation != "HEM2018Down"
+        ):
+            if JET_SORTIDX_FIELD not in jets.fields:
+                jets = ak.with_field(
+                    jets,
+                    original_sortidx,
+                    JET_SORTIDX_FIELD,
+                )
+
+            return {"Jet": jets}
+
+        tight_jet_id = jets.jetId >= 2
+
+        common_mask = (
+            (jets.pt > 15.0)
+            & tight_jet_id
+            & (jets.phi > -1.57)
+            & (jets.phi < -0.87)
+        )
+
+        hem_20 = (
+            common_mask
+            & (jets.eta > -2.5)
+            & (jets.eta < -1.3)
+        )
+
+        hem_35 = (
+            common_mask
+            & (jets.eta > -3.0)
+            & (jets.eta < -2.5)
+        )
+
+        scale = ak.ones_like(jets.pt)
+        scale = ak.where(hem_20, 0.80, scale)
+        scale = ak.where(hem_35, 0.65, scale)
+
+        old_pt = jets.pt
+        shifted_pt = old_pt * scale
+        shifted_mass = jets.mass * scale
+
+        jets = ak.with_field(jets, shifted_pt, "pt")
+        jets = ak.with_field(jets, shifted_mass, "mass")
+
+        shifted_raw_factor = ak.where(
+            shifted_pt != 0,
+            1.0 - jets.pt_raw / shifted_pt,
+            0.0,
+        )
+        jets = ak.with_field(
+            jets,
+            shifted_raw_factor,
+            "rawFactor",
+        )
+
+        if "L1FastJetFactor" in jets.fields:
+            shifted_l1_factor = ak.where(
+                shifted_pt != 0,
+                jets.L1FastJetFactor * old_pt / shifted_pt,
+                jets.L1FastJetFactor,
+            )
+            jets = ak.with_field(
+                jets,
+                shifted_l1_factor,
+                "L1FastJetFactor",
+            )
+
+        new_sortidx = ak.argsort(
+            jets.pt,
+            axis=1,
+            ascending=False,
+        )
+        jets = jets[new_sortidx]
+
+        composed_sortidx = original_sortidx[new_sortidx]
+        jets = ak.with_field(
+            jets,
+            composed_sortidx,
+            JET_SORTIDX_FIELD,
+        )
+
+        return {"Jet": jets}
+
 ###########################################
 class METCalibrator(Calibrator):
 
@@ -991,5 +1122,9 @@ class MuonsCalibrator(Calibrator):
 
 #########################################
 default_calibrators_sequence = [
-    JetsCalibrator, ElectronsScaleCalibrator, MuonsCalibrator, METCalibrator
+    JetsCalibrator,
+    HEM2018Calibrator,
+    ElectronsScaleCalibrator,
+    MuonsCalibrator,
+    METCalibrator,
 ]

--- a/tests/test_calibrators.py
+++ b/tests/test_calibrators.py
@@ -6,7 +6,7 @@ from pocket_coffea.lib.calibrators.common.common import (
     METCalibrator, 
     ElectronsScaleCalibrator, 
     MuonsCalibrator,
-    JetsSoftdropMassCalibrator)
+    JetsSoftdropMassCalibrator, HEM2018Calibrator)
 from pocket_coffea.lib.calibrators.calibrator import Calibrator
 from pocket_coffea.lib.calibrators.calibrators_manager import CalibratorsManager
 
@@ -897,3 +897,86 @@ def test_met_type1_variation_propagation(events, params):
     for v in [x for x in captured if "AK8" in x][:1]:
         assert np.allclose(captured[v], captured["nominal"]), \
             f"AK8 variation {v} must not change the AK4-jet-based MET"
+
+def test_hem2018_calibrator():
+    jets = ak.Array(
+        [
+            [
+                {
+                    "pt": 100.0,
+                    "mass": 20.0,
+                    "eta": -2.0,
+                    "phi": -1.0,
+                    "jetId": 2,
+                    "pt_raw": 80.0,
+                    "rawFactor": 0.2,
+                },
+                {
+                    "pt": 90.0,
+                    "mass": 18.0,
+                    "eta": -2.7,
+                    "phi": -1.0,
+                    "jetId": 2,
+                    "pt_raw": 72.0,
+                    "rawFactor": 0.2,
+                },
+                {
+                    "pt": 70.0,
+                    "mass": 14.0,
+                    "eta": 0.5,
+                    "phi": 0.2,
+                    "jetId": 2,
+                    "pt_raw": 56.0,
+                    "rawFactor": 0.2,
+                },
+            ]
+        ]
+    )
+
+    events = ak.Array(
+        [
+            {
+                "Jet": jets[0],
+            }
+        ]
+    )
+
+    calibrator = HEM2018Calibrator(
+        params=None,
+        metadata={"year": "2018", "isMC": True},
+        do_variations=True,
+    )
+    calibrator.initialize(events)
+
+    nominal = calibrator.calibrate(
+        events,
+        orig_colls={},
+        variation="nominal",
+    )["Jet"]
+
+    up = calibrator.calibrate(
+        events,
+        orig_colls={},
+        variation="HEM2018Up",
+    )["Jet"]
+
+    down = calibrator.calibrate(
+        events,
+        orig_colls={},
+        variation="HEM2018Down",
+    )["Jet"]
+
+    assert ak.all(nominal.pt == events.Jet.pt)
+    assert ak.all(up.pt == events.Jet.pt)
+
+    assert np.allclose(
+        ak.to_numpy(down.pt[0]),
+        np.array([80.0, 70.0, 58.5]),
+    )
+
+    assert np.allclose(
+        ak.to_numpy(down.mass[0]),
+        np.array([16.0, 14.0, 11.7]),
+    )
+
+    assert ak.to_list(down["pocket_sortidx"][0]) == [0, 2, 1]


### PR DESCRIPTION
## Summary

This PR adds a dedicated `HEM2018Calibrator` for the 2018 HEM detector issue.

The calibrator implements the one-sided HEM jet-response variation for simulated 2018 samples and is included in the default calibrator sequence between the jet and MET calibrators.

## Implementation

For `HEM2018Down`, jets satisfying the HEM selection are scaled according to their detector region:

* Jet (p_T > 15) GeV
* Tight jet ID
* (-1.57 < \phi < -0.87)
* Scale by `0.80` for (-2.5 < \eta < -1.3)
* Scale by `0.65` for (-3.0 < \eta < -2.5)

The jet mass is scaled by the same factor.

`HEM2018Up` is identical to the nominal collection, representing the nominal side of this one-sided uncertainty.

The calibrator also:

* updates `rawFactor` after the jet-response shift;
* updates `L1FastJetFactor` when available;
* re-sorts jets by the shifted transverse momentum;
* preserves the mapping to the original NanoAOD jet order through `pocket_sortidx`;
* runs only for simulated 2018 samples;
* exposes variations only when HEM variations are requested.

The calibrator is placed before `METCalibrator` so that the shifted jets are propagated to the Type-1 MET correction.

## Tests

A focused unit test was added to verify that:

* nominal and `HEM2018Up` leave the jet transverse momentum unchanged;
* `HEM2018Down` applies the expected `0.80` and `0.65` response factors;
* jets outside the HEM region remain unchanged;
* jets are correctly re-sorted;
* `pocket_sortidx` remains consistent.

Tests run:

```text
pytest -q tests/test_calibrators.py
13 passed

pytest -q tests/test_full_configs/test_shape_variations.py
7 passed, 2 skipped
```
