### PR TITLE
Split jet pT regression by b-tag and add per-tagger Run3 b-tagging WPs

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1305,26 +1305,24 @@ def process_extra_after_skim(self):
 
 with the matching `jets_calibration` entries (`AK4PFPuppiPNetRegression` -> `JetPNet` and `AK4PFPuppiPNetRegressionPlusNeutrino` -> `JetPNetPlusNeutrino`, both with `apply_pt_regr_*: True`).
 
-The **threshold defaults to the loose (`L`) working point of the tagger used**, read (not hard-coded) from the b-tagging parameters (`pocket_coffea/parameters/btagging.yaml`, overridable by the analysis) via the `btagging_algorithm` and `btagging_WP` fields:
+The **threshold defaults to the loose (`L`) working point of the tagger used**. The working-point score is **read directly from the BTV `correctionlib` file** — the same `btagging.json.gz` that provides the shape SF (`jet_scale_factors.btagSF.<year>.file`) — so the cut on the jets and the SF applied to them always refer to the same tagger and campaign. The tagger to cut on comes from `btagging.working_point.<year>.btagging_algorithm`:
 
 ```yaml
 btagging:
   working_point:
     "2024":
       btagging_algorithm: btagUParTAK4B   # <- tagger used to build the b-tag cut
-      btagging_WP:
-        L: 0.0246                         # <- default threshold (loose WP)
-        M: 0.1272
-        T: 0.4648
 ```
+
+The WP score itself is looked up in the BTV file under the `<tagger>_wp_values` correction (e.g. `particleNet_wp_values`, `deepJet_wp_values`), evaluated with the working-point name — see `get_btag_wp_score` in `pocket_coffea/lib/jets.py`.
 
 The merge uses the same `merge_regressed_jets` helper, with fallback chains ending on the JEC-only jets. The b-tag cut is set with three arguments, so the user chooses **which discriminant** to cut on and **where**:
 
 * `btag_algorithm` — discriminant (jet field) to cut on, e.g. `"btagPNetB"`. Defaults to the `btagging_algorithm` of the parameters.
-* `btag_wp` — working-point name (`"L"`, `"M"`, `"T"`…), threshold read from the parameters. Defaults to `"L"`. Mutually exclusive with `btag_score`.
+* `btag_wp` — working-point name (`"L"`, `"M"`, `"T"`…), score read from the BTV `correctionlib` file. Defaults to `"L"`. Mutually exclusive with `btag_score`.
 * `btag_score` — a raw discriminant value used directly as the threshold.
 
-Both the flat and nested-by-tagger `btagging_WP` layouts are supported. Using it in `apply_object_preselection`:
+Using it in `apply_object_preselection`:
 
 ```python
 from pocket_coffea.lib.jets import merge_regressed_jets

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1245,10 +1245,13 @@ jets_calibration:
 
 ```
 
-The merging of the two jet collections should be done in the user's workflow, e.g. in the `apply_object_preselection` section:
+The merging is done in the user's workflow (e.g. in `apply_object_preselection`) with the `merge_regressed_jets` helper (in `pocket_coffea.lib.jets`). Its arguments `jets_high_btag` and `jets_low_btag` are the collections used for jets passing / failing a b-tag cut; **each may be a single collection or an ordered fallback chain**, in which the first collection with a valid regression (`pt > 0`) is used per jet and the last one is the unconditional fallback (usually the standard JEC jets). Taking whole collections keeps every pt-dependent field (pt, mass, variations) consistent. If `jets_low_btag` is omitted, no b-tag cut is applied.
+
+The simplest case — regressed jet where valid, else the standard JEC jet — is a single fallback chain with no b-tag cut:
 
 ```python
 from pocket_coffea.workflows.base import BaseProcessorABC
+from pocket_coffea.lib.jets import merge_regressed_jets
 
 
 class PtRegrProcessor(BaseProcessorABC):
@@ -1261,14 +1264,22 @@ class PtRegrProcessor(BaseProcessorABC):
         #self.events["JetPtRegPlusNeutrino"] = ak.copy(self.events["Jet"])
 
     def apply_object_preselection(self, variation):
-        # Use the regressed jet from PNet collection if available,
-        # otherwise use the standard, JEC corrected collection.
-        # This way we consider correctly all fields which change depending on
-        # the pt definition, namely the pt, mass and the associated systematic variations:
-        self.events["Jet"] = ak.where(
-            self.events["JetPtReg"].pt > 0,
-            self.events["JetPtReg"],
-            self.events.Jet,
+        # Use the regressed jet where the regression is valid, otherwise the
+        # standard, JEC-corrected collection.
+        self.events["Jet"] = merge_regressed_jets(
+            [self.events["JetPtReg"], self.events["Jet"]],
+        )
+```
+
+Passing `jets_low_btag` and a b-tag cut makes high-b-tag jets always use the regression, even where its pt is invalid (the "second" approach of HIG24-010). The cut is set with `btag_algorithm`, `btag_wp` and `btag_score` (see the next section), defaulting to the loose WP of the tagger from the parameters:
+
+```python
+    def apply_object_preselection(self, variation):
+        self.events["Jet"] = merge_regressed_jets(
+            jets_high_btag=self.events["JetPtReg"],                    # high b-tag: always regressed
+            jets_low_btag=[self.events["JetPtReg"], self.events["Jet"]],  # else: regressed if valid
+            params=self.params,
+            year=self._year,
         )
 ```
 
@@ -1279,6 +1290,68 @@ In order to merge the variations of the `Jet` and `JetPtReg` collections, you ne
 :::{warning}
 When merging the collections like this, make sure to set the `sort_by_pt` option to `False` for the jet type in the jets calibration configuration, otherwise the jet ordering will be changed and the merging will fail.
 :::
