### PR TITLE
Fix b-tag WP tests after btag_wp_values_map moved to parameters

### DIFF
--- a/tests/test_merge_regressed_jets.py
+++ b/tests/test_merge_regressed_jets.py
@@ -70,13 +70,23 @@ def _write_btag_wp_file(directory):
 # module-level parameter sets below can reference it.
 BTAG_FILE = _write_btag_wp_file(tempfile.mkdtemp(prefix="pc_btag_wp_"))
 
-# Minimal parameters. `btagging` selects the discriminant branch to cut on;
-# `jet_scale_factors.btagSF` points at the BTV file the WP score is read from.
+# NanoAOD b-tag discriminant branch -> the correction storing its WP cut values,
+# mirroring `btagging.btag_wp_values_map` in the parameters YAML. Only the two
+# taggers present in the stand-in file above are needed here.
+BTAG_WP_VALUES_MAP = {
+    "btagDeepFlavB": "deepJet_wp_values",
+    "btagPNetB": "particleNet_wp_values",
+}
+
+# Minimal parameters. `btagging` selects the discriminant branch to cut on and
+# maps it to its WP-values correction; `jet_scale_factors.btagSF` points at the
+# BTV file the WP score is read from.
 FLAT_PARAMS = {
     "btagging": {
         "working_point": {
             "2018": {"btagging_algorithm": "btagDeepFlavB"},
-        }
+        },
+        "btag_wp_values_map": BTAG_WP_VALUES_MAP,
     },
     "jet_scale_factors": {
         "btagSF": {"2018": {"file": BTAG_FILE, "name": "deepJet_shape"}}
@@ -86,7 +96,8 @@ NESTED_PARAMS = {
     "btagging": {
         "working_point": {
             "2022_postEE": {"btagging_algorithm": "btagPNetB"},
-        }
+        },
+        "btag_wp_values_map": BTAG_WP_VALUES_MAP,
     },
     "jet_scale_factors": {
         "btagSF": {"2022_postEE": {"file": BTAG_FILE, "name": "particleNet_shape"}}
@@ -98,7 +109,8 @@ MULTI_PARAMS = {
     "btagging": {
         "working_point": {
             "2022_postEE": {"btagging_algorithm": "btagPNetB"},
-        }
+        },
+        "btag_wp_values_map": BTAG_WP_VALUES_MAP,
     },
     "jet_scale_factors": {
         "btagSF": {"2022_postEE": {"file": BTAG_FILE, "name": "particleNet_shape"}}


### PR DESCRIPTION
The tagger -> WP-values-correction mapping used to be a module constant in pocket_coffea/lib/jets.py. It now lives in the parameters, and get_btag_wp_score reads it as params["btagging"]["btag_wp_values_map"].

The synthetic parameter dicts in tests/test_merge_regressed_jets.py were never updated, so every test resolving a working point raised KeyError: 'btag_wp_values_map' before reaching the stand-in BTV file.

Add the mapping to the three parameter sets, covering the two taggers the stand-in correctionlib file defines. This also makes the unknown-tagger assertion exercise the intended "no correction known for this tagger" branch instead of passing on the missing key.
