### PR TITLE
Fix skim export robustness in presel_any_variation mode

### DIFF
--- a/pocket_coffea/utils/skim.py
+++ b/pocket_coffea/utils/skim.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import pathlib
 import shutil
 import json
@@ -24,13 +25,20 @@ def uproot_writeable(events):
     out = {}
     for bname in events.fields:
         if events[bname].fields:
-            out[bname] = ak.zip(
-                {
-                    n: ak.packed(ak.without_parameters(events[bname][n]))
-                    for n in events[bname].fields
-                    if is_rootcompat(events[bname][n])
-                }
-            )
+            b = {
+                n: ak.packed(ak.without_parameters(events[bname][n]))
+                for n in events[bname].fields
+                if is_rootcompat(events[bname][n])
+            }
+            if not b:
+                # A collection whose fields are all option/union typed (e.g. a
+                # derived collection built with ak.mask/pad_none/concatenate)
+                # has no ROOT-writable content, and ak.zip({}) raises IndexError.
+                logging.warning(
+                    f"uproot_writeable: skipping branch '{bname}': no ROOT-compatible field"
+                )
+                continue
+            out[bname] = ak.zip(b)
         else:
             out[bname] = ak.packed(ak.without_parameters(events[bname]))
     return out

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 import copy
 import os
 import logging
+import shutil
+import tempfile
 import time
 
 from coffea import processor
@@ -234,12 +236,23 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
             )
             + ".root"
         )
-        with uproot.recreate(f"{filename}", compression=uproot.ZSTD(5)) as fout:
-            fout["Events"] = uproot_writeable(self.events)
-        # copy the file
-        copy_file(
-            filename, "./", self.cfg.save_skimmed_files_folder, subdirs=[self._dataset]
+        # Write the chunk in a temporary working directory instead of the cwd,
+        # which is often on AFS: TMPDIR (or the HTCondor scratch) points to
+        # node-local storage. copy_file deletes the local file after the copy;
+        # the directory itself is cleaned up here, also on failure.
+        tmpdir = tempfile.mkdtemp(
+            prefix="skim_",
+            dir=os.environ.get("TMPDIR") or os.environ.get("_CONDOR_SCRATCH_DIR"),
         )
+        try:
+            with uproot.recreate(os.path.join(tmpdir, filename), compression=uproot.ZSTD(5)) as fout:
+                fout["Events"] = uproot_writeable(self.events)
+            # copy the file
+            copy_file(
+                filename, tmpdir, self.cfg.save_skimmed_files_folder, subdirs=[self._dataset]
+            )
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
         # save the new file location for the new dataset definition
         self.output["skimmed_files"] = {
             self._dataset: [
@@ -833,12 +846,14 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
 
         # --- Systematic-aware skimming logic
         if self.cfg.save_skimmed_files and skim_mode == "presel_any_variation":
+            # Keep a reference to the uncalibrated events
+            # Taking a snapshot of the events references before any change, in order to avoid
+            # saving the added collections in the skimmed file. The skimmed file should contain only the original NanoAOD branches.
+            events_after_skim = copy.copy(self.events)  #just a shallow copy of the events reference, not a deep copy of the data
+            pass_any_variation = np.zeros(len(self.events), dtype=bool)
+
             self.process_extra_after_skim()
             self.initialize_calibrators()
-
-            # Keep a reference to the uncalibrated events
-            events_after_skim = self.events
-            pass_any_variation = np.zeros(len(self.events), dtype=bool)
 
             # Dry-run loop to accumulate the OR of preselection masks
             n_variations = 0


### PR DESCRIPTION
- Snapshot the events (shallow copy) before running the calibrators in the presel_any_variation skim path, so the exported skim files contain only the original NanoAOD branches instead of derived collections carrying values from the last calibration variation.
- Skip collections with no ROOT-compatible field in uproot_writeable (all fields option/union typed, e.g. built with ak.mask/pad_none) instead of crashing with IndexError from ak.zip({}).
- Write the skimmed chunk in a node-local temporary directory (TMPDIR or the HTCondor scratch) instead of the worker cwd, which is often on AFS, before copying it to the destination; clean up also on failure.