+
+#### Apply the regression with neutrinos only to high b-tag jets
+Two versions of the PNet/UParT regression are available, *with* and *without* neutrinos. The one with neutrinos recovers the energy of neutrinos from semileptonic heavy-flavour decays, so it mostly helps b (and c) jets while it is not motivated for light jets. A natural choice is therefore the regression **with neutrinos for high-b-tag jets** and **without neutrinos for the rest**.
+
+The split is done **in the workflow** from three collections (standard JEC, plain regression, regression + neutrinos), created in `process_extra_after_skim` and calibrated independently:
+
+```python
+def process_extra_after_skim(self):
+    self.events["JetDefault"] = ak.copy(self.events["Jet"])            # JEC only
+    self.events["JetPNet"] = ak.copy(self.events["Jet"])              # regression, no neutrinos
+    self.events["JetPNetPlusNeutrino"] = ak.copy(self.events["Jet"])  # regression + neutrinos
+```
+
+with the matching `jets_calibration` entries (`AK4PFPuppiPNetRegression` -> `JetPNet` and `AK4PFPuppiPNetRegressionPlusNeutrino` -> `JetPNetPlusNeutrino`, both with `apply_pt_regr_*: True`).
+
+The **threshold defaults to the loose (`L`) working point of the tagger used**, read (not hard-coded) from the b-tagging parameters (`pocket_coffea/parameters/btagging.yaml`, overridable by the analysis) via the `btagging_algorithm` and `btagging_WP` fields:
+
+```yaml
+btagging:
+  working_point:
+    "2024":
+      btagging_algorithm: btagUParTAK4B   # <- tagger used to build the b-tag cut
+      btagging_WP:
+        L: 0.0246                         # <- default threshold (loose WP)
+        M: 0.1272
+        T: 0.4648
+```
+
+The merge uses the same `merge_regressed_jets` helper, with fallback chains ending on the JEC-only jets. The b-tag cut is set with three arguments, so the user chooses **which discriminant** to cut on and **where**:
+
+* `btag_algorithm` — discriminant (jet field) to cut on, e.g. `"btagPNetB"`. Defaults to the `btagging_algorithm` of the parameters.
+* `btag_wp` — working-point name (`"L"`, `"M"`, `"T"`…), threshold read from the parameters. Defaults to `"L"`. Mutually exclusive with `btag_score`.
+* `btag_score` — a raw discriminant value used directly as the threshold.
+
+Both the flat and nested-by-tagger `btagging_WP` layouts are supported. Using it in `apply_object_preselection`:
+
+```python
+from pocket_coffea.lib.jets import merge_regressed_jets
+
+
+def apply_object_preselection(self, variation):
+    # high b-tag -> +neutrino regression; rest -> plain regression;
+    # each falls back to the JEC-only jets where a regression is invalid
+    self.events["Jet"] = merge_regressed_jets(
+        # +neutrino -> plain -> JEC-only fallback chain
+        jets_high_btag=[
+            self.events["JetPNetPlusNeutrino"],
+            self.events["JetPNet"],
+            self.events["JetDefault"],
+        ],
+        # plain -> JEC-only fallback chain
+        jets_low_btag=[self.events["JetPNet"], self.events["JetDefault"]],
+        params=self.params,
+        year=self._year,
+        # defaults to the loose WP of the tagger from the parameters; override with
+        # e.g. btag_algorithm="btagPNetB", btag_wp="M" (or btag_score=0.5)
+    )
+```
+
+A ready-to-use implementation is available in the HH4b analysis of `AnalysisConfigs` (`configs/HH4b_common/workflow_common.py`), where the helper is exposed through the `neutrino_regression_btag_cut` workflow option (`None` disables the feature and keeps the standard approach; `True` uses the loose WP, a WP name selects `btag_wp`, and a `float` selects `btag_score`).
+
+The same [warnings](#merge-regressed-and-standard-jet-pt) about `merge_collections_for_variations` and `sort_by_pt` apply when merging the collections this way.
 
 
 ## Create a custom executor to use `onnxruntime`

--- a/pocket_coffea/lib/cut_functions.py
+++ b/pocket_coffea/lib/cut_functions.py
@@ -335,6 +335,9 @@ def nBtagMin(events, params, year, processor_params, **kwargs):
     '''Mask for min N jets with minpt and passing btagging.
     The btag params will come from the processor, not from the parameters
     '''
+    # Local import to avoid the circular import chain
+    # configurator -> cuts -> cut_functions -> jets -> utils -> configurator
+    from .jets import get_btag_wp_threshold
     if params["coll"] == "BJetGood":
         # No need to apply the btaggin on the jet
         # Assume that the collection of clean bjets has been created
@@ -351,7 +354,7 @@ def nBtagMin(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"][params["wp"]]
+                        > get_btag_wp_threshold(btagparam, params["wp"])
                     )
                     & (events[params["coll"]].pt >= params["minpt"]),
                     axis=1,
@@ -363,7 +366,7 @@ def nBtagMin(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"][params["wp"]]
+                        > get_btag_wp_threshold(btagparam, params["wp"])
                     ),
                     axis=1,
                 )
@@ -375,6 +378,9 @@ def nBtagEq(events, params, year, processor_params, **kwargs):
     '''Mask for == N jets with minpt and passing btagging.
     The btag params will come from the processor, not from the parameters
     '''
+    # Local import to avoid the circular import chain
+    # configurator -> cuts -> cut_functions -> jets -> utils -> configurator
+    from .jets import get_btag_wp_threshold
     if params["coll"] == "BJetGood":
         # No need to apply the btaggin on the jet
         # Assume that the collection of clean bjets has been created
@@ -391,7 +397,7 @@ def nBtagEq(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"][params["wp"]]
+                        > get_btag_wp_threshold(btagparam, params["wp"])
                     )
                     & (events[params["coll"]].pt >= params["minpt"]),
                     axis=1,
@@ -403,7 +409,7 @@ def nBtagEq(events, params, year, processor_params, **kwargs):
                 ak.sum(
                     (
                         events[params["coll"]][btagparam["btagging_algorithm"]]
-                        > btagparam["btagging_WP"][params["wp"]]
+                        > get_btag_wp_threshold(btagparam, params["wp"])
                     ),
                     axis=1,
                 )

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -305,18 +305,6 @@ def btagging(Jet, btag, wp, veto=False):
         return Jet[Jet[tagger] > threshold]
 
 
-# NanoAOD b-tag discriminant branch -> the BTV correctionlib correction that
-# stores its working-point cut values. The BTV ``btagging.json.gz`` for a campaign
-# carries one ``<tagger>_wp_values`` correction per tagger, evaluated with the WP
-# name ("L"/"M"/"T"/...) to return the discriminant cut.
-_BTAG_WP_VALUES_CORRECTION = {
-    "btagDeepFlavB": "deepJet_wp_values",
-    "btagPNetB": "particleNet_wp_values",
-    "btagRobustParTAK4": "robustParticleTransformer_wp_values",
-    "btagUParTAK4": "UParTAK4_wp_values",
-}
-
-
 def get_btag_wp_score(params, year, wp, tagger):
     """Read a b-tag working-point discriminant cut from the BTV correctionlib JSON.
 
@@ -324,7 +312,7 @@ def get_btag_wp_score(params, year, wp, tagger):
     the shape SF (``jet_scale_factors.btagSF.<year>.file``), so the cut applied to
     the jets and the SF applied to them always refer to the same tagger and
     campaign. The BTV file exposes the working-point values under a
-    ``<tagger>_wp_values`` correction (see :data:`_BTAG_WP_VALUES_CORRECTION`).
+    ``<tagger>_wp_values`` correction (see ``btagging.btag_wp_values_correction`` in the parameters YAML).
 
     Args:
         params: PocketCoffea parameters (with the ``jet_scale_factors`` section).
@@ -338,11 +326,12 @@ def get_btag_wp_score(params, year, wp, tagger):
     """
     btagSF = params["jet_scale_factors"]["btagSF"][year]
     cset = load_correction_set(btagSF["file"])
