### PR TITLE
Skip already processed chunks when skim job fails

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -515,6 +515,14 @@ In default `"skim"` mode the skim is a pure "drop obviously useless events" stag
 look at branches that exist before any object correction. This is the standard recipe and what the rest of the
 documentation assumes.
 
+#### Resubmitting a partially failed skim
+
+Set `workflow_options={"skim_skip_existing": True}` to skip the ROOT write and copy of a chunk whose output file
+already exists (and is not empty) at the destination. The chunk is still fully processed, so the cutflow,
+`sum_genweights` and the skimmed dataset definition are complete. Use it only when you resubmit the **same** config
+with the **same** chunksize: the output filename is built from the input file uuid and the chunk entry range, so a
+different chunksize produces new files and the old ones are stale.
+
 #### `skim_mode: "presel_any_variation"`
 
 The variation-aware mode lets you push the skim much closer to the analysis preselection without losing events that

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,7 +518,8 @@ documentation assumes.
 #### Resubmitting a partially failed skim
 
 Set `workflow_options={"skim_skip_existing": True}` to skip the ROOT write and copy of a chunk whose output file
-already exists (and is not empty) at the destination. The chunk is still fully processed, so the cutflow,
+already exists at the destination with the expected number of events (the file is opened with uproot, also through
+XRootD; a missing, partial or corrupted file is rewritten). The chunk is still fully processed, so the cutflow,
 `sum_genweights` and the skimmed dataset definition are complete. Use it only when you resubmit the **same** config
 with the **same** chunksize: the output filename is built from the input file uuid and the chunk entry range, so a
 different chunksize produces new files and the old ones are stale.

