### PR TITLE
check-jobs: detect held condor jobs and resubmit increasing memory

### DIFF
--- a/pocket_coffea/scripts/check_jobs.py
+++ b/pocket_coffea/scripts/check_jobs.py
@@ -5,9 +5,16 @@ The status of the jobs can be checked by looking at the file in the jobs folder.
 - job_x.idle: The job is waiting to be executed
 - job_x.running: The job is running
 - job_x.done: The job has finished
-- job_x.failed: The job has failed
-    
+- job_x.failed: The job has failed (the file may contain a short failure
+  reason, e.g. for jobs that were held by condor)
+
     where x is the job id.
+
+Jobs held by condor (e.g. for going over the memory limit) never update
+their flag file, so they are detected from the 012 events in the condor
+logs: memory holds are removed from the queue, their RequestMemory is
+bumped and they are marked as failed so that the normal resubmission
+logic picks them up.
 '''
 
 import os
@@ -34,6 +41,11 @@ from pocket_coffea.utils.job_progress import (
     aggregate_by_group,
     load_job_to_group_map,
     render_progress_bar,
+)
+from pocket_coffea.utils.job_holds import (
+    bump_memory,
+    find_held_jobs,
+    parse_hold_memory_mb,
 )
 from collections import Counter, defaultdict
 
@@ -287,6 +299,7 @@ def check_jobs(jobs_folder, details, resubmit, max_resubmit, blacklist_threshold
     log_text = []
     definitive_failed = []
     resubmitted_and_failed = []
+    reported_holds = set()
     step = 0
     
     with Live(layout, refresh_per_second=1/5, console=console):  # Refresh rate
@@ -320,10 +333,22 @@ def check_jobs(jobs_folder, details, resubmit, max_resubmit, blacklist_threshold
                         failed_job_num = failed_job.split('_')[1]
 
                         if not failed_job in definitive_failed:
+                            # The held-jobs check below writes the hold summary
+                            # into the .failed flag file: report that instead of
+                            # parsing the job output log, which a held job never
+                            # produced (output is only transferred on exit).
+                            flag_note = ""
+                            try:
+                                with open(f"{jobs_folder}/{failed_job}.failed") as f:
+                                    flag_note = f.read().strip()
+                            except OSError:
+                                pass
                             # Check the log file
                             glob_file = glob.glob(f"{jobs_folder}/logs/job_*.{failed_job_num}.out")
                             xrootdfile = None
-                            if glob_file:
+                            if flag_note:
+                                log_text.append(f"[b]Job {failed_job} failed[/] {failed_jobs_stats[failed_job]} times: {flag_note}")
+                            elif glob_file:
                                 with open(glob_file[-1]) as f:
                                     c = f.readlines()
                                     for iln,ln in enumerate(c):
@@ -340,7 +365,7 @@ def check_jobs(jobs_folder, details, resubmit, max_resubmit, blacklist_threshold
                                         log_text.append( f"[b]Job {failed_job} failed[/] {failed_jobs_stats[failed_job]} times. Last error:")
                                         log_text.append("\t"+ "".join(c[-3:]))
                             else:
-                                log_text.append( f"Error in job {failed_job}: No .err file found")
+                                log_text.append( f"Error in job {failed_job}: no job output log found")
 
                             if resubmit and failed_jobs_stats[failed_job] <= max_resubmit:
                                 if xrootdfile:
@@ -437,7 +462,11 @@ def check_jobs(jobs_folder, details, resubmit, max_resubmit, blacklist_threshold
 
                 # check in the logs for SYSTEM_PERIODIC_REMOVE
                 # they are not failed but remain running/idle
-                log_file = glob.glob(f"{jobs_folder}/logs/job_*.log")[0]
+                # The original-submission log is job_<cluster>.log; per-job
+                # resubmission logs are job_<cluster>.<jobid>.log and must not
+                # be picked up here (glob order is arbitrary).
+                log_file = [l for l in glob.glob(f"{jobs_folder}/logs/job_*.log")
+                            if re.match(r"job_\d+\.log$", os.path.basename(l))][0]
                 with open(log_file) as f:
                     c = f.readlines()
                 
@@ -553,13 +582,73 @@ def check_jobs(jobs_folder, details, resubmit, max_resubmit, blacklist_threshold
                                 log_text.append(f"Resubmitted job, {thisjob}, was removed [i]again[/] by the system due to max-time reached. Marked as failed and bumped to longer condor queue: {next_jf}.")
                             
                             os.system(f"mv {failedlog} {jobs_folder}/logs/processedlogs")
-                   
+
+                # Check for held jobs (e.g. over the memory limit): condor keeps
+                # them in the queue and the wrapper never toggles the flag file,
+                # so they would stay .running forever. Memory holds are removed
+                # from the queue, RequestMemory is bumped in the sub file and the
+                # job is marked as failed so that the resubmission logic above
+                # picks it up on the next pass.
+                for (cluster_id, proc_id, job_id), (hold_reason, schedd) in find_held_jobs(jobs_folder).items():
+                    job_name = f"{cluster_id}_{job_id}"
+                    # Already handled (also shields the abort event that our own
+                    # condor_rm appends to the log from the aborted-jobs checks)
+                    if job_name in maxtimelist:
+                        continue
+                    thisjob = f"job_{job_id}"
+                    if thisjob not in running_jobs and thisjob not in idle_jobs:
+                        continue
+
+                    if "memory limit" not in hold_reason.lower():
+                        # Non-memory holds (credentials, transfers, ...) are often
+                        # transient and auto-released: report them but don't act.
+                        if job_name not in reported_holds:
+                            reported_holds.add(job_name)
+                            log_text.append(f"[yellow]{thisjob} ({cluster_id}.{proc_id}) is held: {hold_reason} "
+                                            f"Release it or condor_rm it manually.[/]")
+                        continue
+
+                    # A memory-held job will never succeed as is: remove it from
+                    # the queue (on the schedd it was submitted from) and let the
+                    # resubmission logic requeue it with more memory.
+                    schedd_arg = f"-name {schedd} " if schedd else ""
+                    os.system(f"condor_rm {schedd_arg}{cluster_id}.{proc_id} > /dev/null 2>&1")
+
+                    if thisjob in running_jobs:
+                        running_jobs.remove(thisjob)
+                        os.system(f"rm {jobs_folder}/{thisjob}.running")
+                    if thisjob in idle_jobs:
+                        idle_jobs.remove(thisjob)
+                        os.system(f"rm {jobs_folder}/{thisjob}.idle")
+                    limit_mb, measured_mb = parse_hold_memory_mb(hold_reason)
+                    new_mb = bump_memory(f"{jobs_folder}/{thisjob}.sub", limit_mb, measured_mb)
+                    hold_summary = (f"held over the memory limit ({measured_mb} MB used, "
+                                    f"{limit_mb} MB allowed), RequestMemory bumped to {new_mb} MB")
+
+                    failed_jobs.append(thisjob)
+                    # The hold summary goes into the flag file so the failed-jobs
+                    # report shows it (instead of looking for a job output log
+                    # that a held job never produced)
+                    with open(f"{jobs_folder}/{thisjob}.failed", "w") as f:
+                        f.write(hold_summary + "\n")
+
+                    maxtimelist.append(job_name)
+                    with open(maxtimefile, 'a') as f:
+                        f.write(job_name + "\n")
+
+                    log_text.append(f"{thisjob} was {hold_summary}. Removed from the queue and marked as failed.")
+
                 if len(log_text):
                     if len(log_text) > 20:
                         log_text = log_text[-20:]
                     layout["right"].update(Panel("\n".join(log_text), title="Log"))
 
-                if len(tot_jobs) == len(done_jobs) + len(failed_jobs):
+                # Failed jobs not yet in definitive_failed are still pending a
+                # resubmission attempt (handled at the top of the next pass), so
+                # don't declare completion on them: e.g. a job marked failed by
+                # the held/aborted checks in this very pass.
+                if len(tot_jobs) == len(done_jobs) + len(failed_jobs) \
+                        and all(j in definitive_failed for j in failed_jobs):
                     rprint("[green]All jobs are completed[/]")
                     rprint(f"Now merge outputs with [yellow]merge-outputs -jc {jobs_folder}[/].")
                     break

--- a/pocket_coffea/utils/job_holds.py
+++ b/pocket_coffea/utils/job_holds.py
@@ -1,0 +1,108 @@
+"""Helpers for detecting and handling held HTCondor jobs in the manual-job
+executors' jobs folder (used by `pocket-coffea check-jobs`).
+
+A job held by condor (e.g. for going over the memory limit) stays in the
+queue and its wrapper never toggles the .running/.failed flag files, so the
+only trace is the 012 event in the condor log. These helpers are
+dependency-free (no rucio/rich/coffea) so they can be unit tested anywhere.
+"""
+
+import glob
+import os
+import re
+
+_EVENT_PAT = re.compile(r"^(\d{3}) \((\d+)\.(\d+)\.\d+\)")
+
+
+def parse_request_memory_mb(value):
+    """Parse a condor RequestMemory value ("2GB", "4000MB", "4000") into MB.
+    A bare number is MB, following the condor convention. Returns None if the
+    value cannot be parsed."""
+    m = re.match(r"^([\d.]+)\s*([KMGT]B?)?$", str(value).strip().strip('"'), re.IGNORECASE)
+    if not m:
+        return None
+    scale = {"K": 1 / 1024, "M": 1, "G": 1024, "T": 1024 ** 2}
+    unit = (m.group(2) or "M")[0].upper()
+    return float(m.group(1)) * scale[unit]
+
+
+def parse_hold_memory_mb(reason):
+    """Extract (limit, last measured usage) in MB from a memory-hold reason like
+    'Job has gone over cgroup memory limit of 12000 megabytes. Last measured
+    usage: 23884 megabytes.'. Either can be None if not present."""
+    limit = re.search(r"memory limit of (\d+)", reason)
+    used = re.search(r"[Ll]ast measured usage: (\d+)", reason)
+    return (int(limit.group(1)) if limit else None,
+            int(used.group(1)) if used else None)
+
+
+def bump_memory(sub_file, limit_mb=None, measured_mb=None):
+    """Raise RequestMemory in the sub file after a memory hold. The new request
+    is the largest of 2x the current request, 1.5x the enforced limit and 1.2x
+    the measured usage (the limit can exceed the request: e.g. lxplus provisions
+    3GB/core regardless of a smaller RequestMemory), rounded up to the next GB.
+    Returns the new value in MB, or None if nothing could be computed."""
+    with open(sub_file) as f:
+        lines = f.readlines()
+    current_mb = None
+    for line in lines:
+        if line.strip().lower().startswith("requestmemory"):
+            current_mb = parse_request_memory_mb(line.split("=", 1)[1])
+    candidates = [f * v for f, v in ((2, current_mb), (1.5, limit_mb), (1.2, measured_mb))
+                  if v is not None]
+    if not candidates:
+        return None
+    new_mb = ((int(max(candidates)) + 999) // 1000) * 1000
+    new_line = f"RequestMemory = {new_mb}MB\n"
+    with open(sub_file, "w") as f:
+        for line in lines:
+            if line.strip().lower().startswith("requestmemory"):
+                f.write(new_line)
+                new_line = None
+            elif line.strip() == "queue" and new_line:
+                # No RequestMemory line in the sub file: add one
+                f.write(new_line)
+                f.write(line)
+                new_line = None
+            else:
+                f.write(line)
+    return new_mb
+
+
+def find_held_jobs(jobs_folder):
+    """Scan every condor log in the jobs folder and return the jobs whose most
+    recent event is a hold (012), i.e. currently held; a job that was held and
+    then released or removed does not show up. Returns
+    {(cluster_id, proc_id, job_id): (hold_reason, schedd)} where job_id is the
+    pocket-coffea job number (the ProcId in the original cluster log
+    job_<cluster>.log, the filename suffix in a resubmitted job's
+    job_<cluster>.<job_id>.log) and schedd is the submission host (for
+    condor_rm -name), or None if it could not be determined."""
+    held = {}
+    for log_file in glob.glob(f"{jobs_folder}/logs/job_*.log"):
+        m = re.match(r"job_(\d+)(?:\.(\d+))?\.log$", os.path.basename(log_file))
+        if not m:
+            continue
+        jobid_from_name = m.group(2)
+        with open(log_file) as f:
+            lines = f.readlines()
+        schedd = None
+        last_event = {}
+        for il, line in enumerate(lines):
+            em = _EVENT_PAT.match(line)
+            if not em:
+                continue
+            code, cluster_id, proc_id = em.group(1), em.group(2), int(em.group(3))
+            if schedd is None and code == "000":
+                sm = re.search(r"alias=([\w.-]+)", line)
+                schedd = sm.group(1) if sm else None
+            reason = ""
+            if code == "012" and il + 1 < len(lines):
+                reason = lines[il + 1].strip()
+            last_event[(cluster_id, proc_id)] = (code, reason)
+        for (cluster_id, proc_id), (code, reason) in last_event.items():
+            if code != "012":
+                continue
+            job_id = int(jobid_from_name) if jobid_from_name is not None else proc_id
+            held[(cluster_id, proc_id, job_id)] = (reason, schedd)
+    return held

--- a/tests/test_check_jobs_holds.py
+++ b/tests/test_check_jobs_holds.py
@@ -1,0 +1,155 @@
+"""Unit tests for the held-job detection/handling helpers used by
+`pocket-coffea check-jobs`.
+
+The helpers live in `pocket_coffea/utils/job_holds.py` precisely so they can
+be tested without pulling in rucio / coffea / rich. Log snippets follow the
+real HTCondor user-log format from lxplus (memory holds are Code 34).
+"""
+import pytest
+
+from pocket_coffea.utils.job_holds import (
+    bump_memory,
+    find_held_jobs,
+    parse_hold_memory_mb,
+    parse_request_memory_mb,
+)
+
+SUBMIT_HOST = ("<188.185.72.155:9618?addrs=188.185.72.155-9618"
+               "&alias=bigbird08.cern.ch&noUDP&sock=schedd_2725_b3aa>")
+
+MEM_HOLD_REASON = ("Error from slot1_17@b9g12p1875.cern.ch: Job has gone over "
+                   "cgroup memory limit of 12000 megabytes. Last measured usage: "
+                   "23884 megabytes.  Consider resubmitting with a higher request_memory.")
+
+
+def _submit(cluster, proc):
+    return (f"000 ({cluster}.{proc:03d}.000) 09/01 13:38:08 Job submitted from host: {SUBMIT_HOST}\n"
+            "...\n")
+
+
+def _execute(cluster, proc):
+    return (f"001 ({cluster}.{proc:03d}.000) 09/01 14:00:00 Job executing on host: <137.138.0.1:9618>\n"
+            "...\n")
+
+
+def _hold(cluster, proc, reason=MEM_HOLD_REASON):
+    return (f"012 ({cluster}.{proc:03d}.000) 09/01 14:20:52 Job was held.\n"
+            f"\t{reason}\n"
+            "\tCode 34 Subcode 102\n"
+            "...\n")
+
+
+def _release(cluster, proc):
+    return (f"013 ({cluster}.{proc:03d}.000) 09/01 14:30:00 Job was released.\n"
+            "...\n")
+
+
+def _terminate(cluster, proc):
+    return (f"005 ({cluster}.{proc:03d}.000) 09/01 15:00:00 Job terminated.\n"
+            "\t(1) Normal termination (return value 0)\n"
+            "...\n")
+
+
+@pytest.fixture
+def jobs_folder(tmp_path):
+    (tmp_path / "logs").mkdir()
+    return tmp_path
+
+
+# ----------------------- find_held_jobs -----------------------
+
+def test_find_held_jobs_og_log(jobs_folder):
+    """Original cluster log: held jobs are keyed by ProcId; released or
+    terminated jobs don't show up."""
+    log = "".join([
+        _submit(100, 0), _submit(100, 1), _submit(100, 2), _submit(100, 3),
+        _execute(100, 0), _execute(100, 1), _execute(100, 2), _execute(100, 3),
+        _hold(100, 1),                       # still held
+        _hold(100, 2), _release(100, 2),     # held then released -> not held
+        _terminate(100, 0),
+    ])
+    (jobs_folder / "logs" / "job_100.log").write_text(log)
+
+    held = find_held_jobs(str(jobs_folder))
+    assert list(held) == [("100", 1, 1)]
+    reason, schedd = held[("100", 1, 1)]
+    assert "memory limit of 12000" in reason
+    assert schedd == "bigbird08.cern.ch"
+
+
+def test_find_held_jobs_resubmitted_log(jobs_folder):
+    """Per-job resubmission log job_<cluster>.<jobid>.log: the job number
+    comes from the filename, not the ProcId (always 0)."""
+    (jobs_folder / "logs" / "job_200.42.log").write_text(
+        _submit(200, 0) + _execute(200, 0) + _hold(200, 0)
+    )
+    held = find_held_jobs(str(jobs_folder))
+    assert list(held) == [("200", 0, 42)]
+
+
+def test_find_held_jobs_ignores_healthy_logs(jobs_folder):
+    (jobs_folder / "logs" / "job_300.log").write_text(
+        _submit(300, 0) + _execute(300, 0) + _terminate(300, 0)
+    )
+    assert find_held_jobs(str(jobs_folder)) == {}
+
+
+# ----------------------- parsers -----------------------
+
+def test_parse_hold_memory_mb():
+    assert parse_hold_memory_mb(MEM_HOLD_REASON) == (12000, 23884)
+    assert parse_hold_memory_mb("some unrelated hold reason") == (None, None)
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("2GB", 2048.0),
+    ("4000MB", 4000.0),
+    ("4000", 4000.0),
+    ('"7.5GB"', 7680.0),
+    ("12 GB", 12288.0),
+    ("garbage", None),
+])
+def test_parse_request_memory_mb(value, expected):
+    assert parse_request_memory_mb(value) == expected
+
+
+# ----------------------- bump_memory -----------------------
+
+SUB_TEMPLATE = """Executable = job.sh
++JobFlavour = "workday"
+RequestCpus = 4
+RequestMemory = 2GB
+queue
+"""
+
+
+def test_bump_memory_from_hold_reason(tmp_path):
+    """Real lxplus case: RequestMemory=2GB but the enforced (per-core) limit
+    was 12000 MB with 23884 MB measured -> 1.2x measured, next GB up."""
+    sub = tmp_path / "job_1052.sub"
+    sub.write_text(SUB_TEMPLATE)
+    assert bump_memory(str(sub), limit_mb=12000, measured_mb=23884) == 29000
+    assert "RequestMemory = 29000MB\n" in sub.read_text()
+    # the rest of the sub file is untouched
+    assert '+JobFlavour = "workday"\n' in sub.read_text()
+
+
+def test_bump_memory_doubles_without_hold_details(tmp_path):
+    sub = tmp_path / "job_0.sub"
+    sub.write_text(SUB_TEMPLATE.replace("2GB", "10000MB"))
+    assert bump_memory(str(sub)) == 20000
+    assert "RequestMemory = 20000MB\n" in sub.read_text()
+
+
+def test_bump_memory_adds_missing_line_before_queue(tmp_path):
+    sub = tmp_path / "job_0.sub"
+    sub.write_text("Executable = job.sh\nqueue\n")
+    assert bump_memory(str(sub), limit_mb=12000, measured_mb=23884) == 29000
+    assert sub.read_text() == "Executable = job.sh\nRequestMemory = 29000MB\nqueue\n"
+
+
+def test_bump_memory_nothing_to_do(tmp_path):
+    sub = tmp_path / "job_0.sub"
+    sub.write_text("Executable = job.sh\nqueue\n")
+    assert bump_memory(str(sub)) is None
+    assert sub.read_text() == "Executable = job.sh\nqueue\n"


### PR DESCRIPTION
Jobs held by condor (e.g. over the cgroup memory limit) stay in the queue and the wrapper never toggles the flag files, so check-jobs left them as .running forever. Detect them from the 012 events in the condor logs (a job is held only if that is its most recent event, so held-then-released jobs are not touched).

Memory holds can never succeed as they are: condor_rm them on the schedd they were submitted from (parsed from the log's submit event, since each lxplus node has a different default schedd), bump RequestMemory in the sub file rounded up to the next GB, and mark them .failed so the normal --resubmit logic requeues them. 

The hold summary is written into the .failed flag file so the failed-jobs report shows it instead of looking for a job output log that a held job never produced (output is only transferred on exit). Non-memory holds are often transient and auto-released, so they are only reported.