-    corr_name = _BTAG_WP_VALUES_CORRECTION.get(tagger)
+    wp_values_map = params["btagging"]["btag_wp_values_correction"]
+    corr_name = wp_values_map.get(tagger)
     if corr_name is None:
         raise KeyError(
             f"No BTV working-point-values correction is known for tagger '{tagger}'. "
-            f"Known taggers: {sorted(_BTAG_WP_VALUES_CORRECTION)}."
+            f"Known taggers: {sorted(wp_values_map)}."
         )
     if corr_name not in cset:
         raise KeyError(

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -274,11 +274,162 @@ def compute_jetId(events, jet_type, params, year):
         return ak.unflatten(id_value, counts)
 
 
+def get_btag_wp_threshold(btag, wp, tagger=None):
+    """Return the numeric threshold of a working point, resolving the tagger.
+
+    ``btag`` is the per-year b-tagging block ``btagging.working_point.<year>``.
+    Both the flat (``btagging_WP: {L: ...}``) and the nested-by-tagger
+    (``btagging_WP: {<tagger>: {L: ...}}``) layouts are supported.
+
+    Args:
+        btag: the per-year b-tagging parameters block.
+        wp: working-point name (e.g. ``"L"``, ``"M"``, ``"T"``).
+        tagger: b-tag discriminant branch. When ``None`` it is taken from
+            ``btag["btagging_algorithm"]``.
+
+    Returns:
+        float: the discriminant threshold for the working point.
+    """
+    if tagger is None:
+        tagger = btag["btagging_algorithm"]
+    wps = btag["btagging_WP"]
+    return wps[tagger][wp] if tagger in wps else wps[wp]
+
+
 def btagging(Jet, btag, wp, veto=False):
+    tagger = btag["btagging_algorithm"]
+    threshold = get_btag_wp_threshold(btag, wp, tagger)
     if veto:
-        return Jet[Jet[btag["btagging_algorithm"]] < btag["btagging_WP"][wp]]
+        return Jet[Jet[tagger] < threshold]
     else:
-        return Jet[Jet[btag["btagging_algorithm"]] > btag["btagging_WP"][wp]]
+        return Jet[Jet[tagger] > threshold]
+
+
+def get_btag_working_point(params, year, wp="L", tagger=None):
+    """Look up a b-tag discriminant and working-point threshold from parameters.
+
+    Both the flat (``btagging_WP: {L: ...}``) and nested-by-tagger
+    (``btagging_WP: {<tagger>: {L: ...}}``) parameter layouts are supported.
+
+    Args:
+        params: PocketCoffea parameters (must contain the ``btagging`` section).
+        year: data-taking year key used to index the b-tagging parameters.
+        wp: working-point name (e.g. ``"L"``, ``"M"``, ``"T"``); default loose.
+        tagger: b-tag discriminant branch. When ``None`` it is taken from
+            ``btagging.working_point.<year>.btagging_algorithm``.
+
+    Returns:
+        tuple(str, float): the tagger branch and its threshold for the WP.
+    """
+    wp_params = params["btagging"]["working_point"][year]
+    if tagger is None:
+        tagger = wp_params["btagging_algorithm"]
+    return tagger, get_btag_wp_threshold(wp_params, wp, tagger)
+
+
+def _resolve_btag_threshold(
+    params, year, btag_algorithm=None, btag_wp=None, btag_score=None
+):
+    """Resolve the ``(tagger, threshold)`` to cut on.
+
+    Args:
+        params: PocketCoffea parameters (with the ``btagging`` section).
+        year: data-taking year key.
+        btag_algorithm: discriminant branch; defaults to the tagger in params.
+        btag_wp: working-point name; defaults to loose ``"L"``.
+        btag_score: raw threshold value, mutually exclusive with ``btag_wp``.
+
+    Returns:
+        tuple(str, float): the tagger branch and the numeric threshold.
+    """
+    if btag_score is not None:
+        if btag_wp is not None:
+            raise ValueError("Pass only one of `btag_wp` or `btag_score`.")
+        tagger = btag_algorithm
+        if tagger is None:
+            tagger = params["btagging"]["working_point"][year]["btagging_algorithm"]
+        return tagger, btag_score
+    return get_btag_working_point(params, year, btag_wp or "L", btag_algorithm)
+
+
+def _first_valid_jets(collections):
+    """Reduce a fallback chain to one collection, per jet.
+
+    Args:
+        collections: a single jet collection, or an ordered list of them. For
+            each jet the first collection with a valid pT (``pt > 0``) is kept;
+            the last collection is used as the unconditional fallback.
+
+    Returns:
+        The resolved jet collection.
+    """
+    if not isinstance(collections, (list, tuple)):
+        return collections
+    collections = list(collections)
+    result = collections[-1]
+    for jets in reversed(collections[:-1]):
+        result = ak.where(ak.nan_to_num(jets.pt, nan=-1) > 0, jets, result)
+    return result
+
+
+def merge_regressed_jets(
+    jets_high_btag,
+    jets_low_btag=None,
+    params=None,
+    year=None,
+    btag_algorithm=None,
+    btag_wp=None,
+    btag_score=None,
+):
+    """Merge pT-regressed jet collections choosing, per jet, on a b-tag cut.
+
+    Jets with a b-tag discriminant ``>=`` the threshold take ``jets_high_btag``,
+    the others take ``jets_low_btag``. Taking whole collections (not just pT)
+    keeps every pT-dependent field (pt, mass, systematic variations) consistent
+    within a jet.
+
+    Args:
+        jets_high_btag: collection, or ordered fallback chain, for jets passing
+            the b-tag cut. In a chain the first collection with a valid
+            regression (``pt > 0``) is used per jet and the last one is the
+            unconditional fallback (typically the standard JEC-only jets).
+        jets_low_btag: same, for jets failing the cut. If ``None`` no cut is
+            applied and all jets use ``jets_high_btag``.
+        params: PocketCoffea parameters (needed only when a cut is applied).
+        year: data-taking year key (needed only when a cut is applied).
+        btag_algorithm: discriminant branch to cut on (e.g. ``"btagPNetB"``);
+            defaults to the tagger in the b-tagging parameters.
+        btag_wp: working-point name used as threshold; defaults to loose ``"L"``.
+        btag_score: raw threshold value, mutually exclusive with ``btag_wp``.
+
+    Returns:
+        The merged jet collection.
+
+    Examples::
+
+        # use the regression where valid, else the standard jets
+        merge_regressed_jets([jets_reg, jets_std])
+        # as above, but high b-tag jets always use the regression (loose WP)
+        merge_regressed_jets(jets_reg, [jets_reg, jets_std], params, year)
+        # +neutrino regression for high b-tag jets, plain for the rest, medium WP
+        merge_regressed_jets([jets_nu, jets_noNu, jets_std], [jets_noNu, jets_std],
+                             params, year, btag_algorithm="btagPNetB", btag_wp="M")
+    """
+    high = _first_valid_jets(jets_high_btag)
+    if jets_low_btag is None:
+        return high
+    low = _first_valid_jets(jets_low_btag)
+
+    tagger, threshold = _resolve_btag_threshold(
+        params, year, btag_algorithm, btag_wp, btag_score
+    )
+    # the b-tag score is unchanged by the regression -> read it from any candidate
+    ref_jets = (
+        jets_high_btag[0]
+        if isinstance(jets_high_btag, (list, tuple))
+        else jets_high_btag
+    )
+    return ak.where(ref_jets[tagger] >= threshold, high, low)
 
 
 def CvsLsorted(jets,temp=None):    

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -305,26 +305,75 @@ def btagging(Jet, btag, wp, veto=False):
         return Jet[Jet[tagger] > threshold]
 
 
-def get_btag_working_point(params, year, wp="L", tagger=None):
-    """Look up a b-tag discriminant and working-point threshold from parameters.
+# NanoAOD b-tag discriminant branch -> the BTV correctionlib correction that
+# stores its working-point cut values. The BTV ``btagging.json.gz`` for a campaign
+# carries one ``<tagger>_wp_values`` correction per tagger, evaluated with the WP
+# name ("L"/"M"/"T"/...) to return the discriminant cut.
+_BTAG_WP_VALUES_CORRECTION = {
+    "btagDeepFlavB": "deepJet_wp_values",
+    "btagPNetB": "particleNet_wp_values",
+    "btagRobustParTAK4": "robustParticleTransformer_wp_values",
+    "btagUParTAK4": "UParTAK4_wp_values",
+}
 
-    Both the flat (``btagging_WP: {L: ...}``) and nested-by-tagger
-    (``btagging_WP: {<tagger>: {L: ...}}``) parameter layouts are supported.
+
+def get_btag_wp_score(params, year, wp, tagger):
+    """Read a b-tag working-point discriminant cut from the BTV correctionlib JSON.
+
+    The score is taken directly from the same ``btagging.json.gz`` that provides
+    the shape SF (``jet_scale_factors.btagSF.<year>.file``), so the cut applied to
+    the jets and the SF applied to them always refer to the same tagger and
+    campaign. The BTV file exposes the working-point values under a
+    ``<tagger>_wp_values`` correction (see :data:`_BTAG_WP_VALUES_CORRECTION`).
 
     Args:
-        params: PocketCoffea parameters (must contain the ``btagging`` section).
-        year: data-taking year key used to index the b-tagging parameters.
+        params: PocketCoffea parameters (with the ``jet_scale_factors`` section).
+        year: data-taking year key used to index ``jet_scale_factors.btagSF``.
+        wp: working-point name (e.g. ``"L"``, ``"M"``, ``"T"``).
+        tagger: b-tag discriminant branch (e.g. ``"btagPNetB"``), selecting which
+            per-tagger ``_wp_values`` correction to read.
+
+    Returns:
+        float: the discriminant cut value for the working point.
+    """
+    btagSF = params["jet_scale_factors"]["btagSF"][year]
+    cset = load_correction_set(btagSF["file"])
+    corr_name = _BTAG_WP_VALUES_CORRECTION.get(tagger)
+    if corr_name is None:
+        raise KeyError(
+            f"No BTV working-point-values correction is known for tagger '{tagger}'. "
+            f"Known taggers: {sorted(_BTAG_WP_VALUES_CORRECTION)}."
+        )
+    if corr_name not in cset:
+        raise KeyError(
+            f"Correction '{corr_name}' not found in b-tagging file "
+            f"'{btagSF['file']}'. Available corrections: {list(cset)}."
+        )
+    return float(cset[corr_name].evaluate(wp))
+
+
+def get_btag_working_point(params, year, wp="L", tagger=None):
+    """Resolve the b-tag discriminant branch and its working-point cut.
+
+    The discriminant branch (what to cut on) comes from the ``btagging``
+    parameters, while the cut value is read directly from the BTV correctionlib
+    JSON via :func:`get_btag_wp_score`, so it always matches the tagger and
+    campaign used for the shape SF.
+
+    Args:
+        params: PocketCoffea parameters (``btagging`` and ``jet_scale_factors``).
+        year: data-taking year key used to index the parameters.
         wp: working-point name (e.g. ``"L"``, ``"M"``, ``"T"``); default loose.
         tagger: b-tag discriminant branch. When ``None`` it is taken from
             ``btagging.working_point.<year>.btagging_algorithm``.
 
     Returns:
-        tuple(str, float): the tagger branch and its threshold for the WP.
+        tuple(str, float): the tagger branch and its WP cut value.
     """
     wp_params = params["btagging"]["working_point"][year]
     if tagger is None:
         tagger = wp_params["btagging_algorithm"]
-    return tagger, get_btag_wp_threshold(wp_params, wp, tagger)
+    return tagger, get_btag_wp_score(params, year, wp, tagger)
 
 
 def _resolve_btag_threshold(

--- a/pocket_coffea/lib/jets.py
+++ b/pocket_coffea/lib/jets.py
@@ -312,7 +312,7 @@ def get_btag_wp_score(params, year, wp, tagger):
     the shape SF (``jet_scale_factors.btagSF.<year>.file``), so the cut applied to
     the jets and the SF applied to them always refer to the same tagger and
     campaign. The BTV file exposes the working-point values under a
-    ``<tagger>_wp_values`` correction (see ``btagging.btag_wp_values_correction`` in the parameters YAML).
+    ``<tagger>_wp_values`` correction (see ``btagging.btag_wp_values_map`` in the parameters YAML).
 
     Args:
         params: PocketCoffea parameters (with the ``jet_scale_factors`` section).
@@ -326,7 +326,7 @@ def get_btag_wp_score(params, year, wp, tagger):
     """
     btagSF = params["jet_scale_factors"]["btagSF"][year]
     cset = load_correction_set(btagSF["file"])
-    wp_values_map = params["btagging"]["btag_wp_values_correction"]
+    wp_values_map = params["btagging"]["btag_wp_values_map"]
     corr_name = wp_values_map.get(tagger)
     if corr_name is None:
         raise KeyError(

--- a/pocket_coffea/parameters/btagging.yaml
+++ b/pocket_coffea/parameters/btagging.yaml
@@ -70,13 +70,28 @@ btagging:
     '2022_preEE':
       reference:
         btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer22/#ak4-b-tagging
-      btagging_algorithm: btagDeepFlavB
+      btagging_algorithm: btagPNetB
+      # Working points are indexed per tagger: select the discriminant via
+      # `btagging_algorithm` (or explicitly) and look it up under btagging_WP.
       btagging_WP:
-        L: 0.0583
-        M: 0.3086
-        T: 0.7183
-        XT: 0.8111
-        XXT: 0.9512
+        btagDeepFlavB:
+          L: 0.0583
+          M: 0.3086
+          T: 0.7183
+          XT: 0.8111
+          XXT: 0.9512
+        btagPNetB:
+          L: 0.047
+          M: 0.245
+          T: 0.6734
+          XT: 0.7862
+          XXT: 0.961
+        btagRobustParTAK4B:
+          L: 0.0849
+          M: 0.4319
+          T: 0.8482
+          XT: 0.9151
+          XXT: 0.9874
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81
@@ -88,13 +103,31 @@ btagging:
     '2022_postEE':
       reference:
         btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer22EE/
-      btagging_algorithm: btagDeepFlavB
+      btagging_algorithm: btagPNetB
+      # Working points are indexed per tagger.
       btagging_WP:
-        L: 0.0614
-        M: 0.3196
-        T: 0.7300
-        XT: 0.8184
-        XXT: 0.9542
+        btagDeepFlavB:
+          L: 0.0614
+          M: 0.3196
+          T: 0.7300
+          XT: 0.8184
+          XXT: 0.9542
+        btagPNetB:
+          L: 0.0499
+          M: 0.2605
+          T: 0.6915
+          XT: 0.8033
+          XXT: 0.9664
+        btagRobustParTAK4B:
+          L: 0.0897
+          M: 0.451
+          T: 0.8604
+          XT: 0.9234
+          XXT: 0.9893
+        btagBB:
+          MP: 0.95
+          HP: 0.975
+          VHP: 0.99
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81
@@ -106,13 +139,27 @@ btagging:
     '2023_preBPix':
       reference:
         btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer23/
-      btagging_algorithm: btagDeepFlavB
+      btagging_algorithm: btagPNetB
+      # Working points are indexed per tagger.
       btagging_WP:
-        L: 0.0479
-        M: 0.2431
-        T: 0.6553
-        XT: 0.7667
-        XXT: 0.9459
+        btagDeepFlavB:
+          L: 0.0479
+          M: 0.2431
+          T: 0.6553
+          XT: 0.7667
+          XXT: 0.9459
+        btagPNetB:
+          L: 0.0358
+          M: 0.1917
+          T: 0.6172
+          XT: 0.7515
+          XXT: 0.9659
+        btagRobustParTAK4B:
+          L: 0.0681
+          M: 0.3487
+          T: 0.7969
+          XT: 0.8882
+          XXT: 0.9883
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81
@@ -124,13 +171,27 @@ btagging:
     '2023_postBPix':
       reference:
         btagging_WP: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer23BPix/
-      btagging_algorithm: btagDeepFlavB
+      btagging_algorithm: btagPNetB
+      # Working points are indexed per tagger.
       btagging_WP:
-        L: 0.048
-        M: 0.2435
-        T: 0.6563
-        XT: 0.7671
-        XXT: 0.9483
+        btagDeepFlavB:
+          L: 0.048
+          M: 0.2435
+          T: 0.6563
+          XT: 0.7671
+          XXT: 0.9483
+        btagPNetB:
+          L: 0.0359
+          M: 0.1919
+          T: 0.6133
+          XT: 0.7544
+          XXT: 0.9688
+        btagRobustParTAK4B:
+          L: 0.0683
+          M: 0.3494
+          T: 0.7994
+          XT: 0.8877
+          XXT: 0.9883
       bbtagging_algorithm: btagDDBvL
       bbtagging_WP: 0.86
       bbtagSF_DDBvL_M1_loPt: 0.81

--- a/pocket_coffea/parameters/btagging.yaml
+++ b/pocket_coffea/parameters/btagging.yaml
@@ -220,3 +220,10 @@ btagging:
         T: 0.4648
         XT: 0.6298
         XXT: 0.9739
+  # Map NanoAOD b-tag discriminant branch -> BTV correctionlib correction name that
+  # stores its working-point cut values (evaluated with WP name "L"/"M"/"T"/...).
+  btag_wp_values_correction:
+    btagDeepFlavB: deepJet_wp_values
+    btagPNetB: particleNet_wp_values
+    btagRobustParTAK4B: robustParticleTransformer_wp_values
+    btagUParTAK4B: UParTAK4_wp_values

--- a/pocket_coffea/parameters/btagging.yaml
+++ b/pocket_coffea/parameters/btagging.yaml
@@ -222,7 +222,7 @@ btagging:
         XXT: 0.9739
   # Map NanoAOD b-tag discriminant branch -> BTV correctionlib correction name that
   # stores its working-point cut values (evaluated with WP name "L"/"M"/"T"/...).
-  btag_wp_values_correction:
+  btag_wp_values_map:
     btagDeepFlavB: deepJet_wp_values
     btagPNetB: particleNet_wp_values
     btagRobustParTAK4B: robustParticleTransformer_wp_values

--- a/pocket_coffea/parameters/jet_scale_factors.yaml
+++ b/pocket_coffea/parameters/jet_scale_factors.yaml
@@ -25,18 +25,20 @@ jet_scale_factors:
         '2018':
             file: ${cvmfs:Run2-2018-UL-NanoAODv9,BTV,btagging.json.gz,2025-08-19}
             name: "deepJet_shape"
+        # Run3 default b-tagger is btagPNetB (see btagging.yaml), so the shape SF
+        # must be the matching ParticleNet one, evaluated on the same discriminant.
         '2022_preEE':
             file: ${cvmfs:Run3-22CDSep23-Summer22-NanoAODv12,BTV,btagging.json.gz,2025-08-20}
-            name: "deepJet_shape"
+            name: "particleNet_shape"
         '2022_postEE':
             file: ${cvmfs:Run3-22EFGSep23-Summer22EE-NanoAODv12,BTV,btagging.json.gz,2025-08-20}
-            name: "deepJet_shape"
+            name: "particleNet_shape"
         '2023_preBPix':
             file: ${cvmfs:Run3-23CSep23-Summer23-NanoAODv12,BTV,btagging.json.gz,2025-08-20}
-            name: "deepJet_shape"
+            name: "particleNet_shape"
         '2023_postBPix':
             file: ${cvmfs:Run3-23DSep23-Summer23BPix-NanoAODv12,BTV,btagging.json.gz,2025-08-20}
-            name: "deepJet_shape"
+            name: "particleNet_shape"
         '2024': 
             file: ${cvmfs:Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15,BTV,btagging.json.gz,2026-03-10}
             name: "UParTAK4"

--- a/tests/test_merge_regressed_jets.py
+++ b/tests/test_merge_regressed_jets.py
@@ -1,0 +1,291 @@
+"""Unit tests for the jet pT-regression merging helper.
+
+These mirror the pT-regression workflow check
+(``test_full_configs/test_shape_variations/workflow_ptregr_check.py``), which
+builds extra ``JetPtReg`` / ``JetPtRegPlusNeutrino`` collections from the ``Jet``
+collection. Here we build small synthetic collections and validate that
+``merge_regressed_jets`` combines them correctly. The b-tag cut is exercised in
+all its configurations: no algorithm/WP given (default loose WP), a different
+algorithm, a different WP, a manual raw-score cut, and no cut at all (plain
+merge of regressed and non-regressed jets).
+"""
+
+import awkward as ak
+import numpy as np
+import pytest
+
+from pocket_coffea.lib.jets import (
+    get_btag_working_point,
+    merge_regressed_jets,
+    _resolve_btag_threshold,
+)
+
+# Minimal b-tagging parameters, in the two layouts supported by the helper.
+# flat: btagging_WP: {L: ...}          (older-year layout, e.g. Run2)
+FLAT_PARAMS = {
+    "btagging": {
+        "working_point": {
+            "2018": {
+                "btagging_algorithm": "btagDeepFlavB",
+                "btagging_WP": {"L": 0.05, "M": 0.3, "T": 0.7},
+            }
+        }
+    }
+}
+# nested-by-tagger: btagging_WP: {<tagger>: {L: ...}}
+NESTED_PARAMS = {
+    "btagging": {
+        "working_point": {
+            "2022_postEE": {
+                "btagging_algorithm": "btagPNetB",
+                "btagging_WP": {"btagPNetB": {"L": 0.05, "M": 0.3, "T": 0.7}},
+            }
+        }
+    }
+}
+# two taggers available, default is btagPNetB; used to check that overriding the
+# algorithm actually switches which discriminant the cut is applied to.
+MULTI_PARAMS = {
+    "btagging": {
+        "working_point": {
+            "2022_postEE": {
+                "btagging_algorithm": "btagPNetB",
+                "btagging_WP": {
+                    "btagPNetB": {"L": 0.05, "M": 0.3},
+                    "btagDeepFlavB": {"L": 0.05, "M": 0.3},
+                },
+            }
+        }
+    }
+}
+
+
+def _make_jets(pt_rows, btag_rows, src, algo):
+    """Build a jagged jet collection tagging each jet with its origin (``src``).
+
+    ``pt_rows``/``btag_rows`` are lists of lists (one inner list per event). A
+    jet is "invalid" (regression failed) when its pt is <= 0.
+    """
+    return ak.Array(
+        [
+            [
+                {"pt": float(p), "mass": float(p), algo: float(b), "src": src}
+                for p, b in zip(pts, btags)
+            ]
+            for pts, btags in zip(pt_rows, btag_rows)
+        ]
+    )
+
+
+# Two events; second event has a single jet. b-tag scores straddle the loose WP
+# (0.05): jets 0 and 2 are "high b-tag", jet 1 and the last-event jet are low.
+BTAG = [[0.9, 0.01, 0.3], [0.02]]
+# standard JEC jets: always valid
+STD = _make_jets([[10.0, 10.0, 10.0], [10.0]], BTAG, src=0, algo="btagDeepFlavB")
+# regression without neutrinos: jet 1 and the last-event jet are invalid
+NONU = _make_jets([[11.0, -1.0, 11.0], [-1.0]], BTAG, src=1, algo="btagDeepFlavB")
+# regression with neutrinos: jets 1 and 2 invalid
+NU = _make_jets([[12.0, -1.0, -1.0], [12.0]], BTAG, src=2, algo="btagDeepFlavB")
+
+
+def _make_jets_2tag(pt_rows, pnet_rows, deepjet_rows, src):
+    """Jets carrying two b-tag discriminants (btagPNetB, btagDeepFlavB)."""
+    return ak.Array(
+        [
+            [
+                {
+                    "pt": float(p),
+                    "mass": float(p),
+                    "btagPNetB": float(a),
+                    "btagDeepFlavB": float(b),
+                    "src": src,
+                }
+                for p, a, b in zip(pts, pnet, deep)
+            ]
+            for pts, pnet, deep in zip(pt_rows, pnet_rows, deepjet_rows)
+        ]
+    )
+
+
+def _src(jets):
+    return jets["src"].tolist()
+
+
+# --- reference implementations (the behaviour the helper must reproduce) -------
+def _ref_first(std, reg):
+    return ak.where(ak.nan_to_num(reg.pt, nan=-1) > 0, reg, std)
+
+
+def _ref_second(std, reg, thr, tagger):
+    return ak.where(
+        (ak.nan_to_num(reg.pt, nan=-1) > 0) | (reg[tagger] >= thr), reg, std
+    )
+
+
+def _ref_neutrino_split(nonu, nu, default, thr, tagger):
+    high = nonu[tagger] >= thr
+    nu_valid = ak.nan_to_num(nu.pt, nan=-1) > 0
+    plain_valid = ak.nan_to_num(nonu.pt, nan=-1) > 0
+    low = ak.where(plain_valid, nonu, default)
+    return ak.where(high & nu_valid, nu, low)
+
+
+def test_get_btag_working_point_flat_and_nested():
+    # flat layout: tagger taken from btagging_algorithm, WP read directly
+    assert get_btag_working_point(FLAT_PARAMS, "2018") == ("btagDeepFlavB", 0.05)
+    assert get_btag_working_point(FLAT_PARAMS, "2018", "M") == ("btagDeepFlavB", 0.3)
+    # nested layout: WP read from the per-tagger sub-dict
+    assert get_btag_working_point(NESTED_PARAMS, "2022_postEE") == ("btagPNetB", 0.05)
+    assert get_btag_working_point(NESTED_PARAMS, "2022_postEE", "T") == (
+        "btagPNetB",
+        0.7,
+    )
+
+
+def test_resolve_btag_threshold_score_and_wp():
+    # explicit raw score keeps the tagger from parameters
+    assert _resolve_btag_threshold(FLAT_PARAMS, "2018", btag_score=0.42) == (
+        "btagDeepFlavB",
+        0.42,
+    )
+    # working point resolves to its numeric threshold
+    assert _resolve_btag_threshold(FLAT_PARAMS, "2018", btag_wp="M") == (
+        "btagDeepFlavB",
+        0.3,
+    )
+    # algorithm override is respected
+    tagger, _ = _resolve_btag_threshold(
+        NESTED_PARAMS, "2022_postEE", btag_algorithm="btagPNetB", btag_wp="L"
+    )
+    assert tagger == "btagPNetB"
+
+
+def test_merge_no_btag_cut_uses_regression_where_valid():
+    # single fallback chain, no b-tag cut: regressed jet where valid, else standard
+    out = merge_regressed_jets([NONU, STD])
+    assert _src(out) == _src(_ref_first(STD, NONU))
+    assert _src(out) == [[1, 0, 1], [0]]  # jet 1 / last-event jet fall back to std
+
+
+def test_merge_second_approach_high_btag_forced():
+    # high b-tag jets always take the regression (even if invalid pt), the rest
+    # take the regression where valid, else standard. threshold = loose WP.
+    out = merge_regressed_jets(NONU, [NONU, STD], FLAT_PARAMS, "2018")
+    ref = _ref_second(STD, NONU, 0.05, "btagDeepFlavB")
+    assert _src(out) == _src(ref)
+    # jet 2 is high b-tag but its regression is invalid -> still regressed (src 1)
+    assert _src(out) == [[1, 0, 1], [0]]
+
+
+def test_merge_neutrino_split_by_btag():
+    # +neutrino regression for high b-tag jets, plain regression for the rest,
+    # each with a fallback chain ending on the standard jets.
+    out = merge_regressed_jets(
+        [NU, NONU, STD],
+        [NONU, STD],
+        params=FLAT_PARAMS,
+        year="2018",
+    )
+    ref = _ref_neutrino_split(NONU, NU, STD, 0.05, "btagDeepFlavB")
+    assert _src(out) == _src(ref)
+    # event 0: jet0 high+nu-valid -> nu(2); jet1 low, nonu invalid -> std(0);
+    #          jet2 high, nu invalid, nonu valid -> nonu(1)
+    # event 1: jet low, nonu invalid -> std(0)
+    assert _src(out) == [[2, 0, 1], [0]]
+
+
+# --- the five configuration cases requested for the b-tag cut -----------------
+def test_case_no_algorithm_or_wp_defined_uses_default_loose_wp():
+    # Case: user defines neither the b-tag algorithm nor the WP.
+    # -> tagger comes from btagging_algorithm, threshold is the loose ("L") WP.
+    assert _resolve_btag_threshold(FLAT_PARAMS, "2018") == ("btagDeepFlavB", 0.05)
+    assert _resolve_btag_threshold(NESTED_PARAMS, "2022_postEE") == ("btagPNetB", 0.05)
+    # and the merge with no algo/wp given matches an explicit loose-WP cut
+    default = merge_regressed_jets(NONU, [NONU, STD], FLAT_PARAMS, "2018")
+    explicit_L = merge_regressed_jets(NONU, [NONU, STD], FLAT_PARAMS, "2018", btag_wp="L")
+    assert _src(default) == _src(explicit_L)
+
+
+def test_case_different_btag_algorithm():
+    # Case: user picks a b-tag algorithm different from the parameters' default.
+    # The jet is high on btagPNetB (0.9) but low on btagDeepFlavB (0.01); its
+    # regression is invalid, so it is only kept (forced) when it counts as high.
+    std = _make_jets_2tag([[10.0]], [[0.9]], [[0.01]], src=0)
+    reg = _make_jets_2tag([[-1.0]], [[0.9]], [[0.01]], src=1)
+    # default algorithm (btagPNetB): high b-tag -> forced regressed
+    out_default = merge_regressed_jets(reg, [reg, std], MULTI_PARAMS, "2022_postEE")
+    assert _src(out_default) == [[1]]
+    # override to btagDeepFlavB: now low b-tag, regression invalid -> standard
+    out_deepjet = merge_regressed_jets(
+        reg, [reg, std], MULTI_PARAMS, "2022_postEE", btag_algorithm="btagDeepFlavB"
+    )
+    assert _src(out_deepjet) == [[0]]
+
+
+def test_case_different_btag_wp():
+    # Case: user picks a WP different from the default loose one. A jet with
+    # discriminant 0.2 is high under L (0.05) but low under M (0.3).
+    std = _make_jets([[10.0]], [[0.2]], src=0, algo="btagDeepFlavB")
+    reg = _make_jets([[-1.0]], [[0.2]], src=1, algo="btagDeepFlavB")  # invalid regr.
+    out_L = merge_regressed_jets(reg, [reg, std], FLAT_PARAMS, "2018", btag_wp="L")
+    out_M = merge_regressed_jets(reg, [reg, std], FLAT_PARAMS, "2018", btag_wp="M")
+    assert _src(out_L) == [[1]]  # high under loose -> forced regressed
+    assert _src(out_M) == [[0]]  # low under medium -> standard
+
+
+def test_case_manual_btag_score_cut():
+    # Case: user passes a raw b-tag discriminant threshold. Jet discriminant 0.2.
+    std = _make_jets([[10.0]], [[0.2]], src=0, algo="btagDeepFlavB")
+    reg = _make_jets([[-1.0]], [[0.2]], src=1, algo="btagDeepFlavB")  # invalid regr.
+    below = merge_regressed_jets(reg, [reg, std], FLAT_PARAMS, "2018", btag_score=0.1)
+    above = merge_regressed_jets(reg, [reg, std], FLAT_PARAMS, "2018", btag_score=0.3)
+    assert _src(below) == [[1]]  # 0.2 >= 0.1 -> high -> forced regressed
+    assert _src(above) == [[0]]  # 0.2 <  0.3 -> low  -> standard
+
+
+def test_case_no_btag_cut_just_merges_regressed_and_standard():
+    # Case: no b-tag cut requested (jets_low_btag omitted): simply merge the
+    # regressed jets with the non-regressed ones, using the regression where valid.
+    out = merge_regressed_jets([NONU, STD])
+    assert _src(out) == _src(_ref_first(STD, NONU))
+    assert _src(out) == [[1, 0, 1], [0]]
+
+
+def test_wp_and_equivalent_score_agree():
+    out_wp = merge_regressed_jets(NONU, [NONU, STD], FLAT_PARAMS, "2018", btag_wp="M")
+    out_score = merge_regressed_jets(
+        NONU, [NONU, STD], FLAT_PARAMS, "2018", btag_score=0.3
+    )
+    assert _src(out_wp) == _src(out_score)
+
+
+def test_nested_layout_and_algorithm_override():
+    nonu = _make_jets([[11.0, -1.0], [11.0]], [[0.9, 0.01], [0.02]], 1, "btagPNetB")
+    std = _make_jets([[10.0, 10.0], [10.0]], [[0.9, 0.01], [0.02]], 0, "btagPNetB")
+    out = merge_regressed_jets(
+        nonu,
+        [nonu, std],
+        params=NESTED_PARAMS,
+        year="2022_postEE",
+        btag_algorithm="btagPNetB",
+        btag_wp="L",
+    )
+    ref = _ref_second(std, nonu, 0.05, "btagPNetB")
+    assert _src(out) == _src(ref)
+
+
+def test_btag_wp_and_score_are_mutually_exclusive():
+    with pytest.raises(ValueError):
+        merge_regressed_jets(
+            NONU, [NONU, STD], FLAT_PARAMS, "2018", btag_wp="M", btag_score=0.3
+        )
+
+
+def test_merged_pt_is_taken_from_selected_collection():
+    # sanity check that whole records (not only src) are picked consistently
+    out = merge_regressed_jets([NONU, STD])
+    pt = ak.to_numpy(ak.flatten(out.pt))
+    src = ak.to_numpy(ak.flatten(out["src"]))
+    # regressed jets keep pt 11, jets falling back to standard keep pt 10
+    assert np.all(pt[src == 1] == 11.0)
+    assert np.all(pt[src == 0] == 10.0)

--- a/tests/test_merge_regressed_jets.py
+++ b/tests/test_merge_regressed_jets.py
@@ -10,53 +10,99 @@ algorithm, a different WP, a manual raw-score cut, and no cut at all (plain
 merge of regressed and non-regressed jets).
 """
 
+import pathlib
+import tempfile
+
 import awkward as ak
 import numpy as np
 import pytest
 
+import correctionlib.schemav2 as cs
+
 from pocket_coffea.lib.jets import (
     get_btag_working_point,
+    get_btag_wp_score,
     merge_regressed_jets,
     _resolve_btag_threshold,
 )
 
-# Minimal b-tagging parameters, in the two layouts supported by the helper.
-# flat: btagging_WP: {L: ...}          (older-year layout, e.g. Run2)
+
+def _write_btag_wp_file(directory):
+    """Write a stand-in BTV ``btagging.json.gz``-style correctionlib file.
+
+    Like the real BTV files, it carries one ``<tagger>_wp_values`` correction per
+    tagger, mapping the working-point name to its discriminant cut. The values
+    mirror the previously hard-coded WPs so the assertions stay stable.
+    """
+
+    def _wp_values(name):
+        return cs.Correction(
+            name=name,
+            version=1,
+            inputs=[cs.Variable(name="working_point", type="string")],
+            output=cs.Variable(name="value", type="real"),
+            data=cs.Category(
+                nodetype="category",
+                input="working_point",
+                content=[
+                    cs.CategoryItem(key="L", value=0.05),
+                    cs.CategoryItem(key="M", value=0.3),
+                    cs.CategoryItem(key="T", value=0.7),
+                ],
+            ),
+        )
+
+    cset = cs.CorrectionSet(
+        schema_version=2,
+        corrections=[
+            _wp_values("deepJet_wp_values"),
+            _wp_values("particleNet_wp_values"),
+        ],
+    )
+    path = str(pathlib.Path(directory) / "btagging_wp_values.json")
+    with open(path, "w") as fh:
+        fh.write(cset.model_dump_json(exclude_unset=True))
+    return path
+
+
+# The b-tag WP cuts are read from this stand-in correctionlib file (as they are
+# from the cvmfs BTV JSON in production). Created once at import time so the
+# module-level parameter sets below can reference it.
+BTAG_FILE = _write_btag_wp_file(tempfile.mkdtemp(prefix="pc_btag_wp_"))
+
+# Minimal parameters. `btagging` selects the discriminant branch to cut on;
+# `jet_scale_factors.btagSF` points at the BTV file the WP score is read from.
 FLAT_PARAMS = {
     "btagging": {
         "working_point": {
-            "2018": {
-                "btagging_algorithm": "btagDeepFlavB",
-                "btagging_WP": {"L": 0.05, "M": 0.3, "T": 0.7},
-            }
+            "2018": {"btagging_algorithm": "btagDeepFlavB"},
         }
-    }
+    },
+    "jet_scale_factors": {
+        "btagSF": {"2018": {"file": BTAG_FILE, "name": "deepJet_shape"}}
+    },
 }
-# nested-by-tagger: btagging_WP: {<tagger>: {L: ...}}
 NESTED_PARAMS = {
     "btagging": {
         "working_point": {
-            "2022_postEE": {
-                "btagging_algorithm": "btagPNetB",
-                "btagging_WP": {"btagPNetB": {"L": 0.05, "M": 0.3, "T": 0.7}},
-            }
+            "2022_postEE": {"btagging_algorithm": "btagPNetB"},
         }
-    }
+    },
+    "jet_scale_factors": {
+        "btagSF": {"2022_postEE": {"file": BTAG_FILE, "name": "particleNet_shape"}}
+    },
 }
-# two taggers available, default is btagPNetB; used to check that overriding the
-# algorithm actually switches which discriminant the cut is applied to.
+# default tagger is btagPNetB; used to check that overriding the algorithm
+# actually switches which discriminant the cut is applied to.
 MULTI_PARAMS = {
     "btagging": {
         "working_point": {
-            "2022_postEE": {
-                "btagging_algorithm": "btagPNetB",
-                "btagging_WP": {
-                    "btagPNetB": {"L": 0.05, "M": 0.3},
-                    "btagDeepFlavB": {"L": 0.05, "M": 0.3},
-                },
-            }
+            "2022_postEE": {"btagging_algorithm": "btagPNetB"},
         }
-    }
+    },
+    "jet_scale_factors": {
+        "btagSF": {"2022_postEE": {"file": BTAG_FILE, "name": "particleNet_shape"}}
+    },
 }
 
 
@@ -130,11 +176,20 @@ def _ref_neutrino_split(nonu, nu, default, thr, tagger):
     return ak.where(high & nu_valid, nu, low)
 
 
-def test_get_btag_working_point_flat_and_nested():
-    # flat layout: tagger taken from btagging_algorithm, WP read directly
+def test_get_btag_wp_score_reads_from_json():
+    # the score comes from the <tagger>_wp_values correction in the BTV file
+    assert get_btag_wp_score(FLAT_PARAMS, "2018", "L", "btagDeepFlavB") == 0.05
+    assert get_btag_wp_score(FLAT_PARAMS, "2018", "M", "btagDeepFlavB") == 0.3
+    assert get_btag_wp_score(NESTED_PARAMS, "2022_postEE", "T", "btagPNetB") == 0.7
+    # an unknown tagger has no mapped correction
+    with pytest.raises(KeyError):
+        get_btag_wp_score(FLAT_PARAMS, "2018", "L", "btagUnknown")
+
+
+def test_get_btag_working_point_resolves_tagger_and_score():
+    # tagger taken from btagging_algorithm, score read from the BTV JSON
     assert get_btag_working_point(FLAT_PARAMS, "2018") == ("btagDeepFlavB", 0.05)
     assert get_btag_working_point(FLAT_PARAMS, "2018", "M") == ("btagDeepFlavB", 0.3)
-    # nested layout: WP read from the per-tagger sub-dict
     assert get_btag_working_point(NESTED_PARAMS, "2022_postEE") == ("btagPNetB", 0.05)
     assert get_btag_working_point(NESTED_PARAMS, "2022_postEE", "T") == (
         "btagPNetB",


### PR DESCRIPTION
## Summary
Adds a reusable helper to combine jet pT regression collections (with and without neutrinos) with the standard JEC jets, choosing per jet on a configurable b-tag cut, plus per-tagger b-tagging working points for Run3.

## Changes
- **`pocket_coffea/lib/jets.py`** — add `merge_regressed_jets` (and supporting helpers) to split the pT regression by b-tag: `+neutrino` regression for high-b-tag jets, plain regression for the rest, falling back to the standard JEC jets. Works with WP names or raw b-tag scores and a selectable tagger.
- **`pocket_coffea/parameters/btagging.yaml`** — per-tagger working points for Run3 (`2022_preEE`…`2023_postBPix`), defaulting to `btagPNetB`; older years unchanged.
- **`pocket_coffea/parameters/jet_scale_factors.yaml`** — match the Run3 default b-tag shape SF to `btagPNetB` (`particleNet_shape`).
- **`pocket_coffea/lib/cut_functions.py`** — route the b-tag WP resolution through the shared helper.
- **`tests/test_merge_regressed_jets.py`** — unit tests covering all b-tag cut configurations.
- **`docs/recipes.md`** — document the b-tag split of the regression with/without neutrinos.
- Fix a `KeyError` in `get_jersmear_SFunc` for JER SFs carrying a systematic input.