--- a/pocket_coffea/utils/skim.py
+++ b/pocket_coffea/utils/skim.py
@@ -93,6 +93,22 @@ def copy_file(
     pathlib.Path(local_file).unlink()
 
 
+def skimmed_file_exists(path: str) -> bool:
+    '''True if `path` (local or root://host//abs/path) exists and is not empty.
+    An empty file is a leftover of a failed copy and must be rewritten.'''
+    if path.startswith("root://"):
+        try:
+            import XRootD.client
+        except ImportError as err:
+            raise ImportError(
+                "Install XRootD python bindings with: conda install -c conda-forge xroot"
+            ) from err
+        host, _, remote = path[len("root://"):].partition("/")
+        status, info = XRootD.client.FileSystem(f"root://{host.rstrip(':')}").stat("/" + remote.lstrip("/"))
+        return bool(status.ok) and info.size > 0
+    return os.path.isfile(path) and os.path.getsize(path) > 0
+
+
 
 def apply_skim_sumgenweights_override(accumulator, filesets):
     '''Override `accumulator['sum_genweights']` and

--- a/pocket_coffea/utils/skim.py
+++ b/pocket_coffea/utils/skim.py
@@ -93,21 +93,17 @@ def copy_file(
     pathlib.Path(local_file).unlink()
 
 
-def skimmed_file_exists(path: str) -> bool:
-    '''True if `path` (local or root://host//abs/path) exists and is not empty.
-    An empty file is a leftover of a failed copy and must be rewritten.'''
-    if path.startswith("root://"):
-        try:
-            import XRootD.client
-        except ImportError as err:
-            raise ImportError(
-                "Install XRootD python bindings with: conda install -c conda-forge xroot"
-            ) from err
-        host, _, remote = path[len("root://"):].partition("/")
-        status, info = XRootD.client.FileSystem(f"root://{host.rstrip(':')}").stat("/" + remote.lstrip("/"))
-        return bool(status.ok) and info.size > 0
-    return os.path.isfile(path) and os.path.getsize(path) > 0
-
+def skimmed_file_is_complete(path: str, nevents: int) -> bool:
+    '''True if `path` (local or root://) can be opened and its Events tree has
+    exactly `nevents` entries. Any error (missing, partial or corrupted file)
+    returns False so that the caller rewrites the file.'''
+    import uproot
+    try:
+        with uproot.open(path) as f:
+            return f["Events"].num_entries == nevents
+    except Exception as err:
+        logging.info(f"skimmed_file_is_complete: cannot validate {path}: {err}")
+        return False
 
 
 def apply_skim_sumgenweights_override(accumulator, filesets):

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -21,7 +21,7 @@ from ..lib.columns_manager import ColumnsManager
 from ..lib.hist_manager import HistManager
 from ..lib.jets import load_jet_factory
 from ..lib.calibrators.calibrators_manager import CalibratorsManager
-from ..utils.skim import uproot_writeable, copy_file, apply_skim_sumgenweights_override
+from ..utils.skim import uproot_writeable, copy_file, apply_skim_sumgenweights_override, skimmed_file_exists
 from ..utils.utils import dump_ak_array
 from ..utils.metadata import to_bool
 from ..lib.delayed_eval import DelayedEvalBranchManager
@@ -236,29 +236,33 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
             )
             + ".root"
         )
-        # Write the chunk in a temporary working directory instead of the cwd,
-        # which is often on AFS: TMPDIR (or the HTCondor scratch) points to
-        # node-local storage. copy_file deletes the local file after the copy;
-        # the directory itself is cleaned up here, also on failure.
-        tmpdir = tempfile.mkdtemp(
-            prefix="skim_",
-            dir=os.environ.get("TMPDIR") or os.environ.get("_CONDOR_SCRATCH_DIR"),
-        )
-        try:
-            with uproot.recreate(os.path.join(tmpdir, filename), compression=uproot.ZSTD(5)) as fout:
-                fout["Events"] = uproot_writeable(self.events)
-            # copy the file
-            copy_file(
-                filename, tmpdir, self.cfg.save_skimmed_files_folder, subdirs=[self._dataset]
+        destination = os.path.join(self.cfg.save_skimmed_files_folder, self._dataset, filename)
+        # workflow_options["skim_skip_existing"]: on a resubmission, keep the
+        # metadata (cutflow, sum_genweights, file list) but do not rewrite a
+        # chunk that already exists at the destination.
+        skip_existing = (self.workflow_options or {}).get("skim_skip_existing", False)
+        if skip_existing and skimmed_file_exists(destination):
+            logging.info(f"[skim] {self._dataset}: {filename} exists, skip write")
+        else:
+            # Write the chunk in a temporary working directory instead of the cwd,
+            # which is often on AFS: TMPDIR (or the HTCondor scratch) points to
+            # node-local storage. copy_file deletes the local file after the copy;
+            # the directory itself is cleaned up here, also on failure.
+            tmpdir = tempfile.mkdtemp(
+                prefix="skim_",
+                dir=os.environ.get("TMPDIR") or os.environ.get("_CONDOR_SCRATCH_DIR"),
             )
-        finally:
-            shutil.rmtree(tmpdir, ignore_errors=True)
+            try:
+                with uproot.recreate(os.path.join(tmpdir, filename), compression=uproot.ZSTD(5)) as fout:
+                    fout["Events"] = uproot_writeable(self.events)
+                # copy the file
+                copy_file(
+                    filename, tmpdir, self.cfg.save_skimmed_files_folder, subdirs=[self._dataset]
+                )
+            finally:
+                shutil.rmtree(tmpdir, ignore_errors=True)
         # save the new file location for the new dataset definition
-        self.output["skimmed_files"] = {
-            self._dataset: [
-                os.path.join(self.cfg.save_skimmed_files_folder, self._dataset, filename)
-            ]
-        }
+        self.output["skimmed_files"] = {self._dataset: [destination]}
         self.output["nskimmed_events"] = {self._dataset: [self.nEvents_after_skim]}
 
     @abstractmethod

--- a/pocket_coffea/workflows/base.py
+++ b/pocket_coffea/workflows/base.py
@@ -21,7 +21,7 @@ from ..lib.columns_manager import ColumnsManager
 from ..lib.hist_manager import HistManager
 from ..lib.jets import load_jet_factory
 from ..lib.calibrators.calibrators_manager import CalibratorsManager
-from ..utils.skim import uproot_writeable, copy_file, apply_skim_sumgenweights_override, skimmed_file_exists
+from ..utils.skim import uproot_writeable, copy_file, apply_skim_sumgenweights_override, skimmed_file_is_complete
 from ..utils.utils import dump_ak_array
 from ..utils.metadata import to_bool
 from ..lib.delayed_eval import DelayedEvalBranchManager
@@ -239,10 +239,11 @@ class BaseProcessorABC(processor.ProcessorABC, ABC):
         destination = os.path.join(self.cfg.save_skimmed_files_folder, self._dataset, filename)
         # workflow_options["skim_skip_existing"]: on a resubmission, keep the
         # metadata (cutflow, sum_genweights, file list) but do not rewrite a
-        # chunk that already exists at the destination.
+        # chunk whose file at the destination already has the expected number
+        # of events. A missing, partial or corrupted file is rewritten.
         skip_existing = (self.workflow_options or {}).get("skim_skip_existing", False)
-        if skip_existing and skimmed_file_exists(destination):
-            logging.info(f"[skim] {self._dataset}: {filename} exists, skip write")
+        if skip_existing and skimmed_file_is_complete(destination, self.nEvents_after_skim):
+            logging.info(f"[skim] {self._dataset}: {filename} exists with {self.nEvents_after_skim} events, skip write")
         else:
             # Write the chunk in a temporary working directory instead of the cwd,
             # which is often on AFS: TMPDIR (or the HTCondor scratch) points to

--- a/tests/test_skim_sumgenweights_recovery.py
+++ b/tests/test_skim_sumgenweights_recovery.py
@@ -147,15 +147,19 @@ def test_override_only_acts_on_listed_datasets():
     assert acc["sum_genweights"]["UnknownDS"] == pytest.approx(999.0)
 
 
-# ----------------------- skimmed_file_exists -----------------------
+# ----------------------- skimmed_file_is_complete -----------------------
 
-def test_skimmed_file_exists_local(tmp_path):
-    from pocket_coffea.utils.skim import skimmed_file_exists
+def test_skimmed_file_is_complete_local(tmp_path):
+    import numpy as np
+    import uproot
+    from pocket_coffea.utils.skim import skimmed_file_is_complete
 
-    assert not skimmed_file_exists(str(tmp_path / "missing.root"))
+    assert not skimmed_file_is_complete(str(tmp_path / "missing.root"), 3)
     empty = tmp_path / "empty.root"
     empty.touch()
-    assert not skimmed_file_exists(str(empty))
-    full = tmp_path / "full.root"
-    full.write_bytes(b"x")
-    assert skimmed_file_exists(str(full))
+    assert not skimmed_file_is_complete(str(empty), 3)
+    good = tmp_path / "good.root"
+    with uproot.recreate(good) as f:
+        f["Events"] = {"x": np.arange(3)}
+    assert skimmed_file_is_complete(str(good), 3)
+    assert not skimmed_file_is_complete(str(good), 4)

--- a/tests/test_skim_sumgenweights_recovery.py
+++ b/tests/test_skim_sumgenweights_recovery.py
@@ -145,3 +145,17 @@ def test_override_only_acts_on_listed_datasets():
 
     apply_skim_sumgenweights_override(acc, filesets)
     assert acc["sum_genweights"]["UnknownDS"] == pytest.approx(999.0)
+
+
+# ----------------------- skimmed_file_exists -----------------------
+
+def test_skimmed_file_exists_local(tmp_path):
+    from pocket_coffea.utils.skim import skimmed_file_exists
+
+    assert not skimmed_file_exists(str(tmp_path / "missing.root"))
+    empty = tmp_path / "empty.root"
+    empty.touch()
+    assert not skimmed_file_exists(str(empty))
+    full = tmp_path / "full.root"
+    full.write_bytes(b"x")
+    assert skimmed_file_exists(str(full))


### PR DESCRIPTION
When a skim job set is resubmitted after partial failures, the chunks that already succeeded are rewritten and copied again, which is the slow part. 

With workflow_options={"skim_skip_existing": True} the chunk is still fully processed (cutflow, sum_genweights, skimmed_files, nskimmed_events) but the ROOT write and copy are skipped when the destination file already exists and is not empty. Works for local and root:// destinations.