### PR TITLE
Add combine shape manipulation helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+PocketCoffea is a configuration framework for CMS NanoAOD analyses built on top of [Coffea](https://github.com/CoffeaTeam/coffea/). Analyses are declared in Python configuration files; customization beyond configuration is done by subclassing the base processor.
+
+Documentation: https://pocketcoffea.readthedocs.io
+
+## Install & dev environment
+
+```bash
+pip install -e .[dev,test,docs]
+```
+
+Pre-commit is configured (`black`, `flake8`, `isort`, `pyupgrade`, mypy, codespell, shellcheck, and a local `disallow-caps` hook that bans `PyBind|Numpy|Cmake|CCache|Github|PyTest`). The CI container is `gitlab-registry.cern.ch/cms-analysis/general/pocketcoffea:lxplus-el9-*`; tests run against EOS datasets via a grid proxy, so most full-config tests will not work locally without `voms-proxy-init`.
+
+## Common commands
+
+```bash
+# Run an analysis (main entry point)
+pocket-coffea run --cfg config.py -o output_dir
+# or equivalently
+runner --cfg config.py -o output_dir
+
+# Quick local test (limit-files=1, iterative executor)
+runner --cfg config.py -o output_dir --test
+
+# Build datasets JSON from DAS / Rucio
+pocket-coffea build-datasets --cfg datasets/dataset_definitions.yaml
+pocket-coffea dataset-discovery-cli   # interactive
+
+# Plotting / merging / post-processing
+make-plots ...
+hadd-skimmed-files ...
+merge-outputs ... / split-output ...
+check-jobs ...
+print-parameters ...           # dump the merged OmegaConf parameter tree
+
+# Tests
+pytest tests                                              # full suite
+pytest tests/test_calibrators.py                          # one file
+pytest tests/test_full_configs/test_full_configs.py::test_new_weights -x
+nox -s tests        # run via nox in an isolated venv
+nox -s lint         # pre-commit on all files
+nox -s docs         # build sphinx docs into docs/_build
+
+# Docs (manual)
+cd docs && make html
+```
+
+All CLI scripts are declared in `pyproject.toml` under `[project.scripts]` and the top-level `pocket-coffea` command (defined in `pocket_coffea/__main__.py`) aggregates them as `click` subcommands.
+
+## Architecture
+
+The processing pipeline is centered on **`BaseProcessorABC`** in `pocket_coffea/workflows/base.py`, a `coffea.processor.ProcessorABC` driven by a **`Configurator`** (`pocket_coffea/utils/configurator.py`). A user analysis = a config file that instantiates a `Configurator` with a workflow class plus declarations for skims, preselections, categories, weights, variations, variables, datasets, calibrators, columns.
+
+Per-chunk `process()` flow (see `workflows/base.py`):
+
+1. `load_metadata` — pulls dataset/sample/year/isMC/era/nano_version from `events.metadata`. Subclasses override `load_metadata_extra` to add more.
+2. `skim_events` — runs `self._skim` `Cut`s on **raw NanoAOD before any object correction**; triggers belong here. Counts go into `cutflow.skim`. If `save_skimmed_files` is set, `export_skimmed_chunk` writes a ROOT file (rescaling `skimRescaleGenWeight` so cross sections still match downstream).
+3. **Calibration loop** — `CalibratorsManager.calibration_loop()` (`pocket_coffea/lib/calibrators/`) iterates systematic variations. For each variation: apply object corrections → `apply_object_preselection` (abstract) → `count_objects` (abstract) → `define_common_variables_*` hooks → `apply_preselections` → categorize → fill weights & histograms.
+4. `skim_mode: "presel_any_variation"` (in `workflow_options`) is a special mode: keep events that pass preselection in *any* active calibrator variation (OR of per-variation masks), and skim accordingly. `skip_processing_after_skim` short-circuits the rest. See `PLAN.md` for design notes.
+5. Histograms & weights → `HistManager` (`lib/hist_manager.py`) and `WeightsManager` (`lib/weights/weights_manager.py`); columns dumped via `ColumnsManager`.
+
+**Extensibility hooks** — `BaseProcessorABC` exposes `*_extra` methods (`process_extra_*`, `fill_histograms_extra`, `define_common_variables_before_presel`, etc.) so subclasses inject custom logic without rewriting the pipeline. Concrete processors live alongside the base in `pocket_coffea/workflows/` (e.g. `tthbb_base_processor.py`, `semileptonic_triggerSF.py`).
+
+### Key modules
+
+- `pocket_coffea/workflows/` — `BaseProcessorABC` and concrete subclasses.
+- `pocket_coffea/utils/configurator.py` — the `Configurator` that wires everything together; `utils/utils.py::load_config` loads a config `.py` script.
+- `pocket_coffea/lib/`
+  - `calibrators/` — `CalibratorsManager` and per-object calibrators (JEC/JER, MET, Rochester, etc.); legacy txt-based JEC under `calibrators/legacy/`.
+  - `weights/` — `WeightsManager` and the registry of weight classes; new weights subclass `Weight` in `lib/weights/weights.py`.
+  - `hist_manager.py`, `columns_manager.py`, `categorization.py`, `cut_definition.py`, `cut_functions.py`.
+  - `objects.py`, `jets.py`, `leptons.py`, `triggers.py`, `scale_factors.py`, `reconstruction.py`, `parton_provenance.py`.
+- `pocket_coffea/executors/` — one module per site (`executors_lxplus.py`, `executors_DESY_NAF.py`, etc.) providing a factory; pick via `--executor` or the config. `executors_base.py` defines the iterative/futures executors used by tests. `executors_manual_jobs.py` (`ExecutorFactoryManualABC`) is the base for HTCondor "manual" executors (`condor@lxplus`, `condor@rubin`) — see "Manual-job executors" below.
+- `pocket_coffea/parameters/` — YAML+OmegaConf defaults (lumi, btagging, jets calibration, trigger, plotting style, etc.); merged with user overrides through `parameters/defaults.py`. Executor option defaults live in `parameters/executor_options_defaults.yaml`.
+- `pocket_coffea/scripts/` — CLI implementations (`runner.py`, `dataset/`, `plot/`, `merge_outputs.py`, `check_jobs.py`, ...).
+- `pocket_coffea/utils/site_rewrite.py` — helpers (`find_other_file`, `rewrite_fileset_blocklist`, `_query_replicas`) used by recreate-jobs / check-jobs to migrate file URLs between CMS sites. Uses Rucio (`rucio.Client.list_replicas`) — **not** `dasgoclient`, which isn't always on PATH. Rucio is lazy-imported so the module stays unit-testable without it.
+- `pocket_coffea/law_tasks/` — optional [law](https://github.com/riga/law) workflow tasks.
+
+### Manual-job executors
+
+`ExecutorFactoryManualABC` (`executors/executors_manual_jobs.py`) submits one self-contained HTCondor job per chunk-group instead of streaming work through a Dask scheduler:
+
+1. `prepare_splitting()` slices the fileset. Two modes: **uniform** (single `max-events-per-job` scalar, jobs may mix datasets) or **per-sample** (dict with optional `default`, each dataset is split independently so every job carries one sample). `scaleout: N` is a third path that derives the budget from total events. **Files are atomic** in both `_split_uniform` and `_split_per_sample`: a single file with more events than the per-job limit becomes one oversized job (coffea's `chunksize` still bounds memory inside it, but not wall-time). Splitting across condor jobs at sub-file granularity would require encoding entry ranges via coffea's `steps`; not implemented today.
+2. `prepare_jobs()` writes `jobs_dir/config_job_{i}.pkl` (a cloudpickled `Configurator` with that job's fileset slice) plus `jobs_dir/jobs_config.yaml` summarising every job's slice/config/output paths.
+3. `submit_jobs()` writes `job_{i}.sub` and the wrapper `job.sh`, then `condor_submit`. The wrapper toggles per-job flag files: `.idle → .running → .done | .failed`.
+4. **Resubmission** has two entrypoints: `pocket-coffea run --recreate-jobs <ids|auto>` (one-shot, manual; supports `--blocklist-sites`, `--recreate-queue`) and `pocket-coffea check-jobs --resubmit` (long-running babysitter that reacts to `.failed` flags + log analysis). Both rewrite the per-job pickle in place when needed — they never re-read the dataset JSON.
+
+Concrete subclasses live in `executors_lxplus.py` (`ExecutorFactoryCondorCERN`) and `executors_rubin.py`. Anything depending on `+JobFlavour` / lxplus queues lives in `executors_lxplus.py` (`update_queue`, `set_queue`, the `queues` ladder).
+
+### Tests
+
+- `tests/test_full_configs/<name>/config.py` — full mini-analyses run via `coffea.processor.Runner` with the `iterative` executor. Each test compares the new output against a reference `.coffea` baseline (`reference_commit` constant in `test_full_configs.py`); update the baseline only when behavior changes intentionally. Helpers `compare_outputs` and `compare_totalweight` live in `tests/utils.py`.
+- Unit-style suites: `test_calibrators.py`, `test_categorization.py`, `test_cut_functions.py`, `test_hlt_cut.py`, `test_runner.py`, `test_weights/`, plus `test_manual_jobs_splitting.py` and `test_recreate_jobs_blocklist.py` for the manual-job paths (no rucio/dask needed — they exercise the dependency-free helpers directly).
+- Many tests require xrootd/EOS access (grid proxy). They're designed to run inside the GitLab CI image.
+- **Testing convention for helpers that talk to external services** (Rucio, DAS, xrootd, HTCondor): factor the network call into a small monkey-patchable function (e.g. `site_rewrite._query_replicas`) and patch *that*, not the underlying library. The host modules should lazy-import the heavy dependency inside the function so the module remains importable on a bare CI runner.
+
+## Conventions / gotchas
+
+- **Skim cuts must not depend on corrected objects.** Object corrections happen inside the calibration loop, after skimming.
+- `_isMC`, `_isSkim`, etc. come from `events.metadata` and may arrive as strings — see `load_metadata` for the canonical coercion.
+- For MC, `nano_version` defaults from `params.default_nano_version[year]` if metadata is missing, with heuristic detection from the filename (`NanoAODv12` / `NanoAODv15`).
+- Configs are saved (pickled with cloudpickle) into the output dir at run start; passing a `.pkl` to `runner` reuses a saved config.
+- **`--process-separately`, `--resubmit-failed`, and `--group-samples` are silently ignored by manual-job (`condor@*`) executors.** Those flags only fire after `runner.py:264` exits early on `executor_factory.handles_submission == True`. The manual-job equivalent of `--resubmit-failed` is `--recreate-jobs auto`.
+- **Merging already-merged `.coffea` files double-rescales histograms.** `BaseProcessorABC.postprocess` runs `rescale_sumgenweights` unconditionally (`histo *= 1/sum_genweights`), but `sum_genweights` itself isn't touched, so a second `merge-outputs` pass re-divides already-rescaled histograms. Merge raw `output_job_*.coffea` files in a single call.
+- **`hadd-skimmed-files --check` validates an existing hadd run.** It does not run hadd — it iterates the workload it just rebuilt and validates each expected output file (existence + `TFile.Open` + `Events` tree + `GetEntries` vs. the expected sum from `df["nskimmed_events"]`; falls back to existence-only if ROOT is unimportable). Output paths that start with `root://host/` are stripped via `_strip_xrootd_prefix` so the existence probe hits the FUSE-mounted EOS path; ROOT.TFile.Open still receives the original URL. On failure it writes the triple `hadd_failed.json` / `hadd_failed.txt` / `hadd_failed_splitbyfile.sub` and (re)writes `do_hadd_job_splitbyfile.py`. The wrapper accepts an optional 3rd argv naming the JSON file (defaults to `hadd.json`), and the resubmit sub passes `hadd_failed.json` as that 3rd arg — so the original submission is untouched and a stale on-disk wrapper from before this change is overwritten automatically.
+- **Shape-only shape systematics for rateParam processes** (`utils/stat/combine.py`). A free `rateParam` already floats a process's normalization, so the normalization component of any `shape` systematic on that process is degenerate with it and just adds redundant nuisance freedom. Opt in with `Datacard(shape_only_for_rateparam=True, rateparam_norm_categories=[...])`: every Up/Down template of a `MCProcess` with `has_rateParam=True` is rescaled so its total yield matches nominal, keeping only the bin-to-bin shape and the migration *between* regions. The factor `Σnominal/Σvaried` is computed per `(process, systematic.datacard_name, shift)` in `Datacard.compute_rateparam_shape_scales()` (called from `dump()`), summed with `flow=True` over `rateparam_norm_categories` × the process years where the systematic applies — restricted by the same `process in systematic.processes and year in systematic.years` guard used when writing. Flow-inclusive totals are observable-independent, so each per-category `Datacard` derives the *same* factor without cross-card coordination: `rearrange_histograms` copies with `flow=True`, so content that a sub-range rebinning (e.g. spanet ∈ [0.8, 1]) pushed into under/overflow still counts in the factor (written templates and rates remain in-range only). Requires only that the histograms used for the totals are filled in every norm category: by default the card's own, or pass `rateparam_norm_histograms=df["variables"]["nJets"]` (any variable filled everywhere, never rebinned) when the card's variable uses `only_categories` and lacks some norm category — a missing category raises a `ValueError` naming that option instead of a bare `KeyError`. Regression tests: `tests/test_stat_datacards.py::test_rateparam_scale_consistent_across_rebinned_cards` and `::test_rateparam_scale_from_norm_histograms`. `rateparam_norm_categories` defaults to every category on the input axis; pass the explicit fit-category list when the coffea output holds non-fit categories. Default off — existing datacards unchanged.
+- **Artificial variations injected into histograms** (`utils/stat/shape_manipulation.py`). Both helpers add an extra `{name}Up`/`{name}Down` entry to the `variation` StrCategory axis of the coffea histograms (`{sample: {dataset: hist}}`) *before* the `Datacard` is built, to be declared as a regular `shape` `SystematicUncertainty` with the same name; samples of the process that don't carry the variation fall back to nominal in `rearrange_histograms`, and both return a new dict (untouched samples shared by reference). `add_norm_variation`: Up = nominal × per-category scalar factor (pure normalization, flow bins included). `add_binwise_variation`: Up = nominal reweighted bin-by-bin along the last (variable) axis with per-category weight arrays — length `axis.size` (flow keeps weight 1) or `axis.extent` (flow weighted too); scalars behave like the norm case; weights refer to the binning *before* `bins_edges` rebinning. Down = nominal by default (one-sided); `down_mode="mirror"` divides instead. `preserve_norm=True` rescales each varied template per dataset+category (flow included) so its yield matches nominal — a pure within-category shape variation with no normalization component (scalar entries become no-ops); this also makes the rateParam shape-only factor exactly 1 in every card, so the variation need not be injected into other cards' variables. Both helpers take `datasets=[...]` to restrict the injection (e.g. one year's datasets from `datasets_metadata["by_datataking_period"][year][sample]`): call once per year with different weights — same `variation_name` composes across disjoint dataset sets, overlaps raise, uncovered datasets fall back to nominal in the Datacard. Caveats with `has_rateParam=True` + `shape_only_for_rateparam=True`: only *relative* per-category differences survive (equal scalar factors everywhere = no-op), and for per-bin weights the cross-card factor is only identical if the arrays given for each card's variable represent the same event-level reweighting (same varied total per category) — see the warning in the `add_binwise_variation` docstring. `rescale_histograms(histograms, samples, scale, datasets=None)` is different: it multiplies the selected histograms themselves by one scalar (all categories, nominal and every variation, flow included; variances × scale²) — a plain yield change, no new variation entry — with the same `samples`/`datasets` selection rules (shared `_select_datasets` helper).
+- **`clean_failed_hadd_inputs.py`** is a small helper that reads a hadd manifest (`hadd.json` or `hadd_failed.json`) and runs `clean_skim_branches.clean_file` directly on each output, mirroring `<output_dir>/<dataset>/<basename>`. Despite the name, it operates on the hadd *outputs* — one cleaned file per group, no per-chunk fan-out.
+- The repository contains many stale backup files (`*.py~`, `*.yaml~`, `*.json~`, `out_test/`, `output_tests/`, `myenvtest/`, `venv_local_docs/`) — ignore them; the canonical files are the un-tilded ones.
+- Mirror: this repo is mirrored to `https://gitlab.cern.ch/cms-analysis/general/PocketCoffea` and CI/Docker images are built there, not on GitHub.

--- a/pocket_coffea/utils/skim.py
+++ b/pocket_coffea/utils/skim.py
@@ -161,17 +161,23 @@ def save_skimed_dataset_definition(processing_out, fileout, check_initial_events
     sum_genweights_total = processing_out.get("sum_genweights", {})
     sum_signOf_genweights_total = processing_out.get("sum_signOf_genweights", {})
     # Now add the files
+    inconsistent = []
     for key in datasets_metadata.keys():
         # We first check that the total number of initial events
         # corresponds to the initial number of the events in the metadata
         # to check if we are not missing any event
-        if check_initial_events and int(datasets_metadata[key]["nevents"]) != processing_out["cutflow"]["initial"][key]:
+        nmeta = int(datasets_metadata[key]["nevents"])
+        ncutflow = processing_out["cutflow"]["initial"][key]
+        if check_initial_events and nmeta != ncutflow:
+            msg = f"{key}: metadata nevents={nmeta}, cutflow initial={ncutflow}, missing={nmeta - ncutflow} ({(nmeta - ncutflow) / nmeta * 100:.3f}%)"
             if key in skip_initial_events_check_datasets:
-                print(f"WARNING: The number of initial events in the metadata ({datasets_metadata[key]['nevents']}) is different from the number of initial events in the cutflow ({processing_out['cutflow']['initial'][key]}) for dataset {key}, but the check was explicitly skipped for it.")
+                print(f"WARNING: Inconsistent number of initial events, but the check was explicitly skipped for it. {msg}")
             else:
-                print(f"ERROR: The number of initial events in the metadata is different from the number of initial events in the cutflow for dataset {key}")
-                raise Exception("Inconsistent number of initial events in the output of the skimming processing")
+                print(f"ERROR: Inconsistent number of initial events. {msg}")
+                inconsistent.append(key)
 
+        if key in inconsistent:
+            continue
         # Count the remaining events
         datasets_info[key] =  {
             "metadata": datasets_metadata[key],
@@ -188,6 +194,10 @@ def save_skimed_dataset_definition(processing_out, fileout, check_initial_events
             datasets_info[key]["metadata"]["sum_genweights"] = float(sum_genweights_total[key])
         if key in sum_signOf_genweights_total:
             datasets_info[key]["metadata"]["sum_signOf_genweights"] = float(sum_signOf_genweights_total[key])
+
+    if inconsistent:
+        raise Exception(f"Inconsistent number of initial events in the output of the skimming processing for {len(inconsistent)} dataset(s): {inconsistent}. "
+                        f"Pass them with --skip-initial-events-check to merge-outputs to tolerate the mismatch.")
 
     # Save the json
     with open(fileout, "w") as f:

--- a/pocket_coffea/utils/stat/__init__.py
+++ b/pocket_coffea/utils/stat/__init__.py
@@ -8,6 +8,7 @@ from pocket_coffea.utils.stat.processes import (
 from pocket_coffea.utils.stat.shape_manipulation import (
     add_binwise_variation,
     add_norm_variation,
+    rescale_histograms,
 )
 from pocket_coffea.utils.stat.systematics import Systematics, SystematicUncertainty
 
@@ -21,4 +22,5 @@ __all__ = [
     "Systematics",
     "add_binwise_variation",
     "add_norm_variation",
+    "rescale_histograms",
 ]

--- a/pocket_coffea/utils/stat/__init__.py
+++ b/pocket_coffea/utils/stat/__init__.py
@@ -5,6 +5,10 @@ from pocket_coffea.utils.stat.processes import (
     MCProcess,
     MCProcesses,
 )
+from pocket_coffea.utils.stat.shape_manipulation import (
+    add_binwise_variation,
+    add_norm_variation,
+)
 from pocket_coffea.utils.stat.systematics import Systematics, SystematicUncertainty
 
 __all__ = [
@@ -15,4 +19,6 @@ __all__ = [
     "MCProcesses",
     "SystematicUncertainty",
     "Systematics",
+    "add_binwise_variation",
+    "add_norm_variation",
 ]

--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -590,6 +590,19 @@ class Datacard:
                     )
                     new_histogram_view = new_histogram.view()
                     new_histogram_view[:] = histogram[process_name_byyear, :].view()
+                    if not np.all(
+                        np.mod(new_histogram.values(), 1) == 0
+                    ):
+                        if process.round_counts:
+                            new_histogram_view["value"] = np.round(
+                                new_histogram_view["value"]
+                            )
+                            # Set the variance to the value itself (so the uncertainty is sqrt(N))
+                            new_histogram_view["variance"] = new_histogram_view["value"]
+                        else:
+                            warnings.warn(
+                                f"Data histogram for process '{process_name_byyear}' has non-integer bin values, but it should represent event counts."
+                            )
                     new_histograms[f"{process_name_byyear}_nominal"] = new_histogram
                 else:
                     process_name_byyear = f"{process.name}_{year}"

--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -466,9 +466,14 @@ class Datacard:
                             process_index = new_histogram.axes["process"].index(
                                 "data_obs"
                             )
-                            new_histogram_view[process_index, :] += histogram[
-                                cat, :
-                            ].view()
+                            if "variation" in histogram.axes.name:
+                                new_histogram_view[process_index, :] += histogram[
+                                    cat, "nominal", :
+                                ].view()
+                            else:
+                                new_histogram_view[process_index, :] += histogram[
+                                    cat, :
+                                ].view()
                         else:
                             process_index = new_histogram.axes["process"].index(
                                 f"{process.name}_{year}"
@@ -502,6 +507,14 @@ class Datacard:
                                         new_histogram_view[
                                             process_index, variation_index, :
                                         ] += histogram[cat, "nominal", :].view()
+            if is_data:
+                if not np.all(
+                    np.mod(new_histogram.values(), 1) == 0
+                ):
+                    if process.round_counts:
+                        new_histogram_view["value"] = np.round(
+                            new_histogram_view["value"]
+                        )
         return new_histogram
 
     def _all_input_categories(self) -> list[str]:

--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -79,6 +79,7 @@ class Datacard:
         verbose: bool = True,
         shape_only_for_rateparam: bool = False,
         rateparam_norm_categories: list[str] = None,
+        rateparam_norm_histograms: dict[str, dict[str, hist.Hist]] = None,
     ) -> None:
         """Initialize the Datacard.
 
@@ -93,6 +94,13 @@ class Datacard:
             input histogram axis. Pass the explicit list of fit categories when the coffea
             output contains categories that are not part of the combined datacard.
         :type rateparam_norm_categories: list[str], optional
+        :param rateparam_norm_histograms: Histograms (``{sample: {dataset: hist}}``) of any
+            variable filled in every ``rateparam_norm_categories`` category, used only for the
+            flow-inclusive totals of the shape-only factor. Defaults to the card's own
+            ``histograms``; pass it when the card's variable is restricted with
+            ``only_categories`` and so lacks some norm categories. Never rebinned (the totals
+            include the flow bins, so the binning is irrelevant).
+        :type rateparam_norm_histograms: dict[str, dict[str, hist.Hist]], optional
         """
 
         self.histograms = histograms
@@ -110,6 +118,7 @@ class Datacard:
         self.verbose = verbose
         self.shape_only_for_rateparam = shape_only_for_rateparam
         self.rateparam_norm_categories = rateparam_norm_categories
+        self.rateparam_norm_histograms = rateparam_norm_histograms
         self.rateparam_shape_scale = {}
         if self.bin_suffix is None:
             self.bin_suffix = "_".join(self.years)
@@ -397,6 +406,7 @@ class Datacard:
         self,
         is_data: bool = False,
         category: str = None,
+        histograms: dict[str, dict[str, hist.Hist]] = None,
     ) -> hist.Hist:
         """Rearrange histograms from pocket_coffea output format to match processes
         and systematics in one histogram.
@@ -414,10 +424,13 @@ class Datacard:
         :param category: Category to select; defaults to ``self.category``. Allows building
             the rearranged single-category histogram for any region from the same input.
         :type category: str, optional
+        :param histograms: Input histograms to rearrange; defaults to ``self.histograms``.
+        :type histograms: dict[str, dict[str, hist.Hist]], optional
         :return: Rearranged histogram
         :rtype: hist.Hist
         """
         cat = category if category is not None else self.category
+        hs = histograms if histograms is not None else self.histograms
         if is_data:
             processes = self.data_processes
         else:
@@ -432,10 +445,10 @@ class Datacard:
         sample = list(processes.values())[0].samples[0]
         datasets = list(self.get_datasets_by_sample(sample))
         for dataset in datasets:
-            if not dataset in self.histograms[sample]:
+            if not dataset in hs[sample]:
                 continue
             else:
-                variable_axis = self.histograms[sample][dataset].axes[-1]
+                variable_axis = hs[sample][dataset].axes[-1]
                 break
 
         if is_data:
@@ -472,7 +485,7 @@ class Datacard:
                     for dataset in self.get_datasets_by_sample(sample, year):
                         if self.is_empty_dataset(dataset):
                             continue
-                        histogram = self.histograms[sample][dataset]
+                        histogram = hs[sample][dataset]
                         if is_data:
                             process_index = new_histogram.axes["process"].index(
                                 "data_obs"
@@ -517,13 +530,16 @@ class Datacard:
                                         ] += histogram[cat, "nominal", :].view(flow=True)
         return new_histogram
 
-    def _all_input_categories(self) -> list[str]:
+    def _all_input_categories(
+        self, histograms: dict[str, dict[str, hist.Hist]] = None
+    ) -> list[str]:
         """List the category labels available on the input histograms' category axis."""
+        hs = histograms if histograms is not None else self.histograms
         for process in self.mc_processes.values():
             for sample in process.samples:
                 for dataset in self.get_datasets_by_sample(sample):
-                    if dataset in self.histograms.get(sample, {}):
-                        return list(self.histograms[sample][dataset].axes[0])
+                    if dataset in hs.get(sample, {}):
+                        return list(hs[sample][dataset].axes[0])
         raise RuntimeError("No input histogram found to read the category axis from.")
 
     def compute_rateparam_shape_scales(self) -> dict:
@@ -538,8 +554,8 @@ class Datacard:
         :meth:`rearrange_histograms` preserves the variable-axis flow content and the
         sums here include it: even when a card's variable is rebinned to a sub-range,
         the out-of-range content still counts. Every per-category Datacard therefore
-        derives the same factors, provided every event in a category fills every
-        card's variable.
+        derives the same factors, provided the histograms used for the totals (the
+        card's own, or ``rateparam_norm_histograms``) are filled in every norm category.
 
         :return: mapping ``(process_name, systematic.datacard_name, shift) -> float``
         :rtype: dict
@@ -548,9 +564,22 @@ class Datacard:
         if not rateparam_processes:
             return {}
 
-        cats = self.rateparam_norm_categories or self._all_input_categories()
+        norm_hists = self.rateparam_norm_histograms or self.histograms
+        available = self._all_input_categories(norm_hists)
+        cats = self.rateparam_norm_categories or available
+        missing = set(cats) - set(available)
+        if missing:
+            raise ValueError(
+                f"rateparam_norm_categories {sorted(missing)} are not on the category axis "
+                "of the histograms used for the shape-only totals. Pass "
+                "`rateparam_norm_histograms=` with a variable filled in every norm category "
+                "(e.g. a jet-multiplicity histogram)."
+            )
         hists_by_cat = {
-            cat: self.rearrange_histograms(is_data=False, category=cat) for cat in cats
+            cat: self.rearrange_histograms(
+                is_data=False, category=cat, histograms=norm_hists
+            )
+            for cat in cats
         }
 
         shape_systs = self.systematics.get_systematics_by_type("shape")

--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -401,6 +401,14 @@ class Datacard:
         """Rearrange histograms from pocket_coffea output format to match processes
         and systematics in one histogram.
 
+        The under/overflow content of the variable axis is preserved (copied with
+        ``flow=True``), so flow-inclusive sums of the rearranged histogram equal the
+        input category totals even when rebinning to a sub-range moved content into
+        the flow bins. This is what makes the shape-only rateParam factors of
+        :meth:`compute_rateparam_shape_scales` observable-independent and identical
+        across the per-category datacards. Written templates and rates still use
+        in-range bins only.
+
         :param is_data: Flag to indicate if the datacard is for data, defaults to False
         :type is_data: bool, optional
         :param category: Category to select; defaults to ``self.category``. Allows building
@@ -451,7 +459,10 @@ class Datacard:
                 variable_axis,
                 storage=hist.storage.Weight(),
             )
-        new_histogram_view = new_histogram.view()
+        # flow=True view: keep the variable-axis under/overflow (see docstring).
+        # Categorical axes append their overflow slot at the end, so the integer
+        # process/variation indices used below are unaffected.
+        new_histogram_view = new_histogram.view(flow=True)
 
         for process in processes.values():
             for sample in process.samples:
@@ -468,7 +479,7 @@ class Datacard:
                             )
                             new_histogram_view[process_index, :] += histogram[
                                 cat, :
-                            ].view()
+                            ].view(flow=True)
                         else:
                             process_index = new_histogram.axes["process"].index(
                                 f"{process.name}_{year}"
@@ -479,7 +490,7 @@ class Datacard:
                             ].index("nominal")
                             new_histogram_view[
                                 process_index, variation_index_nominal, :
-                            ] += histogram[cat, "nominal", :].view()
+                            ] += histogram[cat, "nominal", :].view(flow=True)
                             for (
                                 syst_name,
                                 systematic,
@@ -494,14 +505,16 @@ class Datacard:
                                     if source_variation in histogram.axes["variation"]:
                                         new_histogram_view[
                                             process_index, variation_index, :
-                                        ] += histogram[cat, source_variation, :].view()
+                                        ] += histogram[
+                                            cat, source_variation, :
+                                        ].view(flow=True)
                                     else:
                                         print(
                                             f"Setting `{source_variation}` variation to nominal variation for sample {sample}."
                                         )
                                         new_histogram_view[
                                             process_index, variation_index, :
-                                        ] += histogram[cat, "nominal", :].view()
+                                        ] += histogram[cat, "nominal", :].view(flow=True)
         return new_histogram
 
     def _all_input_categories(self) -> list[str]:
@@ -521,8 +534,12 @@ class Datacard:
         and over the process years where the systematic applies. Applying it to every
         Up/Down template holds the process total fixed (the normalization the rateParam
         already absorbs) while preserving the bin-to-bin shape and the region/year
-        migration. The totals are observable-independent (flow included), so every
-        per-category Datacard derives the same factors.
+        migration. The totals are observable-independent because
+        :meth:`rearrange_histograms` preserves the variable-axis flow content and the
+        sums here include it: even when a card's variable is rebinned to a sub-range,
+        the out-of-range content still counts. Every per-category Datacard therefore
+        derives the same factors, provided every event in a category fills every
+        card's variable.
 
         :return: mapping ``(process_name, systematic.datacard_name, shift) -> float``
         :rtype: dict

--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -480,11 +480,11 @@ class Datacard:
                             if "variation" in histogram.axes.name:
                                 new_histogram_view[process_index, :] += histogram[
                                     cat, "nominal", :
-                                ].view()
+                                ].view(flow=True)
                             else:
                                 new_histogram_view[process_index, :] += histogram[
                                     cat, :
-                                ].view()
+                                ].view(flow=True)
                         else:
                             process_index = new_histogram.axes["process"].index(
                                 f"{process.name}_{year}"
@@ -519,7 +519,7 @@ class Datacard:
                                         )
                                         new_histogram_view[
                                             process_index, variation_index, :
-                                        ] += histogram[cat, "nominal", :].view()
+                                        ] += histogram[cat, "nominal", :].view(flow=True)
             if is_data:
                 if not np.all(
                     np.mod(new_histogram.values(), 1) == 0

--- a/pocket_coffea/utils/stat/combine.py
+++ b/pocket_coffea/utils/stat/combine.py
@@ -79,6 +79,7 @@ class Datacard:
         verbose: bool = True,
         shape_only_for_rateparam: bool = False,
         rateparam_norm_categories: list[str] = None,
+        data_variations: dict[str, str] = None,
     ) -> None:
         """Initialize the Datacard.
 
@@ -110,6 +111,7 @@ class Datacard:
         self.verbose = verbose
         self.shape_only_for_rateparam = shape_only_for_rateparam
         self.rateparam_norm_categories = rateparam_norm_categories
+        self.data_variations = data_variations
         self.rateparam_shape_scale = {}
         if self.bin_suffix is None:
             self.bin_suffix = "_".join(self.years)
@@ -145,9 +147,13 @@ class Datacard:
         self._check_histograms()
         self.histogram = self.rearrange_histograms(is_data=False)
 
+        #if self.has_data:
+        #    self.data_obs = self.rearrange_histograms(is_data=True)
         if self.has_data:
-            self.data_obs = self.rearrange_histograms(is_data=True)
-
+            self.data_obs = self.rearrange_histograms(
+                is_data=True,
+                data_variations=self.data_variations,
+            )
         self._check_shapes()
 
         # helper attributes
@@ -397,6 +403,7 @@ class Datacard:
         self,
         is_data: bool = False,
         category: str = None,
+        data_variations: dict[str, str] | None = None,
     ) -> hist.Hist:
         """Rearrange histograms from pocket_coffea output format to match processes
         and systematics in one histogram.
@@ -473,14 +480,36 @@ class Datacard:
                         if self.is_empty_dataset(dataset):
                             continue
                         histogram = self.histograms[sample][dataset]
+                        #if is_data:
+                        #    process_index = new_histogram.axes["process"].index(
+                        #        "data_obs"
+                        #    )
+                        #    if "variation" in histogram.axes.name:
+                        #        new_histogram_view[process_index, :] += histogram[
+                        #            cat, "nominal", :
+                        #        ].view(flow=True)
+                        #    else:
+                        #        new_histogram_view[process_index, :] += histogram[
+                        #            cat, :
+                        #        ].view(flow=True)
+
                         if is_data:
-                            process_index = new_histogram.axes["process"].index(
-                                "data_obs"
-                            )
+                            process_index = new_histogram.axes["process"].index("data_obs")
                             if "variation" in histogram.axes.name:
+                                variation = (
+                                    data_variations.get(sample, "nominal")
+                                    if data_variations is not None
+                                    else "nominal")
+                                if variation not in histogram.axes["variation"]:
+                                    raise ValueError(
+                                        f"Requested data variation {variation!r} for sample "
+                                        f"{sample!r}, dataset {dataset}, but available variations are "
+                                        f"{list(histogram.axes['variation'])}"
+                                    )
                                 new_histogram_view[process_index, :] += histogram[
-                                    cat, "nominal", :
+                                    cat, variation, :
                                 ].view(flow=True)
+
                             else:
                                 new_histogram_view[process_index, :] += histogram[
                                     cat, :

--- a/pocket_coffea/utils/stat/processes.py
+++ b/pocket_coffea/utils/stat/processes.py
@@ -68,11 +68,13 @@ class DataProcess(Process):
     :param samples: Iterable of sample names associated with the process
     :param years: Iterable of years the process is relevant for
     :param label: Label for the process, defaults to `name` if not specified
+    :param round_counts: Flag to indicate if counts should be rounded to integers, defaults to False
 
     Inherits from Process and sets is_data to True by default.
     """
 
     years: Iterable
+    round_counts: bool = False
 
     def __post_init__(self):
         self.is_data = True

--- a/pocket_coffea/utils/stat/shape_manipulation.py
+++ b/pocket_coffea/utils/stat/shape_manipulation.py
@@ -268,6 +268,7 @@ def add_binwise_variation(
             up_i = new_variation_axis.index(up_name)
             down_i = new_variation_axis.index(down_name)
             for category in cat_axis:
+                #breakpoint()
                 weights = _resolve_bin_weights(
                     weights_by_category.get(category, default_weight),
                     variable_axis,

--- a/pocket_coffea/utils/stat/shape_manipulation.py
+++ b/pocket_coffea/utils/stat/shape_manipulation.py
@@ -13,6 +13,10 @@ Two flavors are provided:
 - :func:`add_binwise_variation`: Up = nominal reweighted bin by bin with a
   per-category weight array (generic shape reweighting); a scalar entry behaves
   like a normalization factor.
+
+:func:`rescale_histograms` instead changes the histograms themselves: it
+multiplies the nominal *and* every variation of the selected samples/datasets
+by one scalar (a plain yield rescaling, no new variation entry).
 """
 
 import hist
@@ -49,6 +53,32 @@ def _resolve_bin_weights(weight_spec, variable_axis, category):
         f"{variable_axis.size} (in-range bins of axis {variable_axis.name!r}, "
         f"flow bins keep weight 1) or {variable_axis.extent} (flow slots included)"
     )
+
+
+def _select_datasets(histograms, samples, datasets):
+    """Return the ``{(sample, dataset)}`` pairs targeted by ``samples`` (all must
+    exist in ``histograms``) and ``datasets`` (None = every dataset of those
+    samples). Datasets in the list that are absent from the histograms are
+    ignored (e.g. empty datasets), but a list matching nothing at all raises."""
+    missing_samples = sorted(set(samples) - set(histograms))
+    if missing_samples:
+        raise ValueError(
+            f"Samples {missing_samples} not found in histograms "
+            f"(available: {sorted(histograms)})"
+        )
+    dataset_filter = None if datasets is None else set(datasets)
+    selected = {
+        (sample, dataset)
+        for sample in set(samples)
+        for dataset in histograms[sample]
+        if dataset_filter is None or dataset in dataset_filter
+    }
+    if dataset_filter is not None and not selected:
+        raise ValueError(
+            f"None of the requested datasets {sorted(dataset_filter)} found in "
+            f"the histograms of samples {sorted(set(samples))}"
+        )
+    return selected
 
 
 def add_binwise_variation(
@@ -174,29 +204,20 @@ def add_binwise_variation(
             f"Unknown down_mode {down_mode!r}, expected 'nominal' or 'mirror'"
         )
 
-    missing_samples = sorted(set(samples) - set(histograms))
-    if missing_samples:
-        raise ValueError(
-            f"Samples {missing_samples} not found in histograms "
-            f"(available: {sorted(histograms)})"
-        )
+    selected = _select_datasets(histograms, samples, datasets)
 
     up_name = f"{variation_name}Up"
     down_name = f"{variation_name}Down"
-
-    dataset_filter = None if datasets is None else set(datasets)
-    matched_datasets = 0
 
     new_histograms = dict(histograms)
     for sample in set(samples):
         new_histograms[sample] = {}
         for dataset, histogram in histograms[sample].items():
-            if dataset_filter is not None and dataset not in dataset_filter:
+            if (sample, dataset) not in selected:
                 # carried over untouched; a later call (same variation_name,
                 # different weights) can cover it
                 new_histograms[sample][dataset] = histogram
                 continue
-            matched_datasets += 1
             axis_names = [axis.name for axis in histogram.axes]
             if "cat" not in axis_names or "variation" not in axis_names:
                 raise ValueError(
@@ -308,12 +329,6 @@ def add_binwise_variation(
 
             new_histograms[sample][dataset] = new_histogram
 
-    if dataset_filter is not None and matched_datasets == 0:
-        raise ValueError(
-            f"None of the requested datasets {sorted(dataset_filter)} found in "
-            f"the histograms of samples {sorted(set(samples))}"
-        )
-
     return new_histograms
 
 
@@ -372,3 +387,52 @@ def add_norm_variation(
         down_mode=down_mode,
         datasets=datasets,
     )
+
+
+def rescale_histograms(
+    histograms: dict[str, dict[str, hist.Hist]],
+    samples: list[str],
+    scale: float,
+    datasets: list[str] | None = None,
+) -> dict[str, dict[str, hist.Hist]]:
+    """Rescale the normalization of whole histograms by a constant factor.
+
+    Every histogram of the requested ``samples`` (optionally restricted to
+    ``datasets``) is multiplied by ``scale`` in all its bins: every category,
+    the nominal *and* every variation, under/overflow included. Bin variances
+    scale with ``scale**2``. Unlike :func:`add_norm_variation` no variation
+    entry is created: the histograms themselves change, so the effect is a
+    plain change of the sample yield (e.g. a k-factor or a cross-section fix
+    for one year's datasets).
+
+    Typical use — apply a per-year factor to a sample::
+
+        for year, factor in factor_by_year.items():
+            year_datasets = datasets_metadata["by_datataking_period"][year].get(
+                "TTBB", []
+            )
+            histograms = rescale_histograms(
+                histograms, ["TTBB"], factor, datasets=year_datasets
+            )
+
+    The input dictionary is not modified: a new outer dict is returned,
+    sharing the untouched histogram objects with the input.
+
+    :param histograms: pocket_coffea histograms, ``{sample: {dataset: hist.Hist}}``.
+    :param samples: samples to rescale. Must all be present in ``histograms``.
+    :param scale: scalar multiplied into every bin (variances by its square).
+    :param datasets: optionally restrict the rescaling to these datasets
+        (within the selected samples); absent datasets are ignored, but a
+        list matching nothing raises. Defaults to None (all datasets).
+    :return: new ``{sample: {dataset: hist.Hist}}`` dict.
+    """
+    if np.ndim(scale) != 0:
+        raise ValueError(f"scale must be a scalar, got {scale!r}")
+    selected = _select_datasets(histograms, samples, datasets)
+    new_histograms = dict(histograms)
+    for sample in set(samples):
+        new_histograms[sample] = {
+            dataset: histogram * scale if (sample, dataset) in selected else histogram
+            for dataset, histogram in histograms[sample].items()
+        }
+    return new_histograms

--- a/pocket_coffea/utils/stat/shape_manipulation.py
+++ b/pocket_coffea/utils/stat/shape_manipulation.py
@@ -1,0 +1,374 @@
+"""Utilities to inject artificial shape variations into pocket_coffea histograms.
+
+These helpers operate on the histogram dictionaries stored in the coffea output
+(``df["variables"][variable] -> {sample: {dataset: hist.Hist}}``) *before* they
+are handed to :class:`pocket_coffea.utils.stat.combine.Datacard`, by adding new
+entries to the ``variation`` StrCategory axis. The new entries can then be
+declared as regular ``shape`` :class:`SystematicUncertainty` in the datacard.
+
+Two flavors are provided:
+
+- :func:`add_norm_variation`: Up = nominal scaled by one factor per category
+  (pure normalization effect, all bins including under/overflow).
+- :func:`add_binwise_variation`: Up = nominal reweighted bin by bin with a
+  per-category weight array (generic shape reweighting); a scalar entry behaves
+  like a normalization factor.
+"""
+
+import hist
+import numpy as np
+
+
+def _resolve_bin_weights(weight_spec, variable_axis, category):
+    """Normalize a weight specification to an array over the ``flow=True`` bins
+    of the (last) variable axis.
+
+    - A scalar broadcasts to every bin, under/overflow included (pure
+      normalization of the category).
+    - An array of length ``variable_axis.size`` weights the in-range bins;
+      under/overflow keep weight 1.0.
+    - An array of length ``variable_axis.extent`` also weights the flow slots
+      explicitly (underflow first, when the axis has one).
+    """
+    if np.ndim(weight_spec) == 0:
+        return np.full(variable_axis.extent, float(weight_spec))
+    weights = np.asarray(weight_spec, dtype=float)
+    if weights.ndim != 1:
+        raise ValueError(
+            f"Weights for category {category!r} must be a scalar or a 1D array, "
+            f"got shape {weights.shape}"
+        )
+    if len(weights) == variable_axis.extent:
+        return weights
+    if len(weights) == variable_axis.size:
+        underflow = int(variable_axis.traits.underflow)
+        overflow = int(variable_axis.traits.overflow)
+        return np.concatenate([np.ones(underflow), weights, np.ones(overflow)])
+    raise ValueError(
+        f"Weights for category {category!r} have length {len(weights)}, expected "
+        f"{variable_axis.size} (in-range bins of axis {variable_axis.name!r}, "
+        f"flow bins keep weight 1) or {variable_axis.extent} (flow slots included)"
+    )
+
+
+def add_binwise_variation(
+    histograms: dict[str, dict[str, hist.Hist]],
+    variation_name: str,
+    samples: list[str],
+    weights_by_category: dict,
+    default_weight=1.0,
+    down_mode: str = "nominal",
+    preserve_norm: bool = False,
+    datasets: list[str] | None = None,
+) -> dict[str, dict[str, hist.Hist]]:
+    """Add an artificial per-bin reweighting variation to the variation axis.
+
+    For every histogram of the requested ``samples``, two new entries are
+    appended to the ``variation`` axis:
+
+    - ``{variation_name}Up``: the nominal content multiplied, in each category,
+      bin by bin along the (last) variable axis by the weights given in
+      ``weights_by_category`` (variances scale with the squared weight).
+    - ``{variation_name}Down``: by default an exact copy of the nominal
+      (``down_mode="nominal"``, i.e. a one-sided variation). With
+      ``down_mode="mirror"`` the nominal is instead divided by the same weights
+      (log-mirror, matching the lnN convention; requires strictly positive
+      weights).
+
+    The weights refer to the histogram's own binning **before** any
+    ``bins_edges`` rebinning done by the ``Datacard`` (rebinning then merges the
+    reweighted contents). See :func:`_resolve_bin_weights` for the accepted
+    weight formats: scalar (all bins, flow included), in-range array (flow
+    untouched), or flow-inclusive array. Categories not listed get
+    ``default_weight`` (default 1.0: Up = nominal there).
+
+    Samples not listed in ``samples`` are left untouched (their histograms keep
+    the original variation axis; :meth:`Datacard.rearrange_histograms` falls
+    back to the nominal for them). The input dictionary is not modified: a new
+    outer dict is returned, sharing the untouched histogram objects with the
+    input.
+
+    Typical use — reweight the ttbb shape as a function of the fit variable in
+    the signal region only::
+
+        histograms = add_binwise_variation(
+            histograms,
+            variation_name="ttbb_shape_rw",
+            samples=[s for s in histograms if s.startswith("TTBB")],
+            weights_by_category={"SR": weights_array},  # len = n bins of the variable
+        )
+
+    and declare ``SystematicUncertainty(name="ttbb_shape_rw", typ="shape", ...)``.
+
+    .. note::
+       If the affected process has a free rateParam and the datacard is built
+       with ``shape_only_for_rateparam=True``, the overall yield change of the
+       reweighting is removed with the common factor summed over all
+       ``rateparam_norm_categories``: only the bin-by-bin shape and the
+       relative differences between categories survive.
+
+    .. warning::
+       When several per-category datacards are combined, the shape-only factor
+       is only identical across cards if the varied *total yield per category*
+       is the same in every card's variable — automatic for scalar weights, but
+       for per-bin weights it requires the arrays applied to the different
+       variables to represent the same underlying event-level reweighting. Use
+       ``preserve_norm=True`` to sidestep this entirely: the varied totals then
+       equal the nominal ones per category everywhere, the rateParam factor is
+       exactly 1 in every card, and the variation need not be injected into the
+       other cards' variables at all (they fall back to nominal, which is the
+       same thing). Otherwise, if the weights are known only versus one
+       observable, apply at least the resulting per-category yield ratio (a
+       scalar) to the other cards' histograms so the category totals agree.
+
+    :param histograms: pocket_coffea histograms, ``{sample: {dataset: hist.Hist}}``
+        with axes ``(cat, variation, ..., variable)``; weights act on the last axis.
+    :param variation_name: name of the new variation; entries ``{name}Up`` and
+        ``{name}Down`` are created. Must match the ``name`` (or
+        ``coffea_name_alias``) of the SystematicUncertainty declared for it.
+    :param samples: samples to which the variation is added. Must all be present
+        in ``histograms``.
+    :param weights_by_category: mapping ``category -> weights`` (scalar or
+        per-bin array) applied to the nominal to build the Up template. Every
+        key must exist on the ``cat`` axis of the histograms.
+    :param default_weight: weight specification for categories not listed in
+        ``weights_by_category``, defaults to 1.0.
+    :param down_mode: ``"nominal"`` (default, one-sided: Down = nominal) or
+        ``"mirror"`` (Down = nominal / weights).
+    :param preserve_norm: if True, rescale each varied template — per dataset
+        and per category, flow bins included — so its total yield matches the
+        nominal one, making the variation a pure within-category shape effect
+        with no normalization component (the common rescaling is applied to all
+        bins, flow included, like an event-level weight would be). Guarantees
+        yield neutrality exactly for every dataset, which hand-tuned weight
+        arrays cannot (neutrality depends on the nominal distribution they
+        multiply). Scalar weight entries then become no-ops by construction.
+        Defaults to False.
+    :param datasets: optionally restrict the injection to these datasets
+        (within the selected samples); histograms of other datasets are carried
+        over untouched. Use it to apply different weights per year by calling
+        the function once per year with that year's datasets::
+
+            for year, weights in weights_by_year.items():
+                year_datasets = [
+                    d
+                    for s in samples
+                    for d in datasets_metadata["by_datataking_period"][year].get(s, [])
+                ]
+                histograms = add_binwise_variation(
+                    histograms, "rw", samples, {"SR": weights},
+                    preserve_norm=True, datasets=year_datasets,
+                )
+
+        Repeated calls with the same ``variation_name`` are allowed as long as
+        they touch disjoint datasets (overlaps raise "already present").
+        Datasets in the list that are absent from the histogram dicts are
+        ignored (e.g. empty datasets), but if nothing matches at all a
+        ValueError is raised. Datasets never covered by any call simply fall
+        back to nominal in the Datacard. Defaults to None (all datasets).
+    :return: new ``{sample: {dataset: hist.Hist}}`` dict with the extended
+        variation axis on the requested samples.
+    """
+    if down_mode not in ("nominal", "mirror"):
+        raise ValueError(
+            f"Unknown down_mode {down_mode!r}, expected 'nominal' or 'mirror'"
+        )
+
+    missing_samples = sorted(set(samples) - set(histograms))
+    if missing_samples:
+        raise ValueError(
+            f"Samples {missing_samples} not found in histograms "
+            f"(available: {sorted(histograms)})"
+        )
+
+    up_name = f"{variation_name}Up"
+    down_name = f"{variation_name}Down"
+
+    dataset_filter = None if datasets is None else set(datasets)
+    matched_datasets = 0
+
+    new_histograms = dict(histograms)
+    for sample in set(samples):
+        new_histograms[sample] = {}
+        for dataset, histogram in histograms[sample].items():
+            if dataset_filter is not None and dataset not in dataset_filter:
+                # carried over untouched; a later call (same variation_name,
+                # different weights) can cover it
+                new_histograms[sample][dataset] = histogram
+                continue
+            matched_datasets += 1
+            axis_names = [axis.name for axis in histogram.axes]
+            if "cat" not in axis_names or "variation" not in axis_names:
+                raise ValueError(
+                    f"Histogram for sample {sample}, dataset {dataset} has no "
+                    f"'cat'/'variation' axes (axes: {axis_names}); "
+                    "is this a data histogram?"
+                )
+            try:
+                storage_type = histogram.storage_type
+            except AttributeError:  # hist < 2.8
+                storage_type = histogram._storage_type
+            if storage_type() != hist.storage.Weight():
+                raise NotImplementedError(
+                    f"Histogram for sample {sample}, dataset {dataset} does not "
+                    "use Weight storage"
+                )
+            cat_index = axis_names.index("cat")
+            variation_index = axis_names.index("variation")
+            cat_axis = histogram.axes["cat"]
+            variation_axis = histogram.axes["variation"]
+            variable_axis = histogram.axes[-1]
+
+            unknown_categories = sorted(set(weights_by_category) - set(cat_axis))
+            if unknown_categories:
+                raise ValueError(
+                    f"Categories {unknown_categories} not found on the 'cat' axis "
+                    f"of sample {sample}, dataset {dataset} "
+                    f"(available: {list(cat_axis)})"
+                )
+            if up_name in variation_axis or down_name in variation_axis:
+                raise ValueError(
+                    f"Variation {variation_name!r} already present in histogram "
+                    f"for sample {sample}, dataset {dataset}"
+                )
+            if "nominal" not in variation_axis:
+                raise ValueError(
+                    f"No 'nominal' variation in histogram for sample {sample}, "
+                    f"dataset {dataset}"
+                )
+
+            new_variation_axis = hist.axis.StrCategory(
+                list(variation_axis) + [up_name, down_name],
+                name="variation",
+                label=variation_axis.label,
+            )
+            new_axes = list(histogram.axes)
+            new_axes[variation_index] = new_variation_axis
+            new_histogram = hist.Hist(
+                *new_axes, name=histogram.name, storage=storage_type()
+            )
+
+            old_view = histogram.view(flow=True)
+            new_view = new_histogram.view(flow=True)
+
+            def indexer(cat_i, variation_i, ndim=old_view.ndim):
+                index = [slice(None)] * ndim
+                index[cat_index] = cat_i
+                index[variation_index] = variation_i
+                return tuple(index)
+
+            # Copy the existing variations (same order, first entries of the new
+            # axis). Categorical axes have a trailing overflow slot in the
+            # flow=True view, so slice the variation axis on both sides to drop
+            # it; the (empty) overflow slots of the new view stay zero.
+            copy_index = indexer(slice(None), slice(0, len(variation_axis)))
+            new_view[copy_index] = old_view[copy_index]
+
+            nominal_i = variation_axis.index("nominal")
+            up_i = new_variation_axis.index(up_name)
+            down_i = new_variation_axis.index(down_name)
+            for category in cat_axis:
+                weights = _resolve_bin_weights(
+                    weights_by_category.get(category, default_weight),
+                    variable_axis,
+                    category,
+                )
+                if down_mode == "mirror" and np.any(weights <= 0):
+                    raise ValueError(
+                        f"down_mode='mirror' requires positive weights, got "
+                        f"minimum {weights.min()} for category {category!r}"
+                    )
+                cat_i = cat_axis.index(category)
+                # weights broadcast along the last (variable) axis
+                nominal = old_view[indexer(cat_i, nominal_i)]
+
+                def effective_weights(raw_weights):
+                    """Per-bin weights, rescaled to preserve the category yield
+                    of this dataset (flow included) when preserve_norm is on."""
+                    if not preserve_norm:
+                        return raw_weights
+                    varied_total = (nominal["value"] * raw_weights).sum()
+                    nominal_total = nominal["value"].sum()
+                    if varied_total == 0:
+                        return raw_weights
+                    return raw_weights * (nominal_total / varied_total)
+
+                up_weights = effective_weights(weights)
+                up = new_view[indexer(cat_i, up_i)]
+                up["value"] = nominal["value"] * up_weights
+                up["variance"] = nominal["variance"] * up_weights**2
+                down = new_view[indexer(cat_i, down_i)]
+                if down_mode == "nominal":
+                    down["value"] = nominal["value"]
+                    down["variance"] = nominal["variance"]
+                else:
+                    down_weights = effective_weights(1.0 / weights)
+                    down["value"] = nominal["value"] * down_weights
+                    down["variance"] = nominal["variance"] * down_weights**2
+
+            new_histograms[sample][dataset] = new_histogram
+
+    if dataset_filter is not None and matched_datasets == 0:
+        raise ValueError(
+            f"None of the requested datasets {sorted(dataset_filter)} found in "
+            f"the histograms of samples {sorted(set(samples))}"
+        )
+
+    return new_histograms
+
+
+def add_norm_variation(
+    histograms: dict[str, dict[str, hist.Hist]],
+    variation_name: str,
+    samples: list[str],
+    scale_by_category: dict[str, float],
+    default_scale: float = 1.0,
+    down_mode: str = "nominal",
+    datasets: list[str] | None = None,
+) -> dict[str, dict[str, hist.Hist]]:
+    """Add an artificial per-category normalization variation to the variation axis.
+
+    Special case of :func:`add_binwise_variation` with one scalar factor per
+    category: ``{variation_name}Up`` is the nominal scaled by
+    ``scale_by_category[category]`` in every bin of that category (under/overflow
+    included; ``default_scale`` for categories not listed), so the bin-by-bin
+    shape within a category is untouched. ``{variation_name}Down`` is the
+    nominal itself by default (one-sided), or nominal divided by the factor with
+    ``down_mode="mirror"``.
+
+    Typical use — model a 4FS vs 5FS normalization difference on the ttbb
+    samples::
+
+        histograms = add_norm_variation(
+            histograms,
+            variation_name="4Fvs5F",
+            samples=[s for s in histograms if s.startswith("TTBB")],
+            scale_by_category={"CR": 1.0081, "SR": 0.9143, "CR_ttlf": 1.1309},
+        )
+
+    and declare ``SystematicUncertainty(name="4Fvs5F", typ="shape", ...)``.
+
+    .. note::
+       If the affected process has a free rateParam and the datacard is built
+       with ``shape_only_for_rateparam=True``, the overall normalization of this
+       variation is absorbed by the rateParam rescaling: only the *relative*
+       differences between the per-category factors survive. Equal factors in
+       all fit categories then make the variation a no-op.
+
+    See :func:`add_binwise_variation` for the parameter documentation.
+    """
+    for category, scale in scale_by_category.items():
+        if np.ndim(scale) != 0:
+            raise ValueError(
+                f"scale_by_category[{category!r}] must be a scalar, got "
+                f"{scale!r}; use add_binwise_variation for per-bin weights"
+            )
+    return add_binwise_variation(
+        histograms,
+        variation_name=variation_name,
+        samples=samples,
+        weights_by_category=scale_by_category,
+        default_weight=default_scale,
+        down_mode=down_mode,
+        datasets=datasets,
+    )

--- a/pocket_coffea/utils/stat/systematics.py
+++ b/pocket_coffea/utils/stat/systematics.py
@@ -11,7 +11,9 @@ class SystematicUncertainty:
     Store information about one systematic uncertainty.
 
     :param name: Name of the systematic uncertainty.
-    :param typ: Type of the systematic uncertainty (e.g. 'shape', 'lnN').
+    :param typ: Type of the systematic uncertainty as written in the datacard: 'lnN' or one of
+        the Combine shape flavours 'shape', 'shapeN', 'shapeU', 'shape?'. All shape flavours
+        need Up/Down templates and are handled alike; only the datacard line differs.
     :param processes: List or tuple of process names affected, or a dict mapping process names to values.
     :param years: List or tuple of years the uncertainty applies to.
     :param value: Value (float or tuple of floats) of the uncertainty for all processes, or None if using a dict for processes.
@@ -129,13 +131,21 @@ class Systematics(dict[str, SystematicUncertainty]):
         """Number of Systematics"""
         return len(self.keys())
 
+    @staticmethod
+    def _is_type(syst: SystematicUncertainty, syst_type: str) -> bool:
+        # "shape" covers every Combine shape flavour (shape, shapeN, shapeU, shape?):
+        # they all carry Up/Down templates and only differ in the datacard line.
+        if syst_type == "shape":
+            return syst.typ.startswith("shape")
+        return syst.typ == syst_type
+
     def list_type(self, syst_type: str) -> list[str]:
-        """List of Names of Systematics of a specific type."""
-        return [key for key in self if self[key].typ == syst_type]
+        """List of Names of Systematics of a specific type ("shape" matches all shape flavours)."""
+        return [key for key in self if self._is_type(self[key], syst_type)]
 
     def get_systematics_by_type(self, syst_type: str) -> dict[SystematicUncertainty]:
-        """Dict of Systematics of a specific type."""
-        return {name: syst for name, syst in self.items() if syst.typ == syst_type}
+        """Dict of Systematics of a specific type ("shape" matches all shape flavours)."""
+        return {name: syst for name, syst in self.items() if self._is_type(syst, syst_type)}
 
     def get_systematics_by_process(
         self, process: Process

--- a/tests/test_stat_datacards.py
+++ b/tests/test_stat_datacards.py
@@ -132,7 +132,7 @@ def _norm_variation_histogram(categories=("CR", "SR")):
     return histogram
 
 
-def _norm_variation_datacard(category, bins_edges=None, histogram=None, **kwargs):
+def _norm_variation_datacard(category, bins_edges=None, histogram=None, typ="shape", **kwargs):
     """One rateParam process on the ``_norm_variation_histogram`` input."""
     year, sample, dataset = "2018", "ttbb_sample", "ttbb_dataset"
     if histogram is None:
@@ -161,7 +161,7 @@ def _norm_variation_datacard(category, bins_edges=None, histogram=None, **kwargs
             [
                 SystematicUncertainty(
                     name="norm",
-                    typ="shape",
+                    typ=typ,
                     processes=["ttbb"],
                     years=[year],
                     value=1.0,
@@ -239,3 +239,15 @@ def test_rateparam_scale_from_norm_histograms():
     assert dc_sr.histogram["ttbb_2018", "nominal", :].values().sum() == pytest.approx(
         20.0
     )
+
+
+def test_shapeu_systematic_gets_templates_and_datacard_type():
+    # Combine shape flavours (shapeU here) must be treated like "shape" everywhere
+    # templates are needed, and written with their own type in the card.
+    dc = _norm_variation_datacard("SR", typ="shapeU")
+    assert list(dc.systematics.get_systematics_by_type("shape")) == ["norm"]
+    assert dc.systematics.get_systematics_by_type("shapeU")["norm"].typ == "shapeU"
+    assert "normUp" in dc.histogram.axes["variation"]
+    assert "ttbb_2018_normUp" in dc.create_shape_histogram_dict()
+    (line,) = [l for l in dc.systematics_section().splitlines() if l.startswith("norm")]
+    assert line.split()[1] == "shapeU"

--- a/tests/test_stat_datacards.py
+++ b/tests/test_stat_datacards.py
@@ -106,3 +106,97 @@ def test_rate_matches_clipped_template_integral():
 def test_rate_unchanged_without_negative_bins():
     dc = _single_process_datacard([10.0, 3.0, 5.0, 2.0])
     assert dc.rate("sig_2018") == pytest.approx(20.0)
+
+
+def _norm_variation_datacard(category, bins_edges=None):
+    """One rateParam process, two categories with disjoint x ranges, and an
+    artificial norm variation (+20% in SR only): CR content sits at low x, so a
+    card rebinned to [0.8, 1.0] only keeps it in the underflow."""
+    year, sample, dataset = "2018", "ttbb_sample", "ttbb_dataset"
+    histogram = hist.Hist(
+        hist.axis.StrCategory(["CR", "SR"], name="cat"),
+        hist.axis.StrCategory(["nominal", "normUp", "normDown"], name="variation"),
+        hist.axis.Regular(10, 0, 1, name="x"),
+        storage=hist.storage.Weight(),
+    )
+    view = histogram.view()
+    cr = histogram.axes["cat"].index("CR")
+    sr = histogram.axes["cat"].index("SR")
+    for variation_i, scale_sr in ((0, 1.0), (1, 1.2), (2, 1.0)):
+        view["value"][cr, variation_i, 0] = 10.0  # x ~ 0.05, out of [0.8, 1.0]
+        view["value"][sr, variation_i, 9] = 20.0 * scale_sr  # x ~ 0.95
+        view["variance"][cr, variation_i, 0] = 10.0
+        view["variance"][sr, variation_i, 9] = 20.0 * scale_sr
+    return Datacard(
+        histograms={sample: {dataset: histogram}},
+        datasets_metadata={"by_datataking_period": {year: {sample: [dataset]}}},
+        cutflow={"presel": {dataset: {"nominal": 100}}},
+        years=[year],
+        mc_processes=MCProcesses(
+            [
+                MCProcess(
+                    name="ttbb",
+                    samples=[sample],
+                    is_signal=True,
+                    years=[year],
+                    has_rateParam=True,
+                )
+            ]
+        ),
+        systematics=Systematics(
+            [
+                SystematicUncertainty(
+                    name="norm",
+                    typ="shape",
+                    processes=["ttbb"],
+                    years=[year],
+                    value=1.0,
+                )
+            ]
+        ),
+        category=category,
+        bins_edges=bins_edges,
+        verbose=False,
+        shape_only_for_rateparam=True,
+        rateparam_norm_categories=["CR", "SR"],
+    )
+
+
+def test_rateparam_scale_consistent_across_rebinned_cards():
+    # Regression: the shape-only factor must be computed from category-inclusive
+    # totals. The SR card rebins to [0.8, 1.0], pushing all CR content into the
+    # underflow; rearrange_histograms must keep that flow content so the SR card
+    # derives the same Sum(nominal)/Sum(varied) as the unrebinned CR card, not an
+    # SR-only factor (the old behavior: 30/36 -> 20/24).
+    dc_sr = _norm_variation_datacard("SR", bins_edges=[0.8, 0.9, 1.0])
+    dc_cr = _norm_variation_datacard("CR")
+    expected = 30.0 / 34.0  # (10 + 20) / (10 + 1.2 * 20)
+
+    scales_sr = dc_sr.compute_rateparam_shape_scales()
+    scales_cr = dc_cr.compute_rateparam_shape_scales()
+    assert scales_sr[("ttbb", "norm", "Up")] == pytest.approx(expected)
+    assert scales_cr[("ttbb", "norm", "Up")] == pytest.approx(expected)
+    assert scales_sr[("ttbb", "norm", "Down")] == pytest.approx(1.0)
+
+    # the rearranged histogram keeps the rebinning underflow (10 from CR-range x)
+    assert dc_sr.rearrange_histograms(category="CR")[
+        "ttbb_2018", "nominal", :
+    ].values(flow=True).sum() == pytest.approx(10.0)
+
+    # written in-range templates: the relative SR/CR response stays the injected
+    # +20%, and both cards share the same overall rescaling
+    dc_sr.rateparam_shape_scale = scales_sr
+    dc_cr.rateparam_shape_scale = scales_cr
+    templates_sr = dc_sr.create_shape_histogram_dict()
+    templates_cr = dc_cr.create_shape_histogram_dict()
+    ratio_sr = (
+        templates_sr["ttbb_2018_normUp"].values().sum()
+        / templates_sr["ttbb_2018_nominal"].values().sum()
+    )
+    ratio_cr = (
+        templates_cr["ttbb_2018_normUp"].values().sum()
+        / templates_cr["ttbb_2018_nominal"].values().sum()
+    )
+    assert ratio_sr == pytest.approx(1.2 * expected)
+    assert ratio_cr == pytest.approx(1.0 * expected)
+    assert ratio_sr / ratio_cr == pytest.approx(1.2)

--- a/tests/test_stat_datacards.py
+++ b/tests/test_stat_datacards.py
@@ -108,25 +108,39 @@ def test_rate_unchanged_without_negative_bins():
     assert dc.rate("sig_2018") == pytest.approx(20.0)
 
 
-def _norm_variation_datacard(category, bins_edges=None):
-    """One rateParam process, two categories with disjoint x ranges, and an
-    artificial norm variation (+20% in SR only): CR content sits at low x, so a
-    card rebinned to [0.8, 1.0] only keeps it in the underflow."""
-    year, sample, dataset = "2018", "ttbb_sample", "ttbb_dataset"
+def _norm_variation_histogram(categories=("CR", "SR")):
+    """Two categories with disjoint x ranges and an artificial norm variation
+    (+20% in SR only): CR content sits at low x, so a card rebinned to [0.8, 1.0]
+    only keeps it in the underflow. ``categories`` restricts the category axis
+    (like ``HistConf(only_categories=...)``)."""
     histogram = hist.Hist(
-        hist.axis.StrCategory(["CR", "SR"], name="cat"),
+        hist.axis.StrCategory(list(categories), name="cat"),
         hist.axis.StrCategory(["nominal", "normUp", "normDown"], name="variation"),
         hist.axis.Regular(10, 0, 1, name="x"),
         storage=hist.storage.Weight(),
     )
     view = histogram.view()
-    cr = histogram.axes["cat"].index("CR")
-    sr = histogram.axes["cat"].index("SR")
     for variation_i, scale_sr in ((0, 1.0), (1, 1.2), (2, 1.0)):
-        view["value"][cr, variation_i, 0] = 10.0  # x ~ 0.05, out of [0.8, 1.0]
-        view["value"][sr, variation_i, 9] = 20.0 * scale_sr  # x ~ 0.95
-        view["variance"][cr, variation_i, 0] = 10.0
-        view["variance"][sr, variation_i, 9] = 20.0 * scale_sr
+        if "CR" in categories:
+            cr = histogram.axes["cat"].index("CR")
+            view["value"][cr, variation_i, 0] = 10.0  # x ~ 0.05, out of [0.8, 1.0]
+            view["variance"][cr, variation_i, 0] = 10.0
+        if "SR" in categories:
+            sr = histogram.axes["cat"].index("SR")
+            view["value"][sr, variation_i, 9] = 20.0 * scale_sr  # x ~ 0.95
+            view["variance"][sr, variation_i, 9] = 20.0 * scale_sr
+    return histogram
+
+
+def _norm_variation_datacard(category, bins_edges=None, histogram=None, **kwargs):
+    """One rateParam process on the ``_norm_variation_histogram`` input."""
+    year, sample, dataset = "2018", "ttbb_sample", "ttbb_dataset"
+    if histogram is None:
+        histogram = _norm_variation_histogram()
+    if "rateparam_norm_histograms" in kwargs:
+        kwargs["rateparam_norm_histograms"] = {
+            sample: {dataset: kwargs["rateparam_norm_histograms"]}
+        }
     return Datacard(
         histograms={sample: {dataset: histogram}},
         datasets_metadata={"by_datataking_period": {year: {sample: [dataset]}}},
@@ -159,6 +173,7 @@ def _norm_variation_datacard(category, bins_edges=None):
         verbose=False,
         shape_only_for_rateparam=True,
         rateparam_norm_categories=["CR", "SR"],
+        **kwargs,
     )
 
 
@@ -200,3 +215,27 @@ def test_rateparam_scale_consistent_across_rebinned_cards():
     assert ratio_sr == pytest.approx(1.2 * expected)
     assert ratio_cr == pytest.approx(1.0 * expected)
     assert ratio_sr / ratio_cr == pytest.approx(1.2)
+
+
+def test_rateparam_scale_from_norm_histograms():
+    # A card whose variable is filled in SR only (only_categories) cannot read the
+    # CR totals from its own histogram: it must fail loudly, and it must derive the
+    # same category-inclusive factor when a histogram filled in every norm category
+    # is given as `rateparam_norm_histograms`.
+    sr_only = _norm_variation_histogram(categories=("SR",))
+    with pytest.raises(ValueError, match="rateparam_norm_histograms"):
+        _norm_variation_datacard("SR", histogram=sr_only).compute_rateparam_shape_scales()
+
+    dc_sr = _norm_variation_datacard(
+        "SR",
+        bins_edges=[0.8, 0.9, 1.0],
+        histogram=sr_only,
+        rateparam_norm_histograms=_norm_variation_histogram(),
+    )
+    scales = dc_sr.compute_rateparam_shape_scales()
+    assert scales[("ttbb", "norm", "Up")] == pytest.approx(30.0 / 34.0)
+    assert scales[("ttbb", "norm", "Down")] == pytest.approx(1.0)
+    # the card's own (SR-only, rebinned) templates are untouched by the norm input
+    assert dc_sr.histogram["ttbb_2018", "nominal", :].values().sum() == pytest.approx(
+        20.0
+    )

--- a/tests/test_stat_shape_manipulation.py
+++ b/tests/test_stat_shape_manipulation.py
@@ -1,0 +1,396 @@
+"""Offline unit tests for the artificial per-category normalization variation."""
+import hist
+import numpy as np
+import pytest
+
+from pocket_coffea.utils.stat.combine import Datacard
+from pocket_coffea.utils.stat.processes import MCProcess, MCProcesses
+from pocket_coffea.utils.stat.shape_manipulation import (
+    add_binwise_variation,
+    add_norm_variation,
+)
+from pocket_coffea.utils.stat.systematics import Systematics, SystematicUncertainty
+
+
+def _make_hist(categories, variations, values_by_cat):
+    """Build a (cat, variation, x) Weight histogram; every variation gets the
+    same per-category values, variance = |value|."""
+    nbins = len(next(iter(values_by_cat.values())))
+    histogram = hist.Hist(
+        hist.axis.StrCategory(categories, name="cat", label="Category"),
+        hist.axis.StrCategory(variations, name="variation", label="Variation"),
+        hist.axis.Regular(nbins, 0, nbins, name="x"),
+        storage=hist.storage.Weight(),
+    )
+    view = histogram.view()
+    for cat, values in values_by_cat.items():
+        cat_i = histogram.axes["cat"].index(cat)
+        for variation_i in range(len(variations)):
+            view["value"][cat_i, variation_i, :] = values
+            view["variance"][cat_i, variation_i, :] = np.abs(values)
+    return histogram
+
+
+def test_add_norm_variation_scales_nominal_per_category():
+    histogram = _make_hist(
+        ["CR", "SR"],
+        ["nominal", "existingUp"],
+        {"CR": [1.0, 2.0], "SR": [3.0, 4.0]},
+    )
+    histograms = {
+        "ttbb_dilep": {"dset": histogram},
+        "other": {"dset": histogram.copy()},
+    }
+    out = add_norm_variation(
+        histograms,
+        variation_name="fs45",
+        samples=["ttbb_dilep"],
+        scale_by_category={"SR": 1.2},
+    )
+
+    new = out["ttbb_dilep"]["dset"]
+    assert list(new.axes["variation"]) == ["nominal", "existingUp", "fs45Up", "fs45Down"]
+
+    # existing variations copied untouched
+    for variation in ("nominal", "existingUp"):
+        for cat in ("CR", "SR"):
+            assert np.array_equal(
+                new[cat, variation, :].view(), histogram[cat, variation, :].view()
+            )
+
+    # Up: scaled in SR, default factor 1.0 in CR; variance scales quadratically
+    assert np.allclose(new["SR", "fs45Up", :].values(), np.array([3.0, 4.0]) * 1.2)
+    assert np.allclose(
+        new["SR", "fs45Up", :].variances(), np.array([3.0, 4.0]) * 1.2**2
+    )
+    assert np.array_equal(new["CR", "fs45Up", :].view(), histogram["CR", "nominal", :].view())
+
+    # Down: one-sided, identical to nominal
+    for cat in ("CR", "SR"):
+        assert np.array_equal(
+            new[cat, "fs45Down", :].view(), histogram[cat, "nominal", :].view()
+        )
+
+    # input not mutated; untouched samples shared by reference
+    assert list(histogram.axes["variation"]) == ["nominal", "existingUp"]
+    assert out["other"]["dset"] is histograms["other"]["dset"]
+
+
+def test_add_norm_variation_mirror_down():
+    histogram = _make_hist(["SR"], ["nominal"], {"SR": [2.0, 4.0]})
+    out = add_norm_variation(
+        {"s": {"d": histogram}},
+        variation_name="fs45",
+        samples=["s"],
+        scale_by_category={"SR": 2.0},
+        down_mode="mirror",
+    )
+    new = out["s"]["d"]
+    assert np.allclose(new["SR", "fs45Up", :].values(), [4.0, 8.0])
+    assert np.allclose(new["SR", "fs45Down", :].values(), [1.0, 2.0])
+    assert np.allclose(new["SR", "fs45Down", :].variances(), [0.5, 1.0])
+
+
+def test_add_norm_variation_validations():
+    histogram = _make_hist(["SR"], ["nominal"], {"SR": [1.0]})
+    histograms = {"s": {"d": histogram}}
+    with pytest.raises(ValueError, match="not found in histograms"):
+        add_norm_variation(histograms, "v", ["typo"], {"SR": 1.1})
+    with pytest.raises(ValueError, match="not found on the 'cat' axis"):
+        add_norm_variation(histograms, "v", ["s"], {"typo_cat": 1.1})
+    with pytest.raises(ValueError, match="down_mode"):
+        add_norm_variation(histograms, "v", ["s"], {"SR": 1.1}, down_mode="typo")
+    already = _make_hist(["SR"], ["nominal", "vUp"], {"SR": [1.0]})
+    with pytest.raises(ValueError, match="already present"):
+        add_norm_variation({"s": {"d": already}}, "v", ["s"], {"SR": 1.1})
+
+
+def test_add_binwise_variation_per_bin_weights():
+    histogram = _make_hist(
+        ["CR", "SR"],
+        ["nominal"],
+        {"CR": [1.0, 2.0], "SR": [3.0, 4.0]},
+    )
+    # put content in the flow bins of SR to check they keep weight 1
+    view = histogram.view(flow=True)
+    sr = histogram.axes["cat"].index("SR")
+    view["value"][sr, 0, 0] = 7.0  # underflow
+    view["value"][sr, 0, -1] = 9.0  # overflow
+
+    out = add_binwise_variation(
+        {"s": {"d": histogram}},
+        variation_name="rw",
+        samples=["s"],
+        weights_by_category={"SR": [1.5, 0.5]},
+    )
+    new = out["s"]["d"]
+    # in-range bins reweighted, variances with the squared weight
+    assert np.allclose(new["SR", "rwUp", :].values(), [3.0 * 1.5, 4.0 * 0.5])
+    assert np.allclose(new["SR", "rwUp", :].variances(), [3.0 * 1.5**2, 4.0 * 0.5**2])
+    # flow bins untouched by an in-range weight array
+    up_flow = new["SR", "rwUp", :].view(flow=True)
+    assert up_flow["value"][0] == pytest.approx(7.0)
+    assert up_flow["value"][-1] == pytest.approx(9.0)
+    # unlisted category gets default weight 1.0; Down = nominal everywhere
+    assert np.array_equal(new["CR", "rwUp", :].view(), histogram["CR", "nominal", :].view())
+    for cat in ("CR", "SR"):
+        assert np.array_equal(
+            new[cat, "rwDown", :].view(flow=True),
+            histogram[cat, "nominal", :].view(flow=True),
+        )
+
+
+def test_add_binwise_variation_extent_weights_scale_flow():
+    histogram = _make_hist(["SR"], ["nominal"], {"SR": [2.0, 4.0]})
+    view = histogram.view(flow=True)
+    view["value"][0, 0, 0] = 6.0  # underflow
+    view["value"][0, 0, -1] = 8.0  # overflow
+    # extent = underflow + 2 bins + overflow
+    out = add_binwise_variation(
+        {"s": {"d": histogram}},
+        variation_name="rw",
+        samples=["s"],
+        weights_by_category={"SR": [2.0, 1.5, 0.5, 3.0]},
+    )
+    up_flow = out["s"]["d"]["SR", "rwUp", :].view(flow=True)
+    assert np.allclose(up_flow["value"], [12.0, 3.0, 2.0, 24.0])
+
+
+def test_add_binwise_variation_scalar_matches_norm_variation():
+    histogram = _make_hist(
+        ["CR", "SR"], ["nominal", "otherUp"], {"CR": [1.0, 2.0], "SR": [3.0, 4.0]}
+    )
+    histograms = {"s": {"d": histogram}}
+    out_norm = add_norm_variation(
+        histograms, "v", ["s"], scale_by_category={"SR": 1.2}
+    )
+    out_binwise = add_binwise_variation(
+        histograms, "v", ["s"], weights_by_category={"SR": 1.2}
+    )
+    assert np.array_equal(
+        out_norm["s"]["d"].view(flow=True), out_binwise["s"]["d"].view(flow=True)
+    )
+
+
+def test_add_binwise_variation_mirror_down():
+    histogram = _make_hist(["SR"], ["nominal"], {"SR": [2.0, 4.0]})
+    out = add_binwise_variation(
+        {"s": {"d": histogram}},
+        variation_name="rw",
+        samples=["s"],
+        weights_by_category={"SR": [2.0, 0.5]},
+        down_mode="mirror",
+    )
+    new = out["s"]["d"]
+    assert np.allclose(new["SR", "rwUp", :].values(), [4.0, 2.0])
+    assert np.allclose(new["SR", "rwDown", :].values(), [1.0, 8.0])
+    assert np.allclose(new["SR", "rwDown", :].variances(), [0.5, 16.0])
+
+
+def test_add_binwise_variation_preserve_norm():
+    histogram = _make_hist(
+        ["CR", "SR"], ["nominal"], {"CR": [1.0, 2.0], "SR": [3.0, 4.0]}
+    )
+    # flow content participates in the renormalization
+    view = histogram.view(flow=True)
+    sr = histogram.axes["cat"].index("SR")
+    view["value"][sr, 0, 0] = 1.0  # underflow
+    out = add_binwise_variation(
+        {"s": {"d": histogram}},
+        variation_name="rw",
+        samples=["s"],
+        weights_by_category={"SR": [2.0, 0.5]},
+        preserve_norm=True,
+    )
+    new = out["s"]["d"]
+    up = new["SR", "rwUp", :].view(flow=True)["value"]
+    nominal = histogram["SR", "nominal", :].view(flow=True)["value"]
+    # yield preserved exactly (flow included): pure shape variation
+    assert up.sum() == pytest.approx(nominal.sum())
+    # bins follow the weights up to one common factor:
+    # raw varied = [1*1, 3*2, 4*0.5, 0] = [1, 6, 2, 0], total 9 vs nominal 8
+    r = 8.0 / 9.0
+    assert np.allclose(up, np.array([1.0, 6.0, 2.0, 0.0]) * r)
+    nominal_variance = histogram["SR", "nominal", :].view(flow=True)["variance"]
+    assert np.allclose(
+        new["SR", "rwUp", :].view(flow=True)["variance"],
+        nominal_variance * np.array([1.0, 2.0, 0.5, 1.0]) ** 2 * r**2,
+    )
+    # unlisted category: weights 1 everywhere -> renormalization is a no-op
+    assert np.array_equal(
+        new["CR", "rwUp", :].view(), histogram["CR", "nominal", :].view()
+    )
+
+
+def test_add_binwise_variation_preserve_norm_mirror_and_scalar():
+    histogram = _make_hist(["SR"], ["nominal"], {"SR": [2.0, 4.0]})
+    out = add_binwise_variation(
+        {"s": {"d": histogram}},
+        variation_name="rw",
+        samples=["s"],
+        weights_by_category={"SR": [2.0, 0.5]},
+        down_mode="mirror",
+        preserve_norm=True,
+    )
+    new = out["s"]["d"]
+    assert new["SR", "rwUp", :].values().sum() == pytest.approx(6.0)
+    assert new["SR", "rwDown", :].values().sum() == pytest.approx(6.0)
+    # mirror weights 1/w renormalized independently: raw down [1, 8] -> r = 6/9
+    assert np.allclose(new["SR", "rwDown", :].values(), np.array([1.0, 8.0]) * 6.0 / 9.0)
+
+    # a scalar weight under preserve_norm is a no-op by construction
+    out_scalar = add_binwise_variation(
+        {"s": {"d": histogram}},
+        variation_name="rw",
+        samples=["s"],
+        weights_by_category={"SR": 1.3},
+        preserve_norm=True,
+    )
+    assert np.array_equal(
+        out_scalar["s"]["d"]["SR", "rwUp", :].view(flow=True),
+        histogram["SR", "nominal", :].view(flow=True),
+    )
+
+
+def test_add_binwise_variation_per_year_datasets():
+    h_2024 = _make_hist(["SR"], ["nominal"], {"SR": [2.0, 4.0]})
+    h_2022 = _make_hist(["SR"], ["nominal"], {"SR": [1.0, 3.0]})
+    histograms = {"s": {"ds_2024": h_2024, "ds_2022": h_2022}}
+
+    # first call: 2024 only; 2022 carried over untouched (shared reference)
+    out = add_binwise_variation(
+        histograms, "rw", ["s"], {"SR": [1.5, 0.5]}, datasets=["ds_2024"]
+    )
+    assert out["s"]["ds_2022"] is h_2022
+    assert np.allclose(out["s"]["ds_2024"]["SR", "rwUp", :].values(), [3.0, 2.0])
+
+    # second call, same variation name, different weights for 2022
+    # (missing/empty datasets in the list are tolerated)
+    out2 = add_binwise_variation(
+        out, "rw", ["s"], {"SR": [2.0, 1.0]}, datasets=["ds_2022", "ds_empty"]
+    )
+    assert np.allclose(out2["s"]["ds_2022"]["SR", "rwUp", :].values(), [2.0, 3.0])
+    assert out2["s"]["ds_2024"] is out["s"]["ds_2024"]
+
+    # overlapping call on an already-covered dataset raises
+    with pytest.raises(ValueError, match="already present"):
+        add_binwise_variation(out2, "rw", ["s"], {"SR": 1.1}, datasets=["ds_2024"])
+
+    # a filter matching nothing raises (typo protection)
+    with pytest.raises(ValueError, match="None of the requested datasets"):
+        add_binwise_variation(histograms, "rw2", ["s"], {"SR": 1.1}, datasets=["typo"])
+
+    # wrapper passes the filter through
+    out_norm = add_norm_variation(
+        histograms, "vn", ["s"], scale_by_category={"SR": 1.2}, datasets=["ds_2024"]
+    )
+    assert out_norm["s"]["ds_2022"] is h_2022
+    assert np.allclose(out_norm["s"]["ds_2024"]["SR", "vnUp", :].values(), [2.4, 4.8])
+
+
+def test_add_binwise_variation_validations():
+    histogram = _make_hist(["SR"], ["nominal"], {"SR": [1.0, 2.0]})
+    histograms = {"s": {"d": histogram}}
+    with pytest.raises(ValueError, match="length 3, expected"):
+        add_binwise_variation(histograms, "v", ["s"], {"SR": [1.0, 1.0, 1.0]})
+    with pytest.raises(ValueError, match="scalar or a 1D array"):
+        add_binwise_variation(histograms, "v", ["s"], {"SR": [[1.0], [1.0]]})
+    with pytest.raises(ValueError, match="positive weights"):
+        add_binwise_variation(
+            histograms, "v", ["s"], {"SR": [1.0, 0.0]}, down_mode="mirror"
+        )
+    with pytest.raises(ValueError, match="must be a scalar"):
+        add_norm_variation(histograms, "v", ["s"], scale_by_category={"SR": [1.0, 1.0]})
+
+
+def _two_sample_datacard(scale_by_category, category, shape_only_for_rateparam=False):
+    """One ttbb process made of a dilep sample (gets the variation) and a semilep
+    sample (falls back to nominal), two categories CR/SR."""
+    year = "2018"
+    dilep = _make_hist(["CR", "SR"], ["nominal"], {"CR": [10.0], "SR": [20.0]})
+    semilep = _make_hist(["CR", "SR"], ["nominal"], {"CR": [100.0], "SR": [200.0]})
+    histograms = {"dilep": {"dilep_dset": dilep}, "semilep": {"semilep_dset": semilep}}
+    histograms = add_norm_variation(
+        histograms,
+        variation_name="fs45",
+        samples=["dilep"],
+        scale_by_category=scale_by_category,
+    )
+    datacard = Datacard(
+        histograms=histograms,
+        datasets_metadata={
+            "by_datataking_period": {
+                year: {"dilep": ["dilep_dset"], "semilep": ["semilep_dset"]}
+            }
+        },
+        cutflow={
+            "presel": {
+                "dilep_dset": {"nominal": 100},
+                "semilep_dset": {"nominal": 100},
+            }
+        },
+        years=[year],
+        mc_processes=MCProcesses(
+            [
+                MCProcess(
+                    name="ttbb",
+                    samples=["dilep", "semilep"],
+                    is_signal=True,
+                    years=[year],
+                    has_rateParam=True,
+                )
+            ]
+        ),
+        systematics=Systematics(
+            [
+                SystematicUncertainty(
+                    name="fs45",
+                    typ="shape",
+                    processes=["ttbb"],
+                    years=[year],
+                    value=1.0,
+                )
+            ]
+        ),
+        category=category,
+        verbose=False,
+        shape_only_for_rateparam=shape_only_for_rateparam,
+        rateparam_norm_categories=["CR", "SR"] if shape_only_for_rateparam else None,
+    )
+    if shape_only_for_rateparam:
+        datacard.rateparam_shape_scale = datacard.compute_rateparam_shape_scales()
+    return datacard
+
+
+def test_one_sided_variation_through_datacard():
+    dc = _two_sample_datacard({"SR": 1.2}, category="SR")
+    templates = dc.create_shape_histogram_dict(is_data=False)
+    # Up = scaled dilep + nominal semilep (semilep falls back to nominal)
+    assert templates["ttbb_2018_fs45Up"].values().sum() == pytest.approx(
+        20.0 * 1.2 + 200.0
+    )
+    # one-sided: Down template identical to nominal
+    assert templates["ttbb_2018_fs45Down"].values().sum() == pytest.approx(220.0)
+    assert dc.rate("ttbb_2018") == pytest.approx(220.0)
+    # CR untouched (factor defaults to 1.0)
+    dc_cr = _two_sample_datacard({"SR": 1.2}, category="CR")
+    templates_cr = dc_cr.create_shape_histogram_dict(is_data=False)
+    assert templates_cr["ttbb_2018_fs45Up"].values().sum() == pytest.approx(110.0)
+
+
+def test_interaction_with_shape_only_for_rateparam():
+    # Overall normalization is stripped: only the relative CR/SR difference stays.
+    dc = _two_sample_datacard({"SR": 1.2}, category="SR", shape_only_for_rateparam=True)
+    templates = dc.create_shape_histogram_dict(is_data=False)
+    total_nominal = 330.0  # (10+100) + (20+200)
+    total_up = 110.0 + 224.0
+    expected = 224.0 * total_nominal / total_up
+    assert templates["ttbb_2018_fs45Up"].values().sum() == pytest.approx(expected)
+    assert templates["ttbb_2018_fs45Up"].values().sum() != pytest.approx(224.0)
+
+    # Equal factors in every category are fully absorbed by the rateParam: no-op.
+    dc_flat = _two_sample_datacard(
+        {"CR": 1.2, "SR": 1.2}, category="SR", shape_only_for_rateparam=True
+    )
+    templates_flat = dc_flat.create_shape_histogram_dict(is_data=False)
+    assert templates_flat["ttbb_2018_fs45Up"].values().sum() == pytest.approx(220.0)

--- a/tests/test_stat_shape_manipulation.py
+++ b/tests/test_stat_shape_manipulation.py
@@ -8,6 +8,7 @@ from pocket_coffea.utils.stat.processes import MCProcess, MCProcesses
 from pocket_coffea.utils.stat.shape_manipulation import (
     add_binwise_variation,
     add_norm_variation,
+    rescale_histograms,
 )
 from pocket_coffea.utils.stat.systematics import Systematics, SystematicUncertainty
 
@@ -301,6 +302,41 @@ def test_add_binwise_variation_validations():
         )
     with pytest.raises(ValueError, match="must be a scalar"):
         add_norm_variation(histograms, "v", ["s"], scale_by_category={"SR": [1.0, 1.0]})
+
+
+def test_rescale_histograms():
+    h_2024 = _make_hist(
+        ["CR", "SR"], ["nominal", "vUp"], {"CR": [1.0, 2.0], "SR": [3.0, 4.0]}
+    )
+    h_2022 = _make_hist(["SR"], ["nominal"], {"SR": [1.0, 3.0]})
+    other = h_2022.copy()
+    histograms = {"s": {"ds_2024": h_2024, "ds_2022": h_2022}, "other": {"d": other}}
+
+    out = rescale_histograms(histograms, ["s"], 1.5, datasets=["ds_2024", "ds_empty"])
+    new = out["s"]["ds_2024"]
+    # every category and variation, flow included; variance scales quadratically
+    assert list(new.axes["variation"]) == ["nominal", "vUp"]
+    assert np.allclose(
+        new.view(flow=True)["value"], h_2024.view(flow=True)["value"] * 1.5
+    )
+    assert np.allclose(
+        new.view(flow=True)["variance"], h_2024.view(flow=True)["variance"] * 1.5**2
+    )
+    # untouched datasets/samples shared by reference, input not mutated
+    assert out["s"]["ds_2022"] is h_2022
+    assert out["other"]["d"] is other
+    assert np.allclose(h_2024["SR", "nominal", :].values(), [3.0, 4.0])
+
+    # datasets=None rescales every dataset of the sample
+    out_all = rescale_histograms(histograms, ["s"], 2.0)
+    assert np.allclose(out_all["s"]["ds_2022"]["SR", "nominal", :].values(), [2.0, 6.0])
+
+    with pytest.raises(ValueError, match="not found in histograms"):
+        rescale_histograms(histograms, ["typo"], 2.0)
+    with pytest.raises(ValueError, match="None of the requested datasets"):
+        rescale_histograms(histograms, ["s"], 2.0, datasets=["typo"])
+    with pytest.raises(ValueError, match="must be a scalar"):
+        rescale_histograms(histograms, ["s"], [1.0, 2.0])
 
 
 def _two_sample_datacard(scale_by_category, category, shape_only_for_rateparam=False):


### PR DESCRIPTION
…New module pocket_coffea/utils/stat/shape_manipulation.py with two helpers that inject artificial variations into the coffea histogram dicts before building a Datacard, by appending {name}Up/{name}Down entries to the `variation` StrCategory axis (declared downstream as regular `shape` SystematicUncertainty; samples without the variation fall back to nominal):

- add_norm_variation: Up = nominal x one scalar factor per category (pure normalization effect, flow bins included)
- add_binwise_variation: Up = nominal reweighted bin by bin along the variable axis with per-category weight arrays (length = in-range bins, flow keeps weight 1, or length = extent to weight flow explicitly; scalars behave like the norm case, and add_norm_variation delegates to this helper). Weights refer to the binning before any bins_edges rebinning. Options: down_mode="nominal" (one-sided, default) or "mirror" (nominal / weights); preserve_norm=True rescales each varied template per dataset and category (flow included) so its yield matches nominal exactly, i.e. a pure within-category shape variation with no normalization component; datasets=[...] restricts the injection so the same variation can be built with different weights per year through repeated calls over disjoint dataset sets